### PR TITLE
Codec trait and array refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add store lock tests
  - Added `contiguous_elements` method to `ContiguousIndicesIterator` and `ContiguousLinearisedIndicesIterator`
  - Added `ChunkShape::num_elements`
+ - Added `codec::{Encode,Decode,PartialDecode,PartialDecoder}Options`
+ - Added new `Array::opt` methods which can use new encode/decode options
+   - **Breaking** Existing `Array` `_opt` use new encode/decode options insted of `parallel: bool`
 
 ### Changed
  - Dependency bumps
@@ -32,7 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - `array_subset_iterators.rs`
  - **Major breaking**: storage transformers must be `Arc` wrapped as `StorageTransformerExtension` trait method now take `self: Arc<Self>`
  - Removed lifetimes from `{Async}{Readable,Writable,ReadableWritable,Listable,ReadableListable}Storage`
- - **Breaking**: `Group` and `Array` methods generic on storage now require the storage with a `'static` lifetime
+ - **Breaking**: `Group` and `Array` methods generic on storage now require the storage have a `'static` lifetime
+ - **Breaking**: remove `Array::{set_}parallel_codecs` and `ArrayBuilder::parallel_codecs`
+ - **Breaking**: added `recommended_concurrency` to codec trait methods to facilitate improved parallelisation
+ - **Major breaking**: refactor codec traits:
+   - **Breaking**: remove `par_` variants,
+   - **Breaking**: `_opt` variants use new `codec::{Encode,Decode,PartialDecode,PartialDecoder}Options` instead of `parallel: bool`
+   - variants without prefix/suffix are no longer serial variants but parallel
+     - TODO: Remove these?
 
 ### Removed
  - **Breaking**: remove `InvalidArraySubsetError` and `ArrayExtractElementsError`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ walkdir = "2.3.2"
 zfp-sys = {version = "0.1.4", features = ["static"], optional = true }
 zip = { version = "0.6", optional = true }
 zstd = { version = "0.13", features = ["zstdmt"], optional = true }
+rayon_iter_concurrent_limit = "0.1.0-alpha3"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/benches/array_blosc.rs
+++ b/benches/array_blosc.rs
@@ -32,9 +32,7 @@ fn array_blosc_write_all(c: &mut Criterion) {
                 .unwrap();
                 let data = vec![1u8; num_elements.try_into().unwrap()];
                 let subset = zarrs::array_subset::ArraySubset::new_with_shape(vec![size; 3]);
-                array
-                    .par_store_array_subset_elements(&subset, data)
-                    .unwrap();
+                array.store_array_subset_elements(&subset, data).unwrap();
             });
         });
     }
@@ -69,13 +67,11 @@ fn array_blosc_read_all(c: &mut Criterion) {
             .unwrap();
             let data = vec![1u8; num_elements.try_into().unwrap()];
             let subset = zarrs::array_subset::ArraySubset::new_with_shape(vec![size; 3]);
-            array
-                .par_store_array_subset_elements(&subset, data)
-                .unwrap();
+            array.store_array_subset_elements(&subset, data).unwrap();
 
             // Benchmark reading the data
             b.iter(|| {
-                let _bytes = array.par_retrieve_array_subset(&subset).unwrap();
+                let _bytes = array.retrieve_array_subset(&subset).unwrap();
             });
         });
     }

--- a/benches/array_uncompressed.rs
+++ b/benches/array_uncompressed.rs
@@ -19,9 +19,7 @@ fn array_write_all(c: &mut Criterion) {
                 .unwrap();
                 let data = vec![1u8; num_elements.try_into().unwrap()];
                 let subset = zarrs::array_subset::ArraySubset::new_with_shape(vec![size; 3]);
-                array
-                    .par_store_array_subset_elements(&subset, data)
-                    .unwrap();
+                array.store_array_subset_elements(&subset, data).unwrap();
             });
         });
     }
@@ -49,9 +47,7 @@ fn array_write_all_sharded(c: &mut Criterion) {
                 .unwrap();
                 let data = vec![1u16; num_elements.try_into().unwrap()];
                 let subset = zarrs::array_subset::ArraySubset::new_with_shape(vec![size; 3]);
-                array
-                    .par_store_array_subset_elements(&subset, data)
-                    .unwrap();
+                array.store_array_subset_elements(&subset, data).unwrap();
             });
         });
     }
@@ -76,13 +72,11 @@ fn array_read_all(c: &mut Criterion) {
             .unwrap();
             let data = vec![1u16; num_elements.try_into().unwrap()];
             let subset = zarrs::array_subset::ArraySubset::new_with_shape(vec![size; 3]);
-            array
-                .par_store_array_subset_elements(&subset, data)
-                .unwrap();
+            array.store_array_subset_elements(&subset, data).unwrap();
 
             // Benchmark reading the data
             b.iter(|| {
-                let _bytes = array.par_retrieve_array_subset(&subset).unwrap();
+                let _bytes = array.retrieve_array_subset(&subset).unwrap();
             });
         });
     }
@@ -110,13 +104,11 @@ fn array_read_all_sharded(c: &mut Criterion) {
             .unwrap();
             let data = vec![0u8; num_elements.try_into().unwrap()];
             let subset = zarrs::array_subset::ArraySubset::new_with_shape(vec![size; 3]);
-            array
-                .par_store_array_subset_elements(&subset, data)
-                .unwrap();
+            array.store_array_subset_elements(&subset, data).unwrap();
 
             // Benchmark reading the data
             b.iter(|| {
-                let _bytes = array.par_retrieve_array_subset(&subset).unwrap();
+                let _bytes = array.retrieve_array_subset(&subset).unwrap();
             });
         });
     }

--- a/benches/codecs.rs
+++ b/benches/codecs.rs
@@ -68,12 +68,6 @@ fn codec_blosc(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("decode", size3), |b| {
             b.iter(|| codec.decode(data_encoded.clone(), &rep).unwrap());
         });
-        group.bench_function(BenchmarkId::new("par_encode", size3), |b| {
-            b.iter(|| codec.par_encode(data_decoded.clone()).unwrap());
-        });
-        group.bench_function(BenchmarkId::new("par_decode", size3), |b| {
-            b.iter(|| codec.par_decode(data_encoded.clone(), &rep).unwrap());
-        });
     }
 }
 

--- a/examples/array_write_read.rs
+++ b/examples/array_write_read.rs
@@ -75,7 +75,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     println!("store_chunk [0, 0] and [0, 1]:\n{data_all:+4.1}\n");
 
     // Store multiple chunks
-    array.store_chunks_elements_opt::<f32>(
+    array.store_chunks_elements::<f32>(
         &ArraySubset::new_with_ranges(&[1..2, 0..2]),
         vec![
             //
@@ -83,7 +83,6 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
             //
             1.0, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1, 1.1, 1.0, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1, 1.1,
         ],
-        true,
     )?;
     let data_all = array.retrieve_array_subset_ndarray::<f32>(&subset_all)?;
     println!("store_chunks [1..2, 0..2]:\n{data_all:+4.1}\n");

--- a/examples/sharded_array_write_read.rs
+++ b/examples/sharded_array_write_read.rs
@@ -131,7 +131,7 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         ArraySubset::new_with_start_shape(vec![0, 0], inner_chunk_shape.clone())?,
         ArraySubset::new_with_start_shape(vec![0, 4], inner_chunk_shape.clone())?,
     ];
-    let decoded_inner_chunks = partial_decoder.par_partial_decode(&inner_chunks_to_decode)?;
+    let decoded_inner_chunks = partial_decoder.partial_decode(&inner_chunks_to_decode)?;
     let decoded_inner_chunks = decoded_inner_chunks
         .into_iter()
         .map(|bytes| {

--- a/src/array.rs
+++ b/src/array.rs
@@ -215,8 +215,6 @@ pub struct Array<TStorage: ?Sized> {
     dimension_names: Option<Vec<DimensionName>>,
     /// Additional fields annotated with `"must_understand": false`.
     additional_fields: AdditionalFields,
-    /// If true, codecs run with multithreading (where supported)
-    parallel_codecs: bool,
     /// Zarrs metadata.
     include_zarrs_metadata: bool,
 }
@@ -289,7 +287,6 @@ impl<TStorage: ?Sized> Array<TStorage> {
             additional_fields: metadata.additional_fields,
             storage_transformers,
             dimension_names: metadata.dimension_names,
-            parallel_codecs: true,
             include_zarrs_metadata: true,
         })
     }
@@ -369,19 +366,6 @@ impl<TStorage: ?Sized> Array<TStorage> {
     #[must_use]
     pub const fn additional_fields(&self) -> &AdditionalFields {
         &self.additional_fields
-    }
-
-    /// Returns true if codecs can use multiple threads for encoding and decoding (where supported).
-    #[must_use]
-    pub const fn parallel_codecs(&self) -> bool {
-        self.parallel_codecs
-    }
-
-    /// Enable or disable multithreaded codec encoding/decoding. Enabled by default.
-    ///
-    /// It may be advantageous to turn this off if parallelisation is external to avoid thrashing.
-    pub fn set_parallel_codecs(&mut self, parallel_codecs: bool) {
-        self.parallel_codecs = parallel_codecs;
     }
 
     /// Enable or disable the inclusion of zarrs metadata in the array attributes. Enabled by default.

--- a/src/array/array_async_readable.rs
+++ b/src/array/array_async_readable.rs
@@ -571,11 +571,15 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
                                     self.chunk_array_representation(&chunk_indices)?;
                                 let partial_decoder = self
                                     .codecs()
-                                    .async_partial_decoder(input_handle, &chunk_representation)
+                                    .async_partial_decoder_opt(
+                                        input_handle,
+                                        &chunk_representation,
+                                        options, // FIXME: Adjust internal decode options
+                                    )
                                     .await?;
 
                                 partial_decoder
-                                    .partial_decode_opt(&[array_subset_in_chunk_subset], options)
+                                    .partial_decode_opt(&[array_subset_in_chunk_subset], options) // FIXME: Adjust internal decode options
                                     .await?
                                     .remove(0)
                             };

--- a/src/array/array_async_readable.rs
+++ b/src/array/array_async_readable.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{
     codec::{
         ArrayCodecTraits, ArrayToBytesCodecTraits, AsyncArrayPartialDecoderTraits,
-        AsyncStoragePartialDecoder,
+        AsyncStoragePartialDecoder, DecodeOptions, PartialDecoderOptions,
     },
     transmute_from_bytes_vec,
     unsafe_cell_slice::UnsafeCellSlice,
@@ -50,9 +50,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///
     /// # Panics
     /// Panics if the number of elements in the chunk exceeds `usize::MAX`.
-    pub async fn async_retrieve_chunk_if_exists(
+    pub async fn async_retrieve_chunk_if_exists_opt(
         &self,
         chunk_indices: &[u64],
+        options: &DecodeOptions,
     ) -> Result<Option<Vec<u8>>, ArrayError> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
@@ -70,7 +71,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             let chunk_representation = self.chunk_array_representation(chunk_indices)?;
             let chunk_decoded = self
                 .codecs()
-                .async_decode_opt(chunk_encoded, &chunk_representation, self.parallel_codecs())
+                .async_decode_opt(chunk_encoded, &chunk_representation, options)
                 .await
                 .map_err(ArrayError::CodecError)?;
             let chunk_decoded_size =
@@ -88,6 +89,16 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         }
     }
 
+    /// Read and decode the chunk at `chunk_indices` into its bytes if it exists (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
+    pub async fn async_retrieve_chunk_if_exists(
+        &self,
+        chunk_indices: &[u64],
+    ) -> Result<Option<Vec<u8>>, ArrayError> {
+        self.async_retrieve_chunk_if_exists_opt(chunk_indices, &DecodeOptions::default())
+            .await
+    }
+
     /// Read and decode the chunk at `chunk_indices` into its bytes or the fill value if it does not exist.
     ///
     /// # Errors
@@ -98,8 +109,14 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///
     /// # Panics
     /// Panics if the number of elements in the chunk exceeds `usize::MAX`.
-    pub async fn async_retrieve_chunk(&self, chunk_indices: &[u64]) -> Result<Vec<u8>, ArrayError> {
-        let chunk = self.async_retrieve_chunk_if_exists(chunk_indices).await?;
+    pub async fn async_retrieve_chunk_opt(
+        &self,
+        chunk_indices: &[u64],
+        options: &DecodeOptions,
+    ) -> Result<Vec<u8>, ArrayError> {
+        let chunk = self
+            .async_retrieve_chunk_if_exists_opt(chunk_indices, options)
+            .await?;
         if let Some(chunk) = chunk {
             Ok(chunk)
         } else {
@@ -107,6 +124,13 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             let fill_value = chunk_representation.fill_value().as_ne_bytes();
             Ok(fill_value.repeat(chunk_representation.num_elements_usize()))
         }
+    }
+
+    /// Read and decode the chunk at `chunk_indices` into its bytes or the fill value if it does not exist (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
+    pub async fn async_retrieve_chunk(&self, chunk_indices: &[u64]) -> Result<Vec<u8>, ArrayError> {
+        self.async_retrieve_chunk_opt(chunk_indices, &DecodeOptions::default())
+            .await
     }
 
     /// Read and decode the chunk at `chunk_indices` into a vector of its elements if it exists.
@@ -118,13 +142,26 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///  - `chunk_indices` are invalid,
     ///  - there is a codec decoding error, or
     ///  - an underlying store error.
+    pub async fn async_retrieve_chunk_elements_if_exists_opt<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        chunk_indices: &[u64],
+        options: &DecodeOptions,
+    ) -> Result<Option<Vec<T>>, ArrayError> {
+        validate_element_size::<T>(self.data_type())?;
+        let bytes = self
+            .async_retrieve_chunk_if_exists_opt(chunk_indices, options)
+            .await?;
+        Ok(bytes.map(|bytes| transmute_from_bytes_vec::<T>(bytes)))
+    }
+
+    /// Read and decode the chunk at `chunk_indices` into a vector of its elements if it exists (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
     pub async fn async_retrieve_chunk_elements_if_exists<T: bytemuck::Pod + Send + Sync>(
         &self,
         chunk_indices: &[u64],
     ) -> Result<Option<Vec<T>>, ArrayError> {
-        validate_element_size::<T>(self.data_type())?;
-        let bytes = self.async_retrieve_chunk_if_exists(chunk_indices).await?;
-        Ok(bytes.map(|bytes| transmute_from_bytes_vec::<T>(bytes)))
+        self.async_retrieve_chunk_elements_if_exists_opt(chunk_indices, &DecodeOptions::default())
+            .await
     }
 
     /// Read and decode the chunk at `chunk_indices` into a vector of its elements or the fill value if it does not exist.
@@ -136,13 +173,26 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///  - `chunk_indices` are invalid,
     ///  - there is a codec decoding error, or
     ///  - an underlying store error.
+    pub async fn async_retrieve_chunk_elements_opt<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        chunk_indices: &[u64],
+        options: &DecodeOptions,
+    ) -> Result<Vec<T>, ArrayError> {
+        validate_element_size::<T>(self.data_type())?;
+        let bytes = self
+            .async_retrieve_chunk_opt(chunk_indices, options)
+            .await?;
+        Ok(transmute_from_bytes_vec::<T>(bytes))
+    }
+
+    /// Read and decode the chunk at `chunk_indices` into a vector of its elements or the fill value if it does not exist (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
     pub async fn async_retrieve_chunk_elements<T: bytemuck::Pod + Send + Sync>(
         &self,
         chunk_indices: &[u64],
     ) -> Result<Vec<T>, ArrayError> {
-        validate_element_size::<T>(self.data_type())?;
-        let bytes = self.async_retrieve_chunk(chunk_indices).await?;
-        Ok(transmute_from_bytes_vec::<T>(bytes))
+        self.async_retrieve_chunk_elements_opt(chunk_indices, &DecodeOptions::default())
+            .await
     }
 
     #[cfg(feature = "ndarray")]
@@ -158,9 +208,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///
     /// # Panics
     /// Will panic if a chunk dimension is larger than `usize::MAX`.
-    pub async fn async_retrieve_chunk_ndarray_if_exists<T: bytemuck::Pod + Send + Sync>(
+    pub async fn async_retrieve_chunk_ndarray_if_exists_opt<T: bytemuck::Pod + Send + Sync>(
         &self,
         chunk_indices: &[u64],
+        options: &DecodeOptions,
     ) -> Result<Option<ndarray::ArrayD<T>>, ArrayError> {
         // validate_element_size::<T>(self.data_type())?; in // async_retrieve_chunk_elements_if_exists
         let shape = self
@@ -168,13 +219,24 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             .chunk_shape_u64(chunk_indices, self.shape())?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
         let elements = self
-            .async_retrieve_chunk_elements_if_exists(chunk_indices)
+            .async_retrieve_chunk_elements_if_exists_opt(chunk_indices, options)
             .await?;
         if let Some(elements) = elements {
             Ok(Some(elements_to_ndarray(&shape, elements)?))
         } else {
             Ok(None)
         }
+    }
+
+    #[cfg(feature = "ndarray")]
+    /// Read and decode the chunk at `chunk_indices` into an [`ndarray::ArrayD`] if it exists (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
+    pub async fn async_retrieve_chunk_ndarray_if_exists<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        chunk_indices: &[u64],
+    ) -> Result<Option<ndarray::ArrayD<T>>, ArrayError> {
+        self.async_retrieve_chunk_ndarray_if_exists_opt(chunk_indices, &DecodeOptions::default())
+            .await
     }
 
     #[cfg(feature = "ndarray")]
@@ -190,17 +252,31 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///
     /// # Panics
     /// Will panic if a chunk dimension is larger than `usize::MAX`.
-    pub async fn async_retrieve_chunk_ndarray<T: bytemuck::Pod + Send + Sync>(
+    pub async fn async_retrieve_chunk_ndarray_opt<T: bytemuck::Pod + Send + Sync>(
         &self,
         chunk_indices: &[u64],
+        options: &DecodeOptions,
     ) -> Result<ndarray::ArrayD<T>, ArrayError> {
         // validate_element_size::<T>(self.data_type())?; // in async_retrieve_chunk_elements
         let shape = self
             .chunk_grid()
             .chunk_shape_u64(chunk_indices, self.shape())?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
-        let elements = self.async_retrieve_chunk_elements(chunk_indices).await?;
+        let elements = self
+            .async_retrieve_chunk_elements_opt(chunk_indices, options)
+            .await?;
         elements_to_ndarray(&shape, elements)
+    }
+
+    #[cfg(feature = "ndarray")]
+    /// Read and decode the chunk at `chunk_indices` into an [`ndarray::ArrayD`]. It is filled with the fill value if it does not exist (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
+    pub async fn async_retrieve_chunk_ndarray<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        chunk_indices: &[u64],
+    ) -> Result<ndarray::ArrayD<T>, ArrayError> {
+        self.async_retrieve_chunk_ndarray_opt(chunk_indices, &DecodeOptions::default())
+            .await
     }
 
     /// Read and decode the chunk at `chunk_indices` into its bytes.
@@ -213,7 +289,11 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///
     /// # Panics
     /// Panics if the number of elements in the chunk exceeds `usize::MAX`.
-    pub async fn async_retrieve_chunks(&self, chunks: &ArraySubset) -> Result<Vec<u8>, ArrayError> {
+    pub async fn async_retrieve_chunks_opt(
+        &self,
+        chunks: &ArraySubset,
+        options: &DecodeOptions,
+    ) -> Result<Vec<u8>, ArrayError> {
         if chunks.dimensionality() != self.chunk_grid().dimensionality() {
             return Err(ArrayError::InvalidArraySubset(
                 chunks.clone(),
@@ -229,7 +309,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             0 => Ok(vec![]),
             1 => {
                 let chunk_indices = chunks.start();
-                self.async_retrieve_chunk(chunk_indices).await
+                self.async_retrieve_chunk_opt(chunk_indices, options).await
             }
             _ => {
                 // Decode chunks and copy to output
@@ -249,6 +329,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
                             chunk_indices,
                             &array_subset,
                             unsafe { output_slice.get() },
+                            options,
                         )
                     })
                     .collect::<FuturesUnordered<_>>();
@@ -262,7 +343,28 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         }
     }
 
+    /// Read and decode the chunk at `chunk_indices` into its bytes (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
+    pub async fn async_retrieve_chunks(&self, chunks: &ArraySubset) -> Result<Vec<u8>, ArrayError> {
+        self.async_retrieve_chunks_opt(chunks, &DecodeOptions::default())
+            .await
+    }
+
     /// Read and decode the chunk at `chunk_indices` into a vector of its elements.
+    ///
+    /// # Errors
+    /// Returns an [`ArrayError`] if the size of `T` does not match the data type size or a [`Array::async_retrieve_chunks`] error condition is met.
+    pub async fn async_retrieve_chunks_elements_opt<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        chunks: &ArraySubset,
+        options: &DecodeOptions,
+    ) -> Result<Vec<T>, ArrayError> {
+        validate_element_size::<T>(self.data_type())?;
+        let bytes = self.async_retrieve_chunks_opt(chunks, options).await?;
+        Ok(transmute_from_bytes_vec::<T>(bytes))
+    }
+
+    /// Read and decode the chunk at `chunk_indices` into a vector of its elements (default options).
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if the size of `T` does not match the data type size or a [`Array::async_retrieve_chunks`] error condition is met.
@@ -270,23 +372,37 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         &self,
         chunks: &ArraySubset,
     ) -> Result<Vec<T>, ArrayError> {
-        validate_element_size::<T>(self.data_type())?;
-        let bytes = self.async_retrieve_chunks(chunks).await?;
-        Ok(transmute_from_bytes_vec::<T>(bytes))
+        self.async_retrieve_chunks_elements_opt(chunks, &DecodeOptions::default())
+            .await
     }
 
+    #[cfg(feature = "ndarray")]
     /// Read and decode the chunk at `chunk_indices` into an [`ndarray::ArrayD`].
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if the size of `T` does not match the data type size or a [`Array::async_retrieve_chunks`] error condition is met.
+    pub async fn async_retrieve_chunks_ndarray_opt<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        chunks: &ArraySubset,
+        options: &DecodeOptions,
+    ) -> Result<ndarray::ArrayD<T>, ArrayError> {
+        validate_element_size::<T>(self.data_type())?;
+        let array_subset = self.chunks_subset(chunks)?;
+        let elements = self
+            .async_retrieve_chunks_elements_opt(chunks, options)
+            .await?;
+        elements_to_ndarray(array_subset.shape(), elements)
+    }
+
+    #[cfg(feature = "ndarray")]
+    /// Read and decode the chunk at `chunk_indices` into an [`ndarray::ArrayD`] (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
     pub async fn async_retrieve_chunks_ndarray<T: bytemuck::Pod + Send + Sync>(
         &self,
         chunks: &ArraySubset,
     ) -> Result<ndarray::ArrayD<T>, ArrayError> {
-        validate_element_size::<T>(self.data_type())?;
-        let array_subset = self.chunks_subset(chunks)?;
-        let elements = self.async_retrieve_chunks_elements(chunks).await?;
-        elements_to_ndarray(array_subset.shape(), elements)
+        self.async_retrieve_chunks_ndarray_opt(chunks, &DecodeOptions::default())
+            .await
     }
 
     async fn _async_decode_chunk_into_array_subset(
@@ -294,6 +410,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         chunk_indices: &[u64],
         array_subset: &ArraySubset,
         output: &mut [u8],
+        options: &DecodeOptions,
     ) -> Result<(), ArrayError> {
         // Get the subset of the array corresponding to the chunk
         let chunk_subset_in_array = unsafe {
@@ -312,7 +429,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         let array_subset_in_chunk_subset =
             unsafe { overlap.relative_to_unchecked(chunk_subset_in_array.start()) };
         let decoded_bytes = self
-            .async_retrieve_chunk_subset(chunk_indices, &array_subset_in_chunk_subset)
+            .async_retrieve_chunk_subset_opt(chunk_indices, &array_subset_in_chunk_subset, options)
             .await?;
 
         // Copy decoded bytes to the output
@@ -349,9 +466,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     /// # Panics
     /// Panics if attempting to reference a byte beyond `usize::MAX`.
     #[allow(clippy::too_many_lines)]
-    pub async fn async_retrieve_array_subset(
+    pub async fn async_retrieve_array_subset_opt(
         &self,
         array_subset: &ArraySubset,
+        options: &DecodeOptions,
     ) -> Result<Vec<u8>, ArrayError> {
         if array_subset.dimensionality() != self.chunk_grid().dimensionality() {
             return Err(ArrayError::InvalidArraySubset(
@@ -378,7 +496,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
                 let chunk_subset = self.chunk_subset(chunk_indices).unwrap();
                 if &chunk_subset == array_subset {
                     // Single chunk fast path if the array subset domain matches the chunk domain
-                    self.async_retrieve_chunk(chunk_indices).await
+                    self.async_retrieve_chunk_opt(chunk_indices, options).await
                 } else {
                     let size_output = usize::try_from(
                         array_subset.num_elements() * self.data_type().size() as u64,
@@ -395,6 +513,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
                         chunk_indices,
                         array_subset,
                         output_slice,
+                        options,
                     )
                     .await?;
                     #[allow(clippy::transmute_undefined_repr)]
@@ -456,7 +575,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
                                     .await?;
 
                                 partial_decoder
-                                    .par_partial_decode(&[array_subset_in_chunk_subset])
+                                    .partial_decode_opt(&[array_subset_in_chunk_subset], options)
                                     .await?
                                     .remove(0)
                             };
@@ -501,6 +620,16 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         }
     }
 
+    /// Read and decode the `array_subset` of array into its bytes (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
+    pub async fn async_retrieve_array_subset(
+        &self,
+        array_subset: &ArraySubset,
+    ) -> Result<Vec<u8>, ArrayError> {
+        self.async_retrieve_array_subset_opt(array_subset, &DecodeOptions::default())
+            .await
+    }
+
     /// Read and decode the `array_subset` of array into a vector of its elements.
     ///
     /// # Errors
@@ -510,13 +639,26 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///  - an array subset is invalid or out of bounds of the array,
     ///  - there is a codec decoding error, or
     ///  - an underlying store error.
+    pub async fn async_retrieve_array_subset_elements_opt<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        array_subset: &ArraySubset,
+        options: &DecodeOptions,
+    ) -> Result<Vec<T>, ArrayError> {
+        validate_element_size::<T>(self.data_type())?;
+        let bytes = self
+            .async_retrieve_array_subset_opt(array_subset, options)
+            .await?;
+        Ok(transmute_from_bytes_vec::<T>(bytes))
+    }
+
+    /// Read and decode the `array_subset` of array into a vector of its elements (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
     pub async fn async_retrieve_array_subset_elements<T: bytemuck::Pod + Send + Sync>(
         &self,
         array_subset: &ArraySubset,
     ) -> Result<Vec<T>, ArrayError> {
-        validate_element_size::<T>(self.data_type())?;
-        let bytes = self.async_retrieve_array_subset(array_subset).await?;
-        Ok(transmute_from_bytes_vec::<T>(bytes))
+        self.async_retrieve_array_subset_elements_opt(array_subset, &DecodeOptions::default())
+            .await
     }
 
     #[cfg(feature = "ndarray")]
@@ -530,15 +672,27 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///
     /// # Panics
     /// Will panic if any dimension in `chunk_subset` is `usize::MAX` or larger.
+    pub async fn async_retrieve_array_subset_ndarray_opt<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        array_subset: &ArraySubset,
+        options: &DecodeOptions,
+    ) -> Result<ndarray::ArrayD<T>, ArrayError> {
+        // validate_element_size::<T>(self.data_type())?; // in async_retrieve_array_subset_elements
+        let elements = self
+            .async_retrieve_array_subset_elements_opt(array_subset, options)
+            .await?;
+        elements_to_ndarray(array_subset.shape(), elements)
+    }
+
+    #[cfg(feature = "ndarray")]
+    /// Read and decode the `array_subset` of array into an [`ndarray::ArrayD`] (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
     pub async fn async_retrieve_array_subset_ndarray<T: bytemuck::Pod + Send + Sync>(
         &self,
         array_subset: &ArraySubset,
     ) -> Result<ndarray::ArrayD<T>, ArrayError> {
-        // validate_element_size::<T>(self.data_type())?; // in async_retrieve_array_subset_elements
-        let elements = self
-            .async_retrieve_array_subset_elements(array_subset)
-            .await?;
-        elements_to_ndarray(array_subset.shape(), elements)
+        self.async_retrieve_array_subset_ndarray_opt(array_subset, &DecodeOptions::default())
+            .await
     }
 
     /// Read and decode the `chunk_subset` of the chunk at `chunk_indices` into its bytes.
@@ -552,10 +706,11 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///
     /// # Panics
     /// Will panic if the number of elements in `chunk_subset` is `usize::MAX` or larger.
-    pub async fn async_retrieve_chunk_subset(
+    pub async fn async_retrieve_chunk_subset_opt(
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
+        options: &DecodeOptions,
     ) -> Result<Vec<u8>, ArrayError> {
         let chunk_representation = self.chunk_array_representation(chunk_indices)?;
         if !chunk_subset.inbounds(&chunk_representation.shape_u64()) {
@@ -576,9 +731,9 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
 
         let decoded_bytes = self
             .codecs()
-            .async_partial_decoder_opt(input_handle, &chunk_representation, self.parallel_codecs())
+            .async_partial_decoder_opt(input_handle, &chunk_representation, options)
             .await?
-            .partial_decode_opt(&[chunk_subset.clone()], self.parallel_codecs())
+            .partial_decode_opt(&[chunk_subset.clone()], options)
             .await?;
 
         let total_size = decoded_bytes.iter().map(Vec::len).sum::<usize>();
@@ -593,6 +748,17 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         }
     }
 
+    /// Read and decode the `chunk_subset` of the chunk at `chunk_indices` into its bytes (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
+    pub async fn async_retrieve_chunk_subset(
+        &self,
+        chunk_indices: &[u64],
+        chunk_subset: &ArraySubset,
+    ) -> Result<Vec<u8>, ArrayError> {
+        self.async_retrieve_chunk_subset_opt(chunk_indices, chunk_subset, &DecodeOptions::default())
+            .await
+    }
+
     /// Read and decode the `chunk_subset` of the chunk at `chunk_indices` into its elements.
     ///
     /// # Errors
@@ -601,16 +767,32 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///  - the chunk subset is invalid,
     ///  - there is a codec decoding error, or
     ///  - an underlying store error.
+    pub async fn async_retrieve_chunk_subset_elements_opt<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        chunk_indices: &[u64],
+        chunk_subset: &ArraySubset,
+        options: &DecodeOptions,
+    ) -> Result<Vec<T>, ArrayError> {
+        validate_element_size::<T>(self.data_type())?;
+        let bytes = self
+            .async_retrieve_chunk_subset_opt(chunk_indices, chunk_subset, options)
+            .await?;
+        Ok(transmute_from_bytes_vec::<T>(bytes))
+    }
+
+    /// Read and decode the `chunk_subset` of the chunk at `chunk_indices` into its elements (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
     pub async fn async_retrieve_chunk_subset_elements<T: bytemuck::Pod + Send + Sync>(
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
     ) -> Result<Vec<T>, ArrayError> {
-        validate_element_size::<T>(self.data_type())?;
-        let bytes = self
-            .async_retrieve_chunk_subset(chunk_indices, chunk_subset)
-            .await?;
-        Ok(transmute_from_bytes_vec::<T>(bytes))
+        self.async_retrieve_chunk_subset_elements_opt(
+            chunk_indices,
+            chunk_subset,
+            &DecodeOptions::default(),
+        )
+        .await
     }
 
     #[cfg(feature = "ndarray")]
@@ -625,26 +807,43 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
     ///
     /// # Panics
     /// Will panic if the number of elements in `chunk_subset` is `usize::MAX` or larger.
+    pub async fn async_retrieve_chunk_subset_ndarray_opt<T: bytemuck::Pod + Send + Sync>(
+        &self,
+        chunk_indices: &[u64],
+        chunk_subset: &ArraySubset,
+        options: &DecodeOptions,
+    ) -> Result<ndarray::ArrayD<T>, ArrayError> {
+        // validate_element_size::<T>(self.data_type())?; // in async_retrieve_chunk_subset_elements
+        let elements = self
+            .async_retrieve_chunk_subset_elements_opt(chunk_indices, chunk_subset, options)
+            .await?;
+        elements_to_ndarray(chunk_subset.shape(), elements)
+    }
+
+    #[cfg(feature = "ndarray")]
+    /// Read and decode the `chunk_subset` of the chunk at `chunk_indices` into an [`ndarray::ArrayD`] (default options).
+    #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
     pub async fn async_retrieve_chunk_subset_ndarray<T: bytemuck::Pod + Send + Sync>(
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
     ) -> Result<ndarray::ArrayD<T>, ArrayError> {
-        // validate_element_size::<T>(self.data_type())?; // in async_retrieve_chunk_subset_elements
-        let elements = self
-            .async_retrieve_chunk_subset_elements(chunk_indices, chunk_subset)
-            .await?;
-        elements_to_ndarray(chunk_subset.shape(), elements)
+        self.async_retrieve_chunk_subset_ndarray_opt(
+            chunk_indices,
+            chunk_subset,
+            &DecodeOptions::default(),
+        )
+        .await
     }
 
-    /// Initialises a partial decoder for the chunk at `chunk_indices` with optional parallelism.
+    /// Initialises a partial decoder for the chunk at `chunk_indices`.
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if initialisation of the partial decoder fails.
     pub async fn async_partial_decoder_opt<'a>(
         &'a self,
         chunk_indices: &[u64],
-        parallel: bool,
+        options: &PartialDecoderOptions,
     ) -> Result<Box<dyn AsyncArrayPartialDecoderTraits + 'a>, ArrayError> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
@@ -657,11 +856,11 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         let chunk_representation = self.chunk_array_representation(chunk_indices)?;
         Ok(self
             .codecs()
-            .async_partial_decoder_opt(input_handle, &chunk_representation, parallel)
+            .async_partial_decoder_opt(input_handle, &chunk_representation, options)
             .await?)
     }
 
-    /// Initialises a partial decoder for the chunk at `chunk_indices`.
+    /// Initialises a partial decoder for the chunk at `chunk_indices` (default options).
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if initialisation of the partial decoder fails.
@@ -669,17 +868,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         &'a self,
         chunk_indices: &[u64],
     ) -> Result<Box<dyn AsyncArrayPartialDecoderTraits + 'a>, ArrayError> {
-        self.async_partial_decoder_opt(chunk_indices, false).await
-    }
-
-    /// Initialises a partial decoder for the chunk at `chunk_indices` using multithreading if applicable.
-    ///
-    /// # Errors
-    /// Returns an [`ArrayError`] if initialisation of the partial decoder fails.
-    pub async fn async_par_partial_decoder<'a>(
-        &'a self,
-        chunk_indices: &[u64],
-    ) -> Result<Box<dyn AsyncArrayPartialDecoderTraits + 'a>, ArrayError> {
-        self.async_partial_decoder_opt(chunk_indices, true).await
+        self.async_partial_decoder_opt(chunk_indices, &PartialDecoderOptions::default())
+            .await
     }
 }

--- a/src/array/array_builder.rs
+++ b/src/array/array_builder.rs
@@ -78,8 +78,6 @@ pub struct ArrayBuilder {
     pub dimension_names: Option<Vec<DimensionName>>,
     /// Additional fields.
     pub additional_fields: AdditionalFields,
-    /// Parallel codecs.
-    pub parallel_codecs: bool,
 }
 
 impl ArrayBuilder {
@@ -107,7 +105,6 @@ impl ArrayBuilder {
             storage_transformers: StorageTransformerChain::default(),
             dimension_names: None,
             additional_fields: AdditionalFields::default(),
-            parallel_codecs: true,
         }
     }
 
@@ -125,7 +122,6 @@ impl ArrayBuilder {
             .attributes(array.attributes().clone())
             .chunk_key_encoding(array.chunk_key_encoding().clone())
             .dimension_names(array.dimension_names().clone())
-            .parallel_codecs(array.parallel_codecs())
             .array_to_array_codecs(array.codecs().array_to_array_codecs().to_vec())
             .array_to_bytes_codec(array.codecs().array_to_bytes_codec().clone())
             .bytes_to_bytes_codecs(array.codecs().bytes_to_bytes_codecs().to_vec())
@@ -251,14 +247,6 @@ impl ArrayBuilder {
         self
     }
 
-    /// Set whether or not to use multithreaded codec encoding and decoding.
-    ///
-    /// If parallel codecs is not set, it defaults to true.
-    pub fn parallel_codecs(&mut self, parallel_codecs: bool) -> &mut Self {
-        self.parallel_codecs = parallel_codecs;
-        self
-    }
-
     /// Build into an [`Array`].
     ///
     /// # Errors
@@ -312,7 +300,6 @@ impl ArrayBuilder {
             attributes: self.attributes.clone(),
             dimension_names: self.dimension_names.clone(),
             additional_fields: self.additional_fields.clone(),
-            parallel_codecs: self.parallel_codecs,
             include_zarrs_metadata: true,
         })
     }
@@ -346,7 +333,6 @@ mod tests {
         builder.fill_value(FillValue::from(0i8));
 
         builder.dimension_names(Some(vec!["y".into(), "x".into()]));
-        builder.parallel_codecs(true);
 
         let mut attributes = serde_json::Map::new();
         attributes.insert("key".to_string(), "value".into());
@@ -376,7 +362,6 @@ mod tests {
         assert_eq!(array.chunk_grid_shape(), Some(vec![4, 4]));
         assert_eq!(array.fill_value(), &FillValue::from(0i8));
         assert_eq!(array.dimension_names(), &Some(vec!["y".into(), "x".into()]));
-        assert!(array.parallel_codecs());
         assert_eq!(array.attributes(), &attributes);
         assert_eq!(array.additional_fields(), &additional_fields);
 
@@ -387,7 +372,6 @@ mod tests {
         assert_eq!(builder.attributes, builder2.attributes);
         assert_eq!(builder.dimension_names, builder2.dimension_names);
         assert_eq!(builder.additional_fields, builder2.additional_fields);
-        assert_eq!(builder.parallel_codecs, builder2.parallel_codecs);
     }
 
     #[test]

--- a/src/array/codec/array_to_array/bitround/bitround_partial_decoder.rs
+++ b/src/array/codec/array_to_array/bitround/bitround_partial_decoder.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::{
-        codec::{ArrayPartialDecoderTraits, CodecError},
+        codec::{ArrayPartialDecoderTraits, CodecError, PartialDecodeOptions},
         DataType,
     },
     array_subset::ArraySubset,
@@ -54,11 +54,11 @@ impl ArrayPartialDecoderTraits for BitroundPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         array_subsets: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
         let mut bytes = self
             .input_handle
-            .partial_decode_opt(array_subsets, parallel)?;
+            .partial_decode_opt(array_subsets, options)?;
 
         for bytes in &mut bytes {
             round_bytes(bytes, &self.data_type, self.keepbits)?;
@@ -115,11 +115,11 @@ impl AsyncArrayPartialDecoderTraits for AsyncBitroundPartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         array_subsets: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
         let mut bytes = self
             .input_handle
-            .partial_decode_opt(array_subsets, parallel)
+            .partial_decode_opt(array_subsets, options)
             .await?;
 
         for bytes in &mut bytes {

--- a/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
+++ b/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
@@ -1,6 +1,6 @@
 use super::{calculate_order_decode, permute, transpose_array, TransposeOrder};
 use crate::array::{
-    codec::{ArrayPartialDecoderTraits, ArraySubset, CodecError},
+    codec::{ArrayPartialDecoderTraits, ArraySubset, CodecError, PartialDecodeOptions},
     ChunkRepresentation,
 };
 
@@ -33,7 +33,7 @@ impl ArrayPartialDecoderTraits for TransposePartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
         // Get transposed array subsets
         let mut decoded_regions_transposed = Vec::with_capacity(decoded_regions.len());
@@ -46,7 +46,7 @@ impl ArrayPartialDecoderTraits for TransposePartialDecoder<'_> {
         }
         let mut encoded_value = self
             .input_handle
-            .partial_decode_opt(&decoded_regions_transposed, parallel)?;
+            .partial_decode_opt(&decoded_regions_transposed, options)?;
 
         // Reverse the transpose on each subset
         let order_decode =
@@ -99,7 +99,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncTransposePartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
         // Get transposed array subsets
         let mut decoded_regions_transposed = Vec::with_capacity(decoded_regions.len());
@@ -112,7 +112,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncTransposePartialDecoder<'_> {
         }
         let mut encoded_value = self
             .input_handle
-            .partial_decode_opt(&decoded_regions_transposed, parallel)
+            .partial_decode_opt(&decoded_regions_transposed, options)
             .await?;
 
         // Reverse the transpose on each subset

--- a/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
+++ b/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
@@ -1,6 +1,9 @@
 use crate::{
     array::{
-        codec::{ArrayPartialDecoderTraits, ArraySubset, BytesPartialDecoderTraits, CodecError},
+        codec::{
+            ArrayPartialDecoderTraits, ArraySubset, BytesPartialDecoderTraits, CodecError,
+            PartialDecodeOptions,
+        },
         ChunkRepresentation,
     },
     array_subset::IncompatibleArraySubsetAndShapeError,
@@ -37,7 +40,7 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
         let mut bytes = Vec::with_capacity(decoded_regions.len());
         let chunk_shape = self.decoded_representation.shape_u64();
@@ -55,7 +58,7 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder<'_> {
             // Decode
             let decoded = self
                 .input_handle
-                .partial_decode_opt(&byte_ranges, parallel)?;
+                .partial_decode_opt(&byte_ranges, options)?;
 
             let bytes_subset = decoded.map_or_else(
                 || {
@@ -114,7 +117,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
         let mut bytes = Vec::with_capacity(decoded_regions.len());
         let chunk_shape = self.decoded_representation.shape_u64();
@@ -132,7 +135,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder<'_> {
             // Decode
             let decoded = self
                 .input_handle
-                .partial_decode_opt(&byte_ranges, parallel)
+                .partial_decode_opt(&byte_ranges, options)
                 .await?;
 
             let bytes_subset = decoded.map_or_else(

--- a/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
+++ b/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
@@ -1,6 +1,9 @@
 use crate::{
     array::{
-        codec::{ArrayPartialDecoderTraits, ArraySubset, BytesPartialDecoderTraits, CodecError},
+        codec::{
+            ArrayPartialDecoderTraits, ArraySubset, BytesPartialDecoderTraits, CodecError,
+            PartialDecodeOptions,
+        },
         ChunkRepresentation, DataType,
     },
     array_subset::IncompatibleArraySubsetAndShapeError,
@@ -105,9 +108,9 @@ impl ArrayPartialDecoderTraits for PcodecPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
-        let decoded = self.input_handle.decode_opt(parallel)?;
+        let decoded = self.input_handle.decode_opt(options)?;
         do_partial_decode(decoded, decoded_regions, &self.decoded_representation)
     }
 }
@@ -139,9 +142,9 @@ impl AsyncArrayPartialDecoderTraits for AsyncPCodecPartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
-        let decoded = self.input_handle.decode_opt(parallel).await?;
+        let decoded = self.input_handle.decode_opt(options).await?;
         do_partial_decode(decoded, decoded_regions, &self.decoded_representation)
     }
 }

--- a/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder.rs
+++ b/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder.rs
@@ -9,6 +9,7 @@ use crate::{
         codec::{
             ArrayPartialDecoderTraits, ArraySubset, ArrayToBytesCodecTraits,
             ByteIntervalPartialDecoder, BytesPartialDecoderTraits, CodecChain, CodecError,
+            PartialDecodeOptions, PartialDecoderOptions,
         },
         ravel_indices,
         unsafe_cell_slice::UnsafeCellSlice,
@@ -49,7 +50,7 @@ impl<'a> ShardingPartialDecoder<'a> {
         inner_codecs: &'a CodecChain,
         index_codecs: &'a CodecChain,
         index_location: ShardingIndexLocation,
-        parallel: bool,
+        options: &PartialDecoderOptions,
     ) -> Result<Self, CodecError> {
         let shard_index = Self::decode_shard_index(
             &*input_handle,
@@ -57,7 +58,7 @@ impl<'a> ShardingPartialDecoder<'a> {
             index_location,
             chunk_shape.as_slice(),
             &decoded_representation,
-            parallel,
+            options,
         )?;
         Ok(Self {
             input_handle,
@@ -75,7 +76,7 @@ impl<'a> ShardingPartialDecoder<'a> {
         index_location: ShardingIndexLocation,
         chunk_shape: &[NonZeroU64],
         decoded_representation: &ChunkRepresentation,
-        parallel: bool,
+        options: &PartialDecoderOptions,
     ) -> Result<Option<Vec<u64>>, CodecError> {
         let shard_shape = decoded_representation.shape();
         let chunk_representation = unsafe {
@@ -105,7 +106,7 @@ impl<'a> ShardingPartialDecoder<'a> {
         };
 
         let encoded_shard_index = input_handle
-            .partial_decode_opt(&[index_byte_range], parallel)?
+            .partial_decode_opt(&[index_byte_range], options)?
             .map(|mut v| v.remove(0));
 
         Ok(match encoded_shard_index {
@@ -113,7 +114,7 @@ impl<'a> ShardingPartialDecoder<'a> {
                 encoded_shard_index,
                 &index_array_representation,
                 index_codecs,
-                parallel,
+                options,
             )?),
             None => None,
         })
@@ -124,118 +125,7 @@ impl ArrayPartialDecoderTraits for ShardingPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         array_subsets: &[ArraySubset],
-        parallel: bool,
-    ) -> Result<Vec<Vec<u8>>, CodecError> {
-        if parallel {
-            self.par_partial_decode(array_subsets)
-        } else {
-            self.partial_decode(array_subsets)
-        }
-    }
-
-    fn partial_decode(&self, array_subsets: &[ArraySubset]) -> Result<Vec<Vec<u8>>, CodecError> {
-        let Some(shard_index) = &self.shard_index else {
-            return Ok(array_subsets
-                .iter()
-                .map(|array_subset| {
-                    self.decoded_representation
-                        .fill_value()
-                        .as_ne_bytes()
-                        .repeat(array_subset.num_elements_usize())
-                })
-                .collect());
-        };
-
-        let chunk_representation = unsafe {
-            ChunkRepresentation::new_unchecked(
-                self.chunk_grid.chunk_shape().to_vec(),
-                self.decoded_representation.data_type().clone(),
-                self.decoded_representation.fill_value().clone(),
-            )
-        };
-
-        let chunks_per_shard = calculate_chunks_per_shard(
-            self.decoded_representation.shape(),
-            chunk_representation.shape(),
-        )
-        .map_err(|e| CodecError::Other(e.to_string()))?;
-        let chunks_per_shard = chunk_shape_to_array_shape(chunks_per_shard.as_slice());
-
-        let element_size = self.decoded_representation.element_size();
-        let element_size_u64 = element_size as u64;
-        let fill_value = chunk_representation.fill_value().as_ne_bytes();
-
-        let mut out = Vec::with_capacity(array_subsets.len());
-        for array_subset in array_subsets {
-            let array_subset_size =
-                usize::try_from(array_subset.num_elements() * element_size_u64).unwrap();
-            let mut out_array_subset = vec![0; array_subset_size];
-
-            // Decode those chunks if required and put in chunk cache
-            for (chunk_indices, chunk_subset) in
-                unsafe { array_subset.iter_chunks_unchecked(chunk_representation.shape()) }
-            {
-                let shard_index_index: usize =
-                    usize::try_from(ravel_indices(&chunk_indices, &chunks_per_shard) * 2).unwrap();
-                let offset = shard_index[shard_index_index];
-                let size = shard_index[shard_index_index + 1];
-
-                let overlap = unsafe { array_subset.overlap_unchecked(&chunk_subset) };
-                let decoded_bytes = if offset == u64::MAX && size == u64::MAX {
-                    // The chunk is just the fill value
-                    fill_value.repeat(chunk_subset.num_elements_usize())
-                } else {
-                    // The chunk must be decoded
-                    let partial_decoder = self.inner_codecs.partial_decoder(
-                        Box::new(ByteIntervalPartialDecoder::new(
-                            &*self.input_handle,
-                            offset,
-                            size,
-                        )),
-                        &chunk_representation,
-                    )?;
-                    let array_subset_in_chunk_subset =
-                        unsafe { overlap.relative_to_unchecked(chunk_subset.start()) };
-
-                    // Partial decoding is actually really slow with the blosc codec! Assume sharded chunks are small, and just decode the whole thing and extract bytes
-                    // TODO: Make this behaviour optional?
-                    // partial_decoder
-                    //     .partial_decode(&[array_subset_in_chunk_subset.clone()])?
-                    //     .remove(0)
-                    let decoded_chunk = partial_decoder
-                        .partial_decode(&[ArraySubset::new_with_shape(
-                            chunk_subset.shape().to_vec(),
-                        )])?
-                        .remove(0);
-                    array_subset_in_chunk_subset
-                        .extract_bytes(&decoded_chunk, chunk_subset.shape(), element_size)
-                        .unwrap()
-                };
-
-                // Copy decoded bytes to the output
-                let chunk_subset_in_array_subset =
-                    unsafe { overlap.relative_to_unchecked(array_subset.start()) };
-                let mut decoded_offset = 0;
-                for (array_subset_element_index, num_elements) in unsafe {
-                    chunk_subset_in_array_subset
-                        .iter_contiguous_linearised_indices_unchecked(array_subset.shape())
-                } {
-                    let output_offset =
-                        usize::try_from(array_subset_element_index * element_size_u64).unwrap();
-                    let length = usize::try_from(num_elements * element_size_u64).unwrap();
-                    out_array_subset[output_offset..output_offset + length]
-                        .copy_from_slice(&decoded_bytes[decoded_offset..decoded_offset + length]);
-                    decoded_offset += length;
-                }
-            }
-            out.push(out_array_subset);
-        }
-        Ok(out)
-    }
-
-    fn par_partial_decode(
-        &self,
-        array_subsets: &[ArraySubset],
+        _options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
         let Some(shard_index) = &self.shard_index else {
             return Ok(array_subsets
@@ -275,6 +165,7 @@ impl ArrayPartialDecoderTraits for ShardingPartialDecoder<'_> {
             let out_array_subset_slice = UnsafeCellSlice::new(out_array_subset.as_mut_slice());
 
             // Decode those chunks if required
+            // FIXME: Concurrent limit here
             unsafe { array_subset.iter_chunks_unchecked(chunk_representation.shape()) }
                 .par_bridge()
                 .try_for_each(|(chunk_indices, chunk_subset)| {
@@ -333,6 +224,106 @@ impl ArrayPartialDecoderTraits for ShardingPartialDecoder<'_> {
         }
         Ok(out)
     }
+
+    // fn partial_decode(&self, array_subsets: &[ArraySubset]) -> Result<Vec<Vec<u8>>, CodecError> {
+    //     let Some(shard_index) = &self.shard_index else {
+    //         return Ok(array_subsets
+    //             .iter()
+    //             .map(|array_subset| {
+    //                 self.decoded_representation
+    //                     .fill_value()
+    //                     .as_ne_bytes()
+    //                     .repeat(array_subset.num_elements_usize())
+    //             })
+    //             .collect());
+    //     };
+
+    //     let chunk_representation = unsafe {
+    //         ChunkRepresentation::new_unchecked(
+    //             self.chunk_grid.chunk_shape().to_vec(),
+    //             self.decoded_representation.data_type().clone(),
+    //             self.decoded_representation.fill_value().clone(),
+    //         )
+    //     };
+
+    //     let chunks_per_shard = calculate_chunks_per_shard(
+    //         self.decoded_representation.shape(),
+    //         chunk_representation.shape(),
+    //     )
+    //     .map_err(|e| CodecError::Other(e.to_string()))?;
+    //     let chunks_per_shard = chunk_shape_to_array_shape(chunks_per_shard.as_slice());
+
+    //     let element_size = self.decoded_representation.element_size();
+    //     let element_size_u64 = element_size as u64;
+    //     let fill_value = chunk_representation.fill_value().as_ne_bytes();
+
+    //     let mut out = Vec::with_capacity(array_subsets.len());
+    //     for array_subset in array_subsets {
+    //         let array_subset_size =
+    //             usize::try_from(array_subset.num_elements() * element_size_u64).unwrap();
+    //         let mut out_array_subset = vec![0; array_subset_size];
+
+    //         // Decode those chunks if required and put in chunk cache
+    //         for (chunk_indices, chunk_subset) in
+    //             unsafe { array_subset.iter_chunks_unchecked(chunk_representation.shape()) }
+    //         {
+    //             let shard_index_index: usize =
+    //                 usize::try_from(ravel_indices(&chunk_indices, &chunks_per_shard) * 2).unwrap();
+    //             let offset = shard_index[shard_index_index];
+    //             let size = shard_index[shard_index_index + 1];
+
+    //             let overlap = unsafe { array_subset.overlap_unchecked(&chunk_subset) };
+    //             let decoded_bytes = if offset == u64::MAX && size == u64::MAX {
+    //                 // The chunk is just the fill value
+    //                 fill_value.repeat(chunk_subset.num_elements_usize())
+    //             } else {
+    //                 // The chunk must be decoded
+    //                 let partial_decoder = self.inner_codecs.partial_decoder(
+    //                     Box::new(ByteIntervalPartialDecoder::new(
+    //                         &*self.input_handle,
+    //                         offset,
+    //                         size,
+    //                     )),
+    //                     &chunk_representation,
+    //                 )?;
+    //                 let array_subset_in_chunk_subset =
+    //                     unsafe { overlap.relative_to_unchecked(chunk_subset.start()) };
+
+    //                 // Partial decoding is actually really slow with the blosc codec! Assume sharded chunks are small, and just decode the whole thing and extract bytes
+    //                 // TODO: Make this behaviour optional?
+    //                 // partial_decoder
+    //                 //     .partial_decode(&[array_subset_in_chunk_subset.clone()])?
+    //                 //     .remove(0)
+    //                 let decoded_chunk = partial_decoder
+    //                     .partial_decode(&[ArraySubset::new_with_shape(
+    //                         chunk_subset.shape().to_vec(),
+    //                     )])?
+    //                     .remove(0);
+    //                 array_subset_in_chunk_subset
+    //                     .extract_bytes(&decoded_chunk, chunk_subset.shape(), element_size)
+    //                     .unwrap()
+    //             };
+
+    //             // Copy decoded bytes to the output
+    //             let chunk_subset_in_array_subset =
+    //                 unsafe { overlap.relative_to_unchecked(array_subset.start()) };
+    //             let mut decoded_offset = 0;
+    //             for (array_subset_element_index, num_elements) in unsafe {
+    //                 chunk_subset_in_array_subset
+    //                     .iter_contiguous_linearised_indices_unchecked(array_subset.shape())
+    //             } {
+    //                 let output_offset =
+    //                     usize::try_from(array_subset_element_index * element_size_u64).unwrap();
+    //                 let length = usize::try_from(num_elements * element_size_u64).unwrap();
+    //                 out_array_subset[output_offset..output_offset + length]
+    //                     .copy_from_slice(&decoded_bytes[decoded_offset..decoded_offset + length]);
+    //                 decoded_offset += length;
+    //             }
+    //         }
+    //         out.push(out_array_subset);
+    //     }
+    //     Ok(out)
+    // }
 }
 
 #[cfg(feature = "async")]
@@ -355,7 +346,7 @@ impl<'a> AsyncShardingPartialDecoder<'a> {
         inner_codecs: &'a CodecChain,
         index_codecs: &'a CodecChain,
         index_location: ShardingIndexLocation,
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<AsyncShardingPartialDecoder<'a>, CodecError> {
         let shard_index = Self::decode_shard_index(
             &*input_handle,
@@ -363,7 +354,7 @@ impl<'a> AsyncShardingPartialDecoder<'a> {
             index_location,
             chunk_shape.as_slice(),
             &decoded_representation,
-            parallel,
+            options,
         )
         .await?;
         Ok(Self {
@@ -382,7 +373,7 @@ impl<'a> AsyncShardingPartialDecoder<'a> {
         index_location: ShardingIndexLocation,
         chunk_shape: &[NonZeroU64],
         decoded_representation: &ChunkRepresentation,
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<u64>>, CodecError> {
         let shard_shape = decoded_representation.shape();
         let chunk_representation = unsafe {
@@ -412,7 +403,7 @@ impl<'a> AsyncShardingPartialDecoder<'a> {
         };
 
         let encoded_shard_index = input_handle
-            .partial_decode_opt(&[index_byte_range], parallel)
+            .partial_decode_opt(&[index_byte_range], options)
             .await?
             .map(|mut v| v.remove(0));
 
@@ -422,7 +413,7 @@ impl<'a> AsyncShardingPartialDecoder<'a> {
                     encoded_shard_index,
                     &index_array_representation,
                     index_codecs,
-                    parallel,
+                    options,
                 )
                 .await?,
             ),
@@ -434,117 +425,11 @@ impl<'a> AsyncShardingPartialDecoder<'a> {
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
 impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder<'_> {
+    #[allow(clippy::too_many_lines)]
     async fn partial_decode_opt(
         &self,
         array_subsets: &[ArraySubset],
-        parallel: bool,
-    ) -> Result<Vec<Vec<u8>>, CodecError> {
-        if parallel {
-            self.par_partial_decode(array_subsets).await
-        } else {
-            self.partial_decode(array_subsets).await
-        }
-    }
-
-    async fn partial_decode(
-        &self,
-        array_subsets: &[ArraySubset],
-    ) -> Result<Vec<Vec<u8>>, CodecError> {
-        let Some(shard_index) = &self.shard_index else {
-            return Ok(array_subsets
-                .iter()
-                .map(|array_subset| {
-                    self.decoded_representation
-                        .fill_value()
-                        .as_ne_bytes()
-                        .repeat(array_subset.num_elements_usize())
-                })
-                .collect());
-        };
-
-        let chunk_representation = unsafe {
-            ChunkRepresentation::new_unchecked(
-                self.chunk_grid.chunk_shape().to_vec(),
-                self.decoded_representation.data_type().clone(),
-                self.decoded_representation.fill_value().clone(),
-            )
-        };
-
-        let chunks_per_shard = calculate_chunks_per_shard(
-            self.decoded_representation.shape(),
-            chunk_representation.shape(),
-        )
-        .map_err(|e| CodecError::Other(e.to_string()))?;
-        let chunks_per_shard = chunk_shape_to_array_shape(chunks_per_shard.as_slice());
-
-        let element_size = self.decoded_representation.element_size() as u64;
-        let fill_value = chunk_representation.fill_value().as_ne_bytes();
-
-        let mut out = Vec::with_capacity(array_subsets.len());
-        for array_subset in array_subsets {
-            let array_subset_size =
-                usize::try_from(array_subset.num_elements() * element_size).unwrap();
-            let mut out_array_subset = vec![0; array_subset_size];
-
-            // Decode those chunks if required and put in chunk cache
-            for (chunk_indices, chunk_subset) in
-                unsafe { array_subset.iter_chunks_unchecked(chunk_representation.shape()) }
-            {
-                let shard_index_index: usize =
-                    usize::try_from(ravel_indices(&chunk_indices, &chunks_per_shard) * 2).unwrap();
-                let offset = shard_index[shard_index_index];
-                let size = shard_index[shard_index_index + 1];
-
-                let overlap = unsafe { array_subset.overlap_unchecked(&chunk_subset) };
-                let decoded_bytes = if offset == u64::MAX && size == u64::MAX {
-                    // The chunk is just the fill value
-                    fill_value.repeat(chunk_subset.num_elements_usize())
-                } else {
-                    // The chunk must be decoded
-                    let partial_decoder = self
-                        .inner_codecs
-                        .async_partial_decoder(
-                            Box::new(AsyncByteIntervalPartialDecoder::new(
-                                &*self.input_handle,
-                                offset,
-                                size,
-                            )),
-                            &chunk_representation,
-                        )
-                        .await?;
-                    let array_subset_in_chunk_subset =
-                        unsafe { overlap.relative_to_unchecked(chunk_subset.start()) };
-                    partial_decoder
-                        .partial_decode(&[array_subset_in_chunk_subset.clone()])
-                        .await?
-                        .remove(0)
-                };
-
-                // Copy decoded bytes to the output
-                let chunk_subset_in_array_subset =
-                    unsafe { overlap.relative_to_unchecked(array_subset.start()) };
-                let mut decoded_offset = 0;
-                for (array_subset_element_index, num_elements) in unsafe {
-                    chunk_subset_in_array_subset
-                        .iter_contiguous_linearised_indices_unchecked(array_subset.shape())
-                } {
-                    let output_offset =
-                        usize::try_from(array_subset_element_index * element_size).unwrap();
-                    let length = usize::try_from(num_elements * element_size).unwrap();
-                    out_array_subset[output_offset..output_offset + length]
-                        .copy_from_slice(&decoded_bytes[decoded_offset..decoded_offset + length]);
-                    decoded_offset += length;
-                }
-            }
-            out.push(out_array_subset);
-        }
-        Ok(out)
-    }
-
-    #[allow(clippy::too_many_lines)]
-    async fn par_partial_decode(
-        &self,
-        array_subsets: &[ArraySubset],
+        _options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
         let Some(shard_index) = &self.shard_index else {
             return Ok(array_subsets

--- a/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
+++ b/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
@@ -2,7 +2,9 @@ use zfp_sys::zfp_type;
 
 use crate::{
     array::{
-        codec::{ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError},
+        codec::{
+            ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError, PartialDecodeOptions,
+        },
         ChunkRepresentation,
     },
     array_subset::ArraySubset,
@@ -51,9 +53,9 @@ impl ArrayPartialDecoderTraits for ZfpPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel)?;
+        let encoded_value = self.input_handle.decode_opt(options)?;
         let mut out = Vec::with_capacity(decoded_regions.len());
         let chunk_shape = self.decoded_representation.shape_u64();
         match encoded_value {
@@ -63,7 +65,7 @@ impl ArrayPartialDecoderTraits for ZfpPartialDecoder<'_> {
                     self.zfp_type,
                     encoded_value,
                     &self.decoded_representation,
-                    parallel,
+                    false, // FIXME
                 )?;
                 for array_subset in decoded_regions {
                     let byte_ranges = unsafe {
@@ -132,9 +134,9 @@ impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ArraySubset],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Vec<Vec<u8>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel).await?;
+        let encoded_value = self.input_handle.decode_opt(options).await?;
         let chunk_shape = self.decoded_representation.shape_u64();
         let mut out = Vec::with_capacity(decoded_regions.len());
         match encoded_value {
@@ -144,7 +146,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder<'_> {
                     self.zfp_type,
                     encoded_value,
                     &self.decoded_representation,
-                    parallel,
+                    false, // FIXME
                 )?;
                 for array_subset in decoded_regions {
                     let byte_ranges = unsafe {

--- a/src/array/codec/byte_interval_partial_decoder.rs
+++ b/src/array/codec/byte_interval_partial_decoder.rs
@@ -1,6 +1,6 @@
 use crate::byte_range::{ByteLength, ByteOffset, ByteRange};
 
-use super::{BytesPartialDecoderTraits, CodecError};
+use super::{BytesPartialDecoderTraits, CodecError, PartialDecodeOptions};
 
 #[cfg(feature = "async")]
 use super::AsyncBytesPartialDecoderTraits;
@@ -33,7 +33,7 @@ impl<'a> BytesPartialDecoderTraits for ByteIntervalPartialDecoder<'a> {
     fn partial_decode_opt(
         &self,
         byte_ranges: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
         let byte_ranges: Vec<ByteRange> = byte_ranges
             .iter()
@@ -53,7 +53,7 @@ impl<'a> BytesPartialDecoderTraits for ByteIntervalPartialDecoder<'a> {
                 ),
             })
             .collect();
-        self.inner.partial_decode_opt(&byte_ranges, parallel)
+        self.inner.partial_decode_opt(&byte_ranges, options)
     }
 }
 
@@ -89,7 +89,7 @@ impl<'a> AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder<'a> 
     async fn partial_decode_opt(
         &self,
         byte_ranges: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
         let byte_ranges: Vec<ByteRange> = byte_ranges
             .iter()
@@ -109,6 +109,6 @@ impl<'a> AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder<'a> 
                 ),
             })
             .collect();
-        self.inner.partial_decode_opt(&byte_ranges, parallel).await
+        self.inner.partial_decode_opt(&byte_ranges, options).await
     }
 }

--- a/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
+++ b/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
@@ -1,5 +1,8 @@
 use crate::{
-    array::codec::{bytes_to_bytes::blosc::blosc_nbytes, BytesPartialDecoderTraits, CodecError},
+    array::codec::{
+        bytes_to_bytes::blosc::blosc_nbytes, BytesPartialDecoderTraits, CodecError,
+        PartialDecodeOptions,
+    },
     byte_range::ByteRange,
 };
 
@@ -23,9 +26,9 @@ impl BytesPartialDecoderTraits for BloscPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel)?;
+        let encoded_value = self.input_handle.decode_opt(options)?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };
@@ -74,9 +77,9 @@ impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel).await?;
+        let encoded_value = self.input_handle.decode_opt(options).await?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };

--- a/src/array/codec/bytes_to_bytes/bz2/bz2_partial_decoder.rs
+++ b/src/array/codec/bytes_to_bytes/bz2/bz2_partial_decoder.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 
 use crate::{
-    array::codec::{BytesPartialDecoderTraits, CodecError},
+    array::codec::{BytesPartialDecoderTraits, CodecError, PartialDecodeOptions},
     byte_range::{extract_byte_ranges, ByteRange},
 };
 
@@ -23,9 +23,9 @@ impl BytesPartialDecoderTraits for Bz2PartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel)?;
+        let encoded_value = self.input_handle.decode_opt(options)?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };
@@ -60,9 +60,9 @@ impl AsyncBytesPartialDecoderTraits for AsyncBz2PartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel).await?;
+        let encoded_value = self.input_handle.decode_opt(options).await?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };

--- a/src/array/codec/bytes_to_bytes/crc32c/crc32c_partial_decoder.rs
+++ b/src/array/codec/bytes_to_bytes/crc32c/crc32c_partial_decoder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    array::codec::{BytesPartialDecoderTraits, CodecError},
+    array::codec::{BytesPartialDecoderTraits, CodecError, PartialDecodeOptions},
     byte_range::ByteRange,
 };
 
@@ -24,11 +24,11 @@ impl BytesPartialDecoderTraits for Crc32cPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
         let bytes = self
             .input_handle
-            .partial_decode_opt(decoded_regions, parallel)?;
+            .partial_decode_opt(decoded_regions, options)?;
         let Some(mut bytes) = bytes else {
             return Ok(None);
         };
@@ -73,11 +73,11 @@ impl AsyncBytesPartialDecoderTraits for AsyncCrc32cPartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
         let bytes = self
             .input_handle
-            .partial_decode_opt(decoded_regions, parallel)
+            .partial_decode_opt(decoded_regions, options)
             .await?;
         let Some(mut bytes) = bytes else {
             return Ok(None);

--- a/src/array/codec/bytes_to_bytes/gzip/gzip_partial_decoder.rs
+++ b/src/array/codec/bytes_to_bytes/gzip/gzip_partial_decoder.rs
@@ -3,7 +3,7 @@ use std::io::{Cursor, Read};
 use flate2::bufread::GzDecoder;
 
 use crate::{
-    array::codec::{BytesPartialDecoderTraits, CodecError},
+    array::codec::{BytesPartialDecoderTraits, CodecError, PartialDecodeOptions},
     byte_range::{extract_byte_ranges, ByteRange},
 };
 
@@ -26,9 +26,9 @@ impl BytesPartialDecoderTraits for GzipPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel)?;
+        let encoded_value = self.input_handle.decode_opt(options)?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };
@@ -64,9 +64,9 @@ impl AsyncBytesPartialDecoderTraits for AsyncGzipPartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel).await?;
+        let encoded_value = self.input_handle.decode_opt(options).await?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };

--- a/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
+++ b/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
@@ -1,6 +1,9 @@
 use crate::{
     array::{
-        codec::{BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecError, CodecTraits},
+        codec::{
+            BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecError, CodecTraits,
+            DecodeOptions, EncodeOptions, PartialDecoderOptions, RecommendedConcurrency,
+        },
         BytesRepresentation,
     },
     metadata::Metadata,
@@ -41,7 +44,19 @@ impl CodecTraits for TestUnboundedCodec {
 
 #[cfg_attr(feature = "async", async_trait::async_trait)]
 impl BytesToBytesCodecTraits for TestUnboundedCodec {
-    fn encode_opt(&self, decoded_value: Vec<u8>, _parallel: bool) -> Result<Vec<u8>, CodecError> {
+    /// Return the maximum internal concurrency supported for the requested decoded representation.
+    fn recommended_concurrency(
+        &self,
+        _decoded_representation: &BytesRepresentation,
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        Ok(RecommendedConcurrency::one())
+    }
+
+    fn encode_opt(
+        &self,
+        decoded_value: Vec<u8>,
+        _options: &EncodeOptions,
+    ) -> Result<Vec<u8>, CodecError> {
         Ok(decoded_value)
     }
 
@@ -49,7 +64,7 @@ impl BytesToBytesCodecTraits for TestUnboundedCodec {
         &self,
         encoded_value: Vec<u8>,
         _decoded_representation: &BytesRepresentation,
-        _parallel: bool,
+        _options: &DecodeOptions,
     ) -> Result<Vec<u8>, CodecError> {
         Ok(encoded_value)
     }
@@ -58,7 +73,7 @@ impl BytesToBytesCodecTraits for TestUnboundedCodec {
         &self,
         r: Box<dyn BytesPartialDecoderTraits + 'a>,
         _decoded_representation: &BytesRepresentation,
-        _parallel: bool,
+        _options: &PartialDecoderOptions,
     ) -> Result<Box<dyn BytesPartialDecoderTraits + 'a>, CodecError> {
         Ok(Box::new(
             test_unbounded_partial_decoder::TestUnboundedPartialDecoder::new(r),
@@ -70,7 +85,7 @@ impl BytesToBytesCodecTraits for TestUnboundedCodec {
         &'a self,
         r: Box<dyn AsyncBytesPartialDecoderTraits + 'a>,
         _decoded_representation: &BytesRepresentation,
-        _parallel: bool,
+        _options: &PartialDecoderOptions,
     ) -> Result<Box<dyn AsyncBytesPartialDecoderTraits + 'a>, CodecError> {
         Ok(Box::new(
             test_unbounded_partial_decoder::AsyncTestUnboundedPartialDecoder::new(r),

--- a/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
+++ b/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    array::codec::{BytesPartialDecoderTraits, CodecError},
+    array::codec::{BytesPartialDecoderTraits, CodecError, PartialDecodeOptions},
     byte_range::{extract_byte_ranges, ByteRange},
 };
 
@@ -22,9 +22,9 @@ impl BytesPartialDecoderTraits for TestUnboundedPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel)?;
+        let encoded_value = self.input_handle.decode_opt(options)?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };
@@ -56,9 +56,9 @@ impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel).await?;
+        let encoded_value = self.input_handle.decode_opt(options).await?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };

--- a/src/array/codec/bytes_to_bytes/zstd.rs
+++ b/src/array/codec/bytes_to_bytes/zstd.rs
@@ -67,9 +67,9 @@ mod tests {
         let decoded = codec.decode(encoded, &bytes_representation).unwrap();
         assert_eq!(bytes, decoded);
 
-        let encoded = codec.par_encode(bytes.clone()).unwrap();
-        let decoded = codec.par_decode(encoded, &bytes_representation).unwrap();
-        assert_eq!(bytes, decoded);
+        // let encoded = codec.par_encode(bytes.clone()).unwrap();
+        // let decoded = codec.par_decode(encoded, &bytes_representation).unwrap();
+        // assert_eq!(bytes, decoded);
     }
 
     #[test]

--- a/src/array/codec/bytes_to_bytes/zstd/zstd_partial_decoder.rs
+++ b/src/array/codec/bytes_to_bytes/zstd/zstd_partial_decoder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    array::codec::{BytesPartialDecoderTraits, CodecError},
+    array::codec::{BytesPartialDecoderTraits, CodecError, PartialDecodeOptions},
     byte_range::{extract_byte_ranges, ByteRange},
 };
 
@@ -22,9 +22,9 @@ impl BytesPartialDecoderTraits for ZstdPartialDecoder<'_> {
     fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel)?;
+        let encoded_value = self.input_handle.decode_opt(options)?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };
@@ -59,9 +59,9 @@ impl AsyncBytesPartialDecoderTraits for AsyncZstdPartialDecoder<'_> {
     async fn partial_decode_opt(
         &self,
         decoded_regions: &[ByteRange],
-        parallel: bool,
+        options: &PartialDecodeOptions,
     ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        let encoded_value = self.input_handle.decode_opt(parallel).await?;
+        let encoded_value = self.input_handle.decode_opt(options).await?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
         };

--- a/src/array/codec/options.rs
+++ b/src/array/codec/options.rs
@@ -1,0 +1,73 @@
+//! Options for codec encoding and decoding.
+
+use std::num::NonZeroUsize;
+
+/// Encode options.
+pub struct EncodeOptions {
+    concurrent_limit: NonZeroUsize,
+}
+
+impl Default for EncodeOptions {
+    fn default() -> Self {
+        Self {
+            concurrent_limit: std::thread::available_parallelism().unwrap(),
+        }
+    }
+}
+
+impl EncodeOptions {
+    /// Return the concurrent limit.
+    #[must_use]
+    pub fn concurrent_limit(&self) -> NonZeroUsize {
+        self.concurrent_limit
+    }
+
+    /// Set the concurrent limit.
+    pub fn set_concurrent_limit(&mut self, concurrent_limit: NonZeroUsize) {
+        self.concurrent_limit = concurrent_limit;
+    }
+
+    /// FIXME: Temporary, remove
+    #[must_use]
+    pub fn is_parallel(&self) -> bool {
+        self.concurrent_limit.get() > 1
+    }
+}
+
+/// Decode options.
+pub struct DecodeOptions {
+    concurrent_limit: NonZeroUsize,
+}
+
+impl Default for DecodeOptions {
+    fn default() -> Self {
+        Self {
+            concurrent_limit: std::thread::available_parallelism().unwrap(),
+        }
+    }
+}
+
+impl DecodeOptions {
+    /// Return the concurrent limit.
+    #[must_use]
+    pub fn concurrent_limit(&self) -> NonZeroUsize {
+        self.concurrent_limit
+    }
+
+    /// Set the concurrent limit.
+    pub fn set_concurrent_limit(&mut self, concurrent_limit: NonZeroUsize) {
+        self.concurrent_limit = concurrent_limit;
+    }
+
+    /// FIXME: Temporary, remove
+    #[must_use]
+    pub fn is_parallel(&self) -> bool {
+        self.concurrent_limit.get() > 1
+    }
+}
+
+/// Partial decoder options.
+pub type PartialDecoderOptions = DecodeOptions;
+
+/// Partial decode options.
+pub type PartialDecodeOptions = DecodeOptions;


### PR DESCRIPTION
This is a major refactor of codec traits and the array structure.
Previously, various codec and array methods had three variants:
1. `<method>_opt(..., parallel: bool)` supporting optional parallelism
2. `<method>(...)`, serial
3. `par_<method>(...)` , parallel

Now, there are just two variants:
1. `<method>_opt(..., options: &SomeOptionsStruct)`
2. `<method>(...)`, default options (maximum concurrency)

This new API provides finer-grained control of the number of concurrent operations executed within an encode/decode method.
Most internal operations use the `_opt` API. The efficient/maximum concurrency of codecs can be queried (presently, this may not be accurate for many codecs).

This has the potential to improve performance and reduce memory usage. For example, a call of `Array::retrieve_chunks` which decodes multiple *shards* could recognise that the *inner chunks* can be decoded with massive parallelisation, and thus only decode one shard at a time. This behaviour is not yet implemented, but will follow shortly.
