### PR TITLE
Dimension names cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - `Indices` and `Chunks` implement `IntoParallelIter`
    - **Breaking**: array subset iterators are moved into public `array_subset::iterators` and no longer in the `array_subset` namespace
  - Add a fast path to `Array::retrieve_chunk_subset{_opt}` if the entire chunk is requested
- - `DimensionName::new()` now accepts anything implementing `Into<String>`
+ - `DimensionName::new()` generalised to accept a name implementing `Into<String>`
+ - **Breaking**: `ArrayBuilder::dimension_names()` generalised to accept `Option<I>` where `I: IntoIterator<Item = D>` and `D: Into<DimensionName>`
+   - Can now write
+`builder.dimension_names(["y", "x"].into())` instead of `builder.dimension_names(vec!["y".into(), "x".into()].into())` 
 
 ### Removed
  - **Breaking**: remove `InvalidArraySubsetError` and `ArrayExtractElementsError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - **Breaking** Existing `Array` `_opt` use new encode/decode options insted of `parallel: bool`
  - Implement `DoubleEndedIterator` for `{Indices,LinearisedIndices,ContiguousIndices,ContiguousLinearisedIndicesIterator}Iterator`
  - Add `ParIndicesIterator` and `ParChunksIterator`
+ - Implement `From<String>` for `DimensionName`
 
 ### Changed
  - Dependency bumps
@@ -51,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - `Indices` and `Chunks` implement `IntoParallelIter`
    - **Breaking**: array subset iterators are moved into public `array_subset::iterators` and no longer in the `array_subset` namespace
  - Add a fast path to `Array::retrieve_chunk_subset{_opt}` if the entire chunk is requested
+ - `DimensionName::new()` now accepts anything implementing `Into<String>`
 
 ### Removed
  - **Breaking**: remove `InvalidArraySubsetError` and `ArrayExtractElementsError`

--- a/examples/array_write_read.rs
+++ b/examples/array_write_read.rs
@@ -43,7 +43,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         FillValue::from(ZARR_NAN_F32),
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed
-    .dimension_names(Some(vec!["y".into(), "x".into()]))
+    .dimension_names(["y", "x"].into())
     // .storage_transformers(vec![].into())
     .build(store.clone(), array_path)?;
 

--- a/examples/async_array_write_read.rs
+++ b/examples/async_array_write_read.rs
@@ -44,7 +44,7 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         FillValue::from(ZARR_NAN_F32),
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed
-    .dimension_names(Some(vec!["y".into(), "x".into()]))
+    .dimension_names(["y", "x"].into())
     // .storage_transformers(vec![].into())
     .build(store.clone(), array_path)?;
 

--- a/examples/rectangular_array_write_read.rs
+++ b/examples/rectangular_array_write_read.rs
@@ -48,7 +48,7 @@ fn rectangular_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(feature = "gzip")]
         Box::new(codec::GzipCodec::new(5)?),
     ])
-    .dimension_names(Some(vec!["y".into(), "x".into()]))
+    .dimension_names(["y", "x"].into())
     // .storage_transformers(vec![].into())
     .build(store.clone(), array_path)?;
 

--- a/examples/sharded_array_write_read.rs
+++ b/examples/sharded_array_write_read.rs
@@ -66,7 +66,7 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         FillValue::from(0u16),
     )
     .array_to_bytes_codec(Box::new(sharding_codec_builder.build()))
-    .dimension_names(Some(vec!["y".into(), "x".into()]))
+    .dimension_names(["y", "x"].into())
     // .storage_transformers(vec![].into())
     .build(store.clone(), array_path)?;
 

--- a/examples/zip_array_write_read.rs
+++ b/examples/zip_array_write_read.rs
@@ -30,7 +30,7 @@ fn write_array_to_storage<TStorage: ReadableWritableStorageTraits + 'static>(
         #[cfg(feature = "gzip")]
         Box::new(codec::GzipCodec::new(5)?),
     ])
-    .dimension_names(Some(vec!["y".into(), "x".into()]))
+    .dimension_names(["y", "x"].into())
     // .storage_transformers(vec![].into())
     .build(storage, ARRAY_PATH)?;
 

--- a/src/array/dimension_name.rs
+++ b/src/array/dimension_name.rs
@@ -27,8 +27,14 @@ impl DimensionName {
 }
 
 impl From<&str> for DimensionName {
-    fn from(value: &str) -> Self {
-        Self(Some(value.into()))
+    fn from(name: &str) -> Self {
+        Self(Some(name.into()))
+    }
+}
+
+impl From<String> for DimensionName {
+    fn from(name: String) -> Self {
+        Self(Some(name))
     }
 }
 

--- a/src/array/dimension_name.rs
+++ b/src/array/dimension_name.rs
@@ -15,7 +15,7 @@ impl Default for DimensionName {
 impl DimensionName {
     /// Create a new dimension with `name`. Use [`default`](DimensionName::default) to create a dimension with no name.
     #[must_use]
-    pub fn new(name: &str) -> Self {
+    pub fn new<T: Into<String>>(name: T) -> Self {
         Self(Some(name.into()))
     }
 
@@ -28,13 +28,13 @@ impl DimensionName {
 
 impl From<&str> for DimensionName {
     fn from(name: &str) -> Self {
-        Self(Some(name.into()))
+        Self::new(name)
     }
 }
 
 impl From<String> for DimensionName {
     fn from(name: String) -> Self {
-        Self(Some(name))
+        Self::new(name)
     }
 }
 


### PR DESCRIPTION
This makes `DimensionName::new()` and `ArrayBuilder::dimension_names()` generic over their inputs.

Can now write
```rust
ArrayBuilder::new(...).dimension_names(["y", "x"].into())
```
instead of
```rust
ArrayBuilder::new(...).dimension_names(vec!["y".into(), "x".into()].into())
```