### PR TITLE
Refactor storage types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - **Breaking**: use `IncompatibleArraySubsetAndShapeError` in `ArrayStoreBytesError::InvalidArrayShape`
  - Increase coverage for:
    - `array_subset_iterators.rs`
+ - **Major breaking**: storage transformers must be `Arc` wrapped as `StorageTransformerExtension` trait method now take `self: Arc<Self>`
+ - Removed lifetimes from `{Async}{Readable,Writable,ReadableWritable,Listable,ReadableListable}Storage`
+ - **Breaking**: `Group` and `Array` methods generic on storage now require the storage with a `'static` lifetime
 
 ### Removed
  - **Breaking**: remove `InvalidArraySubsetError` and `ArrayExtractElementsError`

--- a/examples/http_array_read.rs
+++ b/examples/http_array_read.rs
@@ -20,9 +20,9 @@ fn http_array_read() -> Result<(), Box<dyn std::error::Error>> {
         std::io::stdout(),
         //    )
     ));
-    let usage_log = UsageLogStorageTransformer::new(log_writer, || {
+    let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
         chrono::Utc::now().format("[%T%.3f] ").to_string()
-    });
+    }));
     let store = usage_log.create_readable_transformer(store);
 
     // Init the existing array, reading metadata

--- a/examples/sharded_array_write_read.rs
+++ b/examples/sharded_array_write_read.rs
@@ -27,11 +27,15 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         std::io::stdout(),
         //    )
     ));
-    let usage_log = UsageLogStorageTransformer::new(log_writer, || {
+    let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
         chrono::Utc::now().format("[%T%.3f] ").to_string()
-    });
-    let store_readable_listable = usage_log.create_readable_listable_transformer(store.clone());
-    let store = usage_log.create_readable_writable_transformer(store);
+    }));
+    let store_readable_listable = usage_log
+        .clone()
+        .create_readable_listable_transformer(store.clone());
+    let store = usage_log
+        .clone()
+        .create_readable_writable_transformer(store);
 
     // Create a group
     let group_path = "/group";

--- a/examples/zip_array_write_read.rs
+++ b/examples/zip_array_write_read.rs
@@ -14,7 +14,7 @@ use zarrs::{
 // const ARRAY_PATH: &'static str = "/array";
 const ARRAY_PATH: &str = "/";
 
-fn write_array_to_storage<TStorage: ReadableWritableStorageTraits>(
+fn write_array_to_storage<TStorage: ReadableWritableStorageTraits + 'static>(
     storage: Arc<TStorage>,
 ) -> Result<Array<TStorage>, Box<dyn std::error::Error>> {
     use zarrs::array::{chunk_grid::ChunkGridTraits, codec, DataType, FillValue};
@@ -87,7 +87,7 @@ fn write_array_to_storage<TStorage: ReadableWritableStorageTraits>(
     Ok(array)
 }
 
-fn read_array_from_store<TStorage: ReadableStorageTraits>(
+fn read_array_from_store<TStorage: ReadableStorageTraits + 'static>(
     array: Array<TStorage>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Read the whole array

--- a/src/array/array_async_readable.rs
+++ b/src/array/array_async_readable.rs
@@ -22,7 +22,7 @@ use super::{
 #[cfg(feature = "ndarray")]
 use super::elements_to_ndarray;
 
-impl<TStorage: ?Sized + AsyncReadableStorageTraits> Array<TStorage> {
+impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     /// Create an array in `storage` at `path`. The metadata is read from the store.
     ///
     /// # Errors
@@ -54,7 +54,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> Array<TStorage> {
         &self,
         chunk_indices: &[u64],
     ) -> Result<Option<Vec<u8>>, ArrayError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_async_readable_transformer(storage_handle);
@@ -438,7 +438,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> Array<TStorage> {
                                 overlap.relative_to_unchecked(chunk_subset_in_array.start())
                             };
 
-                            let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+                            let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
                             let storage_transformer = self
                                 .storage_transformers()
                                 .create_async_readable_transformer(storage_handle);
@@ -565,7 +565,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> Array<TStorage> {
             ));
         }
 
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_async_readable_transformer(storage_handle);
@@ -646,7 +646,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> Array<TStorage> {
         chunk_indices: &[u64],
         parallel: bool,
     ) -> Result<Box<dyn AsyncArrayPartialDecoderTraits + 'a>, ArrayError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_async_readable_transformer(storage_handle);

--- a/src/array/array_async_readable_writable.rs
+++ b/src/array/array_async_readable_writable.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{Array, ArrayError};
 
-impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits> Array<TStorage> {
+impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TStorage> {
     /// Encode `subset_bytes` and store in `array_subset`.
     ///
     /// If `parallel` is true, chunks intersecting the array subset are retrieved in parallel.

--- a/src/array/array_async_writable.rs
+++ b/src/array/array_async_writable.rs
@@ -9,13 +9,13 @@ use crate::{
 
 use super::{codec::ArrayCodecTraits, Array, ArrayError};
 
-impl<TStorage: ?Sized + AsyncWritableStorageTraits> Array<TStorage> {
+impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
     /// Store metadata.
     ///
     /// # Errors
     /// Returns [`StorageError`] if there is an underlying store error.
     pub async fn async_store_metadata(&self) -> Result<(), StorageError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_async_writable_transformer(storage_handle);
@@ -52,7 +52,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> Array<TStorage> {
             self.async_erase_chunk(chunk_indices).await?;
             Ok(())
         } else {
-            let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+            let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
             let storage_transformer = self
                 .storage_transformers()
                 .create_async_writable_transformer(storage_handle);
@@ -234,7 +234,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> Array<TStorage> {
     /// # Errors
     /// Returns a [`StorageError`] if there is an underlying store error.
     pub async fn async_erase_chunk(&self, chunk_indices: &[u64]) -> Result<(), StorageError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_async_writable_transformer(storage_handle);
@@ -252,7 +252,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> Array<TStorage> {
     /// # Errors
     /// Returns a [`StorageError`] if there is an underlying store error.
     pub async fn async_erase_chunks(&self, chunks: &ArraySubset) -> Result<(), StorageError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_async_writable_transformer(storage_handle);

--- a/src/array/array_sync_readable.rs
+++ b/src/array/array_sync_readable.rs
@@ -20,7 +20,7 @@ use super::{
 #[cfg(feature = "ndarray")]
 use super::elements_to_ndarray;
 
-impl<TStorage: ?Sized + ReadableStorageTraits> Array<TStorage> {
+impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
     /// Create an array in `storage` at `path`. The metadata is read from the store.
     ///
     /// # Errors
@@ -51,7 +51,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Array<TStorage> {
         &self,
         chunk_indices: &[u64],
     ) -> Result<Option<Vec<u8>>, ArrayError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_readable_transformer(storage_handle);
@@ -641,7 +641,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Array<TStorage> {
             ));
         }
 
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_readable_transformer(storage_handle);
@@ -716,7 +716,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Array<TStorage> {
         chunk_indices: &[u64],
         parallel: bool,
     ) -> Result<Box<dyn ArrayPartialDecoderTraits + 'a>, ArrayError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_readable_transformer(storage_handle);

--- a/src/array/array_sync_readable_writable.rs
+++ b/src/array/array_sync_readable_writable.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{unravel_index, Array, ArrayError};
 
-impl<TStorage: ?Sized + ReadableWritableStorageTraits> Array<TStorage> {
+impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage> {
     /// Encode `subset_bytes` and store in `array_subset`.
     ///
     /// If `parallel` is true, chunks intersecting the array subset are retrieved in parallel.

--- a/src/array/array_sync_writable.rs
+++ b/src/array/array_sync_writable.rs
@@ -9,13 +9,13 @@ use crate::{
 
 use super::{codec::ArrayCodecTraits, unravel_index, Array, ArrayError};
 
-impl<TStorage: ?Sized + WritableStorageTraits> Array<TStorage> {
+impl<TStorage: ?Sized + WritableStorageTraits + 'static> Array<TStorage> {
     /// Store metadata.
     ///
     /// # Errors
     /// Returns [`StorageError`] if there is an underlying store error.
     pub fn store_metadata(&self) -> Result<(), StorageError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_writable_transformer(storage_handle);
@@ -51,7 +51,7 @@ impl<TStorage: ?Sized + WritableStorageTraits> Array<TStorage> {
             self.erase_chunk(chunk_indices)?;
             Ok(())
         } else {
-            let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+            let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
             let storage_transformer = self
                 .storage_transformers()
                 .create_writable_transformer(storage_handle);
@@ -315,7 +315,7 @@ impl<TStorage: ?Sized + WritableStorageTraits> Array<TStorage> {
     /// # Errors
     /// Returns a [`StorageError`] if there is an underlying store error.
     pub fn erase_chunk(&self, chunk_indices: &[u64]) -> Result<(), StorageError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_writable_transformer(storage_handle);
@@ -336,7 +336,7 @@ impl<TStorage: ?Sized + WritableStorageTraits> Array<TStorage> {
         chunks: &ArraySubset,
         parallel: bool,
     ) -> Result<(), StorageError> {
-        let storage_handle = Arc::new(StorageHandle::new(&*self.storage));
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_writable_transformer(storage_handle);

--- a/src/array/codec.rs
+++ b/src/array/codec.rs
@@ -517,19 +517,19 @@ pub trait AsyncArrayPartialDecoderTraits: Send + Sync {
 }
 
 /// A [`ReadableStorage`] partial decoder.
-pub struct StoragePartialDecoder<'a> {
-    storage: ReadableStorage<'a>,
+pub struct StoragePartialDecoder {
+    storage: ReadableStorage,
     key: StoreKey,
 }
 
-impl<'a> StoragePartialDecoder<'a> {
+impl StoragePartialDecoder {
     /// Create a new storage partial decoder.
-    pub fn new(storage: ReadableStorage<'a>, key: StoreKey) -> Self {
+    pub fn new(storage: ReadableStorage, key: StoreKey) -> Self {
         Self { storage, key }
     }
 }
 
-impl BytesPartialDecoderTraits for StoragePartialDecoder<'_> {
+impl BytesPartialDecoderTraits for StoragePartialDecoder {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
@@ -543,22 +543,22 @@ impl BytesPartialDecoderTraits for StoragePartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// A [`ReadableStorage`] partial decoder.
-pub struct AsyncStoragePartialDecoder<'a> {
-    storage: AsyncReadableStorage<'a>,
+pub struct AsyncStoragePartialDecoder {
+    storage: AsyncReadableStorage,
     key: StoreKey,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncStoragePartialDecoder<'a> {
+impl AsyncStoragePartialDecoder {
     /// Create a new storage partial decoder.
-    pub fn new(storage: AsyncReadableStorage<'a>, key: StoreKey) -> Self {
+    pub fn new(storage: AsyncReadableStorage, key: StoreKey) -> Self {
         Self { storage, key }
     }
 }
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder<'_> {
+impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],

--- a/src/group.rs
+++ b/src/group.rs
@@ -193,14 +193,14 @@ fn validate_group_metadata(metadata: &GroupMetadataV3) -> Result<(), GroupCreate
 
 impl<TStorage: ?Sized + ReadableStorageTraits> Group<TStorage> {}
 
-impl<TStorage: ?Sized + WritableStorageTraits> Group<TStorage> {
+impl<TStorage: ?Sized + WritableStorageTraits + 'static> Group<TStorage> {
     /// Store metadata.
     ///
     /// # Errors
     ///
     /// Returns [`StorageError`] if there is an underlying store error.
     pub fn store_metadata(&self) -> Result<(), StorageError> {
-        let storage_handle = StorageHandle::new(&*self.storage);
+        let storage_handle = StorageHandle::new(self.storage.clone());
         crate::storage::create_group(&storage_handle, self.path(), &self.metadata())
     }
 }
@@ -213,7 +213,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> Group<TStorage> {
     ///
     /// Returns [`StorageError`] if there is an underlying store error.
     pub async fn async_store_metadata(&self) -> Result<(), StorageError> {
-        let storage_handle = StorageHandle::new(&*self.storage);
+        let storage_handle = StorageHandle::new(self.storage.clone());
         crate::storage::async_create_group(&storage_handle, self.path(), &self.metadata()).await
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -60,35 +60,35 @@ pub use self::storage_handle::StorageHandle;
 pub use storage_value_io::StorageValueIO;
 
 /// [`Arc`] wrapped readable storage.
-pub type ReadableStorage<'a> = Arc<dyn ReadableStorageTraits + 'a>;
+pub type ReadableStorage = Arc<dyn ReadableStorageTraits>;
 
 /// [`Arc`] wrapped writable storage.
-pub type WritableStorage<'a> = Arc<dyn WritableStorageTraits + 'a>;
+pub type WritableStorage = Arc<dyn WritableStorageTraits>;
 
 /// [`Arc`] wrapped readable and writable storage.
-pub type ReadableWritableStorage<'a> = Arc<dyn ReadableWritableStorageTraits + 'a>;
+pub type ReadableWritableStorage = Arc<dyn ReadableWritableStorageTraits>;
 
 /// [`Arc`] wrapped listable storage.
-pub type ListableStorage<'a> = Arc<dyn ListableStorageTraits + 'a>;
+pub type ListableStorage = Arc<dyn ListableStorageTraits>;
 
 /// [`Arc`] wrapped readable and listable storage.
-pub type ReadableListableStorage<'a> = Arc<dyn ReadableListableStorageTraits + 'a>;
+pub type ReadableListableStorage = Arc<dyn ReadableListableStorageTraits>;
 
 #[cfg(feature = "async")]
 /// [`Arc`] wrapped asynchronous readable storage.
-pub type AsyncReadableStorage<'a> = Arc<dyn AsyncReadableStorageTraits + 'a>;
+pub type AsyncReadableStorage = Arc<dyn AsyncReadableStorageTraits>;
 
 #[cfg(feature = "async")]
 /// [`Arc`] wrapped asynchronous writable storage.
-pub type AsyncWritableStorage<'a> = Arc<dyn AsyncWritableStorageTraits + 'a>;
+pub type AsyncWritableStorage = Arc<dyn AsyncWritableStorageTraits>;
 
 #[cfg(feature = "async")]
 /// [`Arc`] wrapped asynchronous listable storage.
-pub type AsyncListableStorage<'a> = Arc<dyn AsyncListableStorageTraits + 'a>;
+pub type AsyncListableStorage = Arc<dyn AsyncListableStorageTraits>;
 
 #[cfg(feature = "async")]
 /// [`Arc`] wrapped asynchronous readable and listable storage.
-pub type AsyncReadableListableStorage<'a> = Arc<dyn AsyncReadableListableStorageTraits + 'a>;
+pub type AsyncReadableListableStorage = Arc<dyn AsyncReadableListableStorageTraits>;
 
 /// A [`StoreKey`] and [`ByteRange`].
 #[derive(Debug, Clone)]

--- a/src/storage/storage_transformer.rs
+++ b/src/storage/storage_transformer.rs
@@ -59,60 +59,51 @@ pub trait StorageTransformerExtension: core::fmt::Debug + Send + Sync {
     fn create_metadata(&self) -> Option<Metadata>;
 
     /// Create a readable transformer.
-    fn create_readable_transformer<'a>(
-        &'a self,
-        storage: ReadableStorage<'a>,
-    ) -> ReadableStorage<'a>;
+    fn create_readable_transformer(self: Arc<Self>, storage: ReadableStorage) -> ReadableStorage;
 
     /// Create a writable transformer.
-    fn create_writable_transformer<'a>(
-        &'a self,
-        storage: WritableStorage<'a>,
-    ) -> WritableStorage<'a>;
+    fn create_writable_transformer(self: Arc<Self>, storage: WritableStorage) -> WritableStorage;
 
     /// Create a readable and writable transformer.
-    fn create_readable_writable_transformer<'a>(
-        &'a self,
-        storage: ReadableWritableStorage<'a>,
-    ) -> ReadableWritableStorage<'a>;
+    fn create_readable_writable_transformer(
+        self: Arc<Self>,
+        storage: ReadableWritableStorage,
+    ) -> ReadableWritableStorage;
 
     /// Create a listable transformer.
-    fn create_listable_transformer<'a>(
-        &'a self,
-        storage: ListableStorage<'a>,
-    ) -> ListableStorage<'a>;
+    fn create_listable_transformer(self: Arc<Self>, storage: ListableStorage) -> ListableStorage;
 
     /// Create a readable and listable transformer.
-    fn create_readable_listable_transformer<'a>(
-        &'a self,
-        storage: ReadableListableStorage<'a>,
-    ) -> ReadableListableStorage<'a>;
+    fn create_readable_listable_transformer(
+        self: Arc<Self>,
+        storage: ReadableListableStorage,
+    ) -> ReadableListableStorage;
 
     #[cfg(feature = "async")]
     /// Create an asynchronous readable transformer.
-    fn create_async_readable_transformer<'a>(
-        &'a self,
-        storage: AsyncReadableStorage<'a>,
-    ) -> AsyncReadableStorage<'a>;
+    fn create_async_readable_transformer(
+        self: Arc<Self>,
+        storage: AsyncReadableStorage,
+    ) -> AsyncReadableStorage;
 
     #[cfg(feature = "async")]
     /// Create an asynchronous writable transformer.
-    fn create_async_writable_transformer<'a>(
-        &'a self,
-        storage: AsyncWritableStorage<'a>,
-    ) -> AsyncWritableStorage<'a>;
+    fn create_async_writable_transformer(
+        self: Arc<Self>,
+        storage: AsyncWritableStorage,
+    ) -> AsyncWritableStorage;
 
     #[cfg(feature = "async")]
     /// Create an asynchronous listable transformer.
-    fn create_async_listable_transformer<'a>(
-        &'a self,
-        storage: AsyncListableStorage<'a>,
-    ) -> AsyncListableStorage<'a>;
+    fn create_async_listable_transformer(
+        self: Arc<Self>,
+        storage: AsyncListableStorage,
+    ) -> AsyncListableStorage;
 
     #[cfg(feature = "async")]
     /// Create an asynchronous readable and listable transformer.
-    fn create_async_readable_listable_transformer<'a>(
-        &'a self,
-        storage: AsyncReadableListableStorage<'a>,
-    ) -> AsyncReadableListableStorage<'a>;
+    fn create_async_readable_listable_transformer(
+        self: Arc<Self>,
+        storage: AsyncReadableListableStorage,
+    ) -> AsyncReadableListableStorage;
 }

--- a/src/storage/storage_transformer/storage_transformer_chain.rs
+++ b/src/storage/storage_transformer/storage_transformer_chain.rs
@@ -55,104 +55,107 @@ impl StorageTransformerChain {
 
 impl StorageTransformerChain {
     /// Create a readable storage transformer.
-    pub fn create_readable_transformer<'a>(
-        &'a self,
-        mut storage: ReadableStorage<'a>,
-    ) -> ReadableStorage<'a> {
+    pub fn create_readable_transformer(&self, mut storage: ReadableStorage) -> ReadableStorage {
         for transformer in &self.0 {
-            storage = transformer.create_readable_transformer(storage);
+            storage = transformer.clone().create_readable_transformer(storage);
         }
         storage
     }
 
     /// Create a writable storage transformer.
-    pub fn create_writable_transformer<'a>(
-        &'a self,
-        mut storage: WritableStorage<'a>,
-    ) -> WritableStorage<'a> {
+    pub fn create_writable_transformer(&self, mut storage: WritableStorage) -> WritableStorage {
         for transformer in &self.0 {
-            storage = transformer.create_writable_transformer(storage);
+            storage = transformer.clone().create_writable_transformer(storage);
         }
         storage
     }
 
     /// Create a readable and writable storage transformer.
-    pub fn create_readable_writable_transformer<'a>(
-        &'a self,
-        mut storage: ReadableWritableStorage<'a>,
-    ) -> ReadableWritableStorage<'a> {
+    pub fn create_readable_writable_transformer(
+        &self,
+        mut storage: ReadableWritableStorage,
+    ) -> ReadableWritableStorage {
         for transformer in &self.0 {
-            storage = transformer.create_readable_writable_transformer(storage);
+            storage = transformer
+                .clone()
+                .create_readable_writable_transformer(storage);
         }
         storage
     }
 
     /// Create a listable storage transformer.
-    pub fn create_listable_transformer<'a>(
-        &'a self,
-        mut storage: ListableStorage<'a>,
-    ) -> ListableStorage<'a> {
+    pub fn create_listable_transformer(&self, mut storage: ListableStorage) -> ListableStorage {
         for transformer in &self.0 {
-            storage = transformer.create_listable_transformer(storage);
+            storage = transformer.clone().create_listable_transformer(storage);
         }
         storage
     }
 
     /// Create a readable and listable storage transformer.
-    pub fn create_readable_listable_transformer<'a>(
-        &'a self,
-        mut storage: ReadableListableStorage<'a>,
-    ) -> ReadableListableStorage<'a> {
+    pub fn create_readable_listable_transformer(
+        &self,
+        mut storage: ReadableListableStorage,
+    ) -> ReadableListableStorage {
         for transformer in &self.0 {
-            storage = transformer.create_readable_listable_transformer(storage);
+            storage = transformer
+                .clone()
+                .create_readable_listable_transformer(storage);
         }
         storage
     }
 
     #[cfg(feature = "async")]
     /// Create an asynchronous readable storage transformer.
-    pub fn create_async_readable_transformer<'a>(
-        &'a self,
-        mut storage: AsyncReadableStorage<'a>,
-    ) -> AsyncReadableStorage<'a> {
+    pub fn create_async_readable_transformer(
+        &self,
+        mut storage: AsyncReadableStorage,
+    ) -> AsyncReadableStorage {
         for transformer in &self.0 {
-            storage = transformer.create_async_readable_transformer(storage);
+            storage = transformer
+                .clone()
+                .create_async_readable_transformer(storage);
         }
         storage
     }
 
     #[cfg(feature = "async")]
     /// Create an asynchronous writable storage transformer.
-    pub fn create_async_writable_transformer<'a>(
-        &'a self,
-        mut storage: AsyncWritableStorage<'a>,
-    ) -> AsyncWritableStorage<'a> {
+    pub fn create_async_writable_transformer(
+        &self,
+        mut storage: AsyncWritableStorage,
+    ) -> AsyncWritableStorage {
         for transformer in &self.0 {
-            storage = transformer.create_async_writable_transformer(storage);
+            storage = transformer
+                .clone()
+                .create_async_writable_transformer(storage);
         }
         storage
     }
 
     #[cfg(feature = "async")]
     /// Create an asynchronous listable storage transformer.
-    pub fn create_async_listable_transformer<'a>(
-        &'a self,
-        mut storage: AsyncListableStorage<'a>,
-    ) -> AsyncListableStorage<'a> {
+    pub fn create_async_listable_transformer(
+        &self,
+        mut storage: AsyncListableStorage,
+    ) -> AsyncListableStorage {
         for transformer in &self.0 {
-            storage = transformer.create_async_listable_transformer(storage);
+            storage = transformer
+                .clone()
+                .create_async_listable_transformer(storage);
         }
         storage
     }
 
     #[cfg(feature = "async")]
     /// Create an asynchronous readable listable storage transformer.
-    pub fn create_async_readable_listable_transformer<'a>(
-        &'a self,
-        mut storage: AsyncReadableListableStorage<'a>,
-    ) -> AsyncReadableListableStorage<'a> {
+    pub fn create_async_readable_listable_transformer(
+        &self,
+        mut storage: AsyncReadableListableStorage,
+    ) -> AsyncReadableListableStorage {
         for transformer in &self.0 {
-            storage = transformer.create_async_readable_listable_transformer(storage);
+            storage = transformer
+                .clone()
+                .create_async_readable_listable_transformer(storage);
         }
         storage
     }

--- a/src/storage/storage_transformer/usage_log.rs
+++ b/src/storage/storage_transformer/usage_log.rs
@@ -44,9 +44,9 @@ use super::StorageTransformerExtension;
 ///     std::io::stdout(),
 ///     //    )
 /// ));
-/// let usage_log = UsageLogStorageTransformer::new(log_writer, || {
+/// let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
 ///     chrono::Utc::now().format("[%T%.3f] ").to_string()
-/// });
+/// }));
 /// let store = usage_log.create_readable_writable_transformer(store);
 /// ````
 ///
@@ -101,65 +101,65 @@ impl StorageTransformerExtension for UsageLogStorageTransformer {
         None
     }
 
-    fn create_readable_transformer<'a>(&self, storage: ReadableStorage<'a>) -> ReadableStorage<'a> {
+    fn create_readable_transformer(self: Arc<Self>, storage: ReadableStorage) -> ReadableStorage {
         self.create_transformer(storage)
     }
 
-    fn create_readable_writable_transformer<'a>(
-        &'a self,
-        storage: ReadableWritableStorage<'a>,
-    ) -> ReadableWritableStorage<'a> {
+    fn create_readable_writable_transformer(
+        self: Arc<Self>,
+        storage: ReadableWritableStorage,
+    ) -> ReadableWritableStorage {
         self.create_transformer(storage)
     }
 
-    fn create_writable_transformer<'a>(&self, storage: WritableStorage<'a>) -> WritableStorage<'a> {
+    fn create_writable_transformer(self: Arc<Self>, storage: WritableStorage) -> WritableStorage {
         self.create_transformer(storage)
     }
 
-    fn create_listable_transformer<'a>(&self, storage: ListableStorage<'a>) -> ListableStorage<'a> {
+    fn create_listable_transformer(self: Arc<Self>, storage: ListableStorage) -> ListableStorage {
         self.create_transformer(storage)
     }
 
-    fn create_readable_listable_transformer<'a>(
-        &self,
-        storage: ReadableListableStorage<'a>,
-    ) -> ReadableListableStorage<'a> {
+    fn create_readable_listable_transformer(
+        self: Arc<Self>,
+        storage: ReadableListableStorage,
+    ) -> ReadableListableStorage {
         self.create_transformer(storage)
     }
 
     #[cfg(feature = "async")]
     /// Create an asynchronous readable transformer.
-    fn create_async_readable_transformer<'a>(
-        &'a self,
-        storage: AsyncReadableStorage<'a>,
-    ) -> AsyncReadableStorage<'a> {
+    fn create_async_readable_transformer(
+        self: Arc<Self>,
+        storage: AsyncReadableStorage,
+    ) -> AsyncReadableStorage {
         self.create_transformer(storage)
     }
 
     #[cfg(feature = "async")]
     /// Create an asynchronous writable transformer.
-    fn create_async_writable_transformer<'a>(
-        &'a self,
-        storage: AsyncWritableStorage<'a>,
-    ) -> AsyncWritableStorage<'a> {
+    fn create_async_writable_transformer(
+        self: Arc<Self>,
+        storage: AsyncWritableStorage,
+    ) -> AsyncWritableStorage {
         self.create_transformer(storage)
     }
 
     #[cfg(feature = "async")]
     /// Create an asynchronous listable transformer.
-    fn create_async_listable_transformer<'a>(
-        &'a self,
-        storage: AsyncListableStorage<'a>,
-    ) -> AsyncListableStorage<'a> {
+    fn create_async_listable_transformer(
+        self: Arc<Self>,
+        storage: AsyncListableStorage,
+    ) -> AsyncListableStorage {
         self.create_transformer(storage)
     }
 
     #[cfg(feature = "async")]
     /// Create an asynchronous readable and listable transformer.
-    fn create_async_readable_listable_transformer<'a>(
-        &'a self,
-        storage: AsyncReadableListableStorage<'a>,
-    ) -> AsyncReadableListableStorage<'a> {
+    fn create_async_readable_listable_transformer(
+        self: Arc<Self>,
+        storage: AsyncReadableListableStorage,
+    ) -> AsyncReadableListableStorage {
         self.create_transformer(storage)
     }
 }


### PR DESCRIPTION
This is mostly an internal change, but downstream users may need to:
 - `Arc` wrap storage transformers
 - In methods generic over storage, add a `'static` lifetime to storage