### PR TITLE
Add public getters for Node properties 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add more tests for `Array`, codecs, store locks, and more
  - Add `array_write_read_ndarray` example
  - Add `array::bytes_to_ndarray()` and make `array::elements_to_ndarray()` public
+ - [#13](https://github.com/LDeakin/zarrs/pull/13) Add `node::Node::path()`, `metadata()`, and `children()` by [@lorenzocerrone]
+ - [#13](https://github.com/LDeakin/zarrs/pull/13) Derive `Clone` for `node::Node` and `node::NodeMetadata` by [@lorenzocerrone]
 
 ### Changed
 #### Arrays

--- a/src/node.rs
+++ b/src/node.rs
@@ -141,34 +141,22 @@ impl Node {
         unsafe { NodeName::new_unchecked(name) }
     }
 
-    /// Returns the path of the node.
+    /// Returns a reference to the path of the node.
     #[must_use] 
-    pub fn path(&self) -> &NodePath {
+    pub fn get_path(&self) -> &NodePath {
         &self.path
     }
 
-    /// Returns the metadata of the node.
+    /// Returns a reference to the metadata of the node.
     #[must_use]
     pub fn metadata(&self) -> &NodeMetadata {
         &self.metadata
     }
 
-    /// Returns a copy of the metadata of the node.
-    #[must_use]
-    pub fn get_metadata(&self) -> NodeMetadata {
-        self.metadata.clone()
-    }
-
-    /// Returns the children of the node.
+    /// Returns a reference to the metadata of the node.
     #[must_use]
     pub fn children(&self) -> &Vec<Node> {
         &self.children
-    }
-
-    /// Returns a copy of the children of the node.
-    #[must_use]
-    pub fn get_children(&self) -> Vec<Node> {
-        self.children.clone()
     }
 
     /// Return a tree representation of a hierarchy as a string.

--- a/src/node.rs
+++ b/src/node.rs
@@ -142,7 +142,7 @@ impl Node {
     }
 
     /// Returns a reference to the path of the node.
-    #[must_use] 
+    #[must_use]
     pub fn path(&self) -> &NodePath {
         &self.path
     }
@@ -153,9 +153,9 @@ impl Node {
         &self.metadata
     }
 
-    /// Returns a reference to the metadata of the node.
+    /// Returns a reference to the children of the node.
     #[must_use]
-    pub fn children(&self) -> &Vec<Node> {
+    pub fn children(&self) -> &[Node] {
         &self.children
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -143,7 +143,7 @@ impl Node {
 
     /// Returns a reference to the path of the node.
     #[must_use] 
-    pub fn get_path(&self) -> &NodePath {
+    pub fn path(&self) -> &NodePath {
         &self.path
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -31,7 +31,7 @@ use crate::storage::{
 /// A Zarr hierarchy node.
 ///
 /// See <https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#hierarchy>.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Node {
     /// Node path.
     path: NodePath,
@@ -139,6 +139,36 @@ impl Node {
     pub fn name(&self) -> NodeName {
         let name = self.path.as_str().split('/').last().unwrap_or_default();
         unsafe { NodeName::new_unchecked(name) }
+    }
+
+    /// Returns the path of the node.
+    #[must_use] 
+    pub fn path(&self) -> &NodePath {
+        &self.path
+    }
+
+    /// Returns the metadata of the node.
+    #[must_use]
+    pub fn metadata(&self) -> &NodeMetadata {
+        &self.metadata
+    }
+
+    /// Returns a copy of the metadata of the node.
+    #[must_use]
+    pub fn get_metadata(&self) -> NodeMetadata {
+        self.metadata.clone()
+    }
+
+    /// Returns the children of the node.
+    #[must_use]
+    pub fn children(&self) -> &Vec<Node> {
+        &self.children
+    }
+
+    /// Returns a copy of the children of the node.
+    #[must_use]
+    pub fn get_children(&self) -> Vec<Node> {
+        self.children.clone()
     }
 
     /// Return a tree representation of a hierarchy as a string.

--- a/src/node/node_metadata.rs
+++ b/src/node/node_metadata.rs
@@ -1,7 +1,7 @@
 use crate::{array::ArrayMetadata, group::GroupMetadata};
 
 /// Node metadata ([`ArrayMetadata`] or [`GroupMetadata`]).
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum NodeMetadata {
     /// Array metadata.


### PR DESCRIPTION
Feature requested in #12 

Changes:

- implement three getter methods for the `zarrs::Node` struct
```rust
/// Returns a reference to the path of the node.
    #[must_use] 
    pub fn path(&self) -> &NodePath {
        &self.path
    }

    /// Returns a reference to the metadata of the node.
    #[must_use]
    pub fn metadata(&self) -> &NodeMetadata {
        &self.metadata
    }

    /// Returns a reference to the metadata of the node.
    #[must_use]
    pub fn children(&self) -> &Vec<Node> {
        &self.children
    }
```

- Derived clone traits for `zarrs::Node` and `zarrs::node::NodeMetadata`

