### PR TITLE
Support 8 and 16 bit integer data types with zfp codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - Allow float fill values to be created from int fill value metadata
  - Make `chunk_grid::{regular,rectangular}` public
+ - Support 8 and 16 bit integer data types with zfp codec by promoting to 32 bit
 
 ### Fixed
  - Fix `compute_encoded_size()` for `BitroundCodec` incorrectly indicating various data types were unsupported

--- a/src/array/codec/array_to_bytes/zfp/zfp_array.rs
+++ b/src/array/codec/array_to_bytes/zfp/zfp_array.rs
@@ -1,0 +1,45 @@
+#[derive(Debug)]
+pub enum ZfpArray {
+    Int32(Vec<i32>),
+    Int64(Vec<i64>),
+    Float(Vec<f32>),
+    Double(Vec<f64>),
+}
+
+impl ZfpArray {
+    pub fn len(&self) -> usize {
+        match self {
+            ZfpArray::Int32(v) => v.len(),
+            ZfpArray::Int64(v) => v.len(),
+            ZfpArray::Float(v) => v.len(),
+            ZfpArray::Double(v) => v.len(),
+        }
+    }
+
+    pub fn zfp_type(&self) -> zfp_sys::zfp_type {
+        match self {
+            ZfpArray::Int32(_) => zfp_sys::zfp_type_zfp_type_int32,
+            ZfpArray::Int64(_) => zfp_sys::zfp_type_zfp_type_int64,
+            ZfpArray::Float(_) => zfp_sys::zfp_type_zfp_type_float,
+            ZfpArray::Double(_) => zfp_sys::zfp_type_zfp_type_double,
+        }
+    }
+
+    // pub fn as_ptr(&self) -> *const std::ffi::c_void {
+    //     match self {
+    //         ZfpArray::Int32(v) => v.as_ptr().cast::<std::ffi::c_void>(),
+    //         ZfpArray::Int64(v) => v.as_ptr().cast::<std::ffi::c_void>(),
+    //         ZfpArray::Float(v) => v.as_ptr().cast::<std::ffi::c_void>(),
+    //         ZfpArray::Double(v) => v.as_ptr().cast::<std::ffi::c_void>(),
+    //     }
+    // }
+
+    pub fn as_mut_ptr(&mut self) -> *mut std::ffi::c_void {
+        match self {
+            ZfpArray::Int32(v) => v.as_mut_ptr().cast::<std::ffi::c_void>(),
+            ZfpArray::Int64(v) => v.as_mut_ptr().cast::<std::ffi::c_void>(),
+            ZfpArray::Float(v) => v.as_mut_ptr().cast::<std::ffi::c_void>(),
+            ZfpArray::Double(v) => v.as_mut_ptr().cast::<std::ffi::c_void>(),
+        }
+    }
+}

--- a/src/array/codec/array_to_bytes/zfp/zfp_field.rs
+++ b/src/array/codec/array_to_bytes/zfp/zfp_field.rs
@@ -1,38 +1,31 @@
-use std::ptr::NonNull;
+use super::ZfpArray;
+use std::{marker::PhantomData, ptr::NonNull};
 use zfp_sys::{
     zfp_field, zfp_field_1d, zfp_field_2d, zfp_field_3d, zfp_field_4d, zfp_field_free, zfp_type,
-    zfp_type_zfp_type_double, zfp_type_zfp_type_float, zfp_type_zfp_type_int32,
-    zfp_type_zfp_type_int64,
 };
 
 /// A `zfp` field.
 #[derive(Debug)]
-pub(super) struct ZfpField(NonNull<zfp_field>);
+pub(super) struct ZfpField<'a> {
+    field: NonNull<zfp_field>,
+    phantom: PhantomData<&'a zfp_field>,
+}
 
-impl Drop for ZfpField {
+impl Drop for ZfpField<'_> {
     fn drop(&mut self) {
         unsafe {
-            zfp_field_free(self.0.as_ptr());
+            zfp_field_free(self.field.as_ptr());
         }
     }
 }
 
-#[allow(non_upper_case_globals)]
-const fn zfp_type_to_size(zfp_type_: zfp_type) -> Option<usize> {
-    match zfp_type_ {
-        zfp_type_zfp_type_int32 | zfp_type_zfp_type_float => Some(4),
-        zfp_type_zfp_type_int64 | zfp_type_zfp_type_double => Some(8),
-        _ => None,
-    }
-}
-
-impl ZfpField {
-    pub fn new(data: &mut [u8], zfp_type_: zfp_type, shape: &[usize]) -> Option<Self> {
+impl<'a> ZfpField<'a> {
+    pub fn new(array: &'a mut ZfpArray, shape: &[usize]) -> Option<Self> {
         match shape.len() {
-            1 => Self::new_1d(data, zfp_type_, shape[0]),
-            2 => Self::new_2d(data, zfp_type_, shape[1], shape[0]),
-            3 => Self::new_3d(data, zfp_type_, shape[2], shape[1], shape[0]),
-            4 => Self::new_4d(data, zfp_type_, shape[3], shape[2], shape[1], shape[0]),
+            1 => Self::new_1d(array, shape[0]),
+            2 => Self::new_2d(array, shape[1], shape[0]),
+            3 => Self::new_3d(array, shape[2], shape[1], shape[0]),
+            4 => Self::new_4d(array, shape[3], shape[2], shape[1], shape[0]),
             _ => None,
         }
     }
@@ -40,87 +33,87 @@ impl ZfpField {
     pub unsafe fn new_empty(zfp_type_: zfp_type, shape: &[usize]) -> Option<Self> {
         let pointer = core::ptr::null_mut::<u8>().cast::<std::ffi::c_void>();
         match shape.len() {
-            1 => NonNull::new(unsafe { zfp_field_1d(pointer, zfp_type_, shape[0]) }).map(Self),
-            2 => NonNull::new(unsafe { zfp_field_2d(pointer, zfp_type_, shape[1], shape[0]) })
-                .map(Self),
+            1 => NonNull::new(unsafe { zfp_field_1d(pointer, zfp_type_, shape[0]) }).map(|field| {
+                Self {
+                    field,
+                    phantom: PhantomData,
+                }
+            }),
+            2 => NonNull::new(unsafe { zfp_field_2d(pointer, zfp_type_, shape[1], shape[0]) }).map(
+                |field| Self {
+                    field,
+                    phantom: PhantomData,
+                },
+            ),
             3 => NonNull::new(unsafe {
                 zfp_field_3d(pointer, zfp_type_, shape[2], shape[1], shape[0])
             })
-            .map(Self),
+            .map(|field| Self {
+                field,
+                phantom: PhantomData,
+            }),
             4 => NonNull::new(unsafe {
                 zfp_field_4d(pointer, zfp_type_, shape[3], shape[2], shape[1], shape[0])
             })
-            .map(Self),
+            .map(|field| Self {
+                field,
+                phantom: PhantomData,
+            }),
             _ => None,
         }
     }
 
-    pub fn new_1d(data: &mut [u8], zfp_type_: zfp_type, nx: usize) -> Option<Self> {
-        if let Some(size) = zfp_type_to_size(zfp_type_) {
-            if size * nx != data.len() {
-                return None;
-            }
-        } else {
+    pub fn new_1d(array: &mut ZfpArray, nx: usize) -> Option<Self> {
+        if nx != array.len() {
             return None;
         }
-        let pointer = data.as_mut_ptr().cast::<std::ffi::c_void>();
-        let field = unsafe { zfp_field_1d(pointer, zfp_type_, nx) };
-        NonNull::new(field).map(Self)
+        let field = unsafe { zfp_field_1d(array.as_mut_ptr(), array.zfp_type(), nx) };
+        NonNull::new(field).map(|field| Self {
+            field,
+            phantom: PhantomData,
+        })
     }
 
-    pub fn new_2d(data: &mut [u8], zfp_type_: zfp_type, nx: usize, ny: usize) -> Option<Self> {
-        if let Some(size) = zfp_type_to_size(zfp_type_) {
-            if size * nx * ny != data.len() {
-                return None;
-            }
-        } else {
+    pub fn new_2d(array: &mut ZfpArray, nx: usize, ny: usize) -> Option<Self> {
+        if nx * ny != array.len() {
             return None;
         }
-        let pointer = data.as_mut_ptr().cast::<std::ffi::c_void>();
-        let field = unsafe { zfp_field_2d(pointer, zfp_type_, nx, ny) };
-        NonNull::new(field).map(Self)
+        let field = unsafe { zfp_field_2d(array.as_mut_ptr(), array.zfp_type(), nx, ny) };
+        NonNull::new(field).map(|field| Self {
+            field,
+            phantom: PhantomData,
+        })
     }
 
-    pub fn new_3d(
-        data: &mut [u8],
-        zfp_type_: zfp_type,
-        nx: usize,
-        ny: usize,
-        nz: usize,
-    ) -> Option<Self> {
-        if let Some(size) = zfp_type_to_size(zfp_type_) {
-            if size * nx * ny * nz != data.len() {
-                return None;
-            }
-        } else {
+    pub fn new_3d(array: &'a mut ZfpArray, nx: usize, ny: usize, nz: usize) -> Option<Self> {
+        if nx * ny * nz != array.len() {
             return None;
         }
-        let pointer = data.as_mut_ptr().cast::<std::ffi::c_void>();
-        let field = unsafe { zfp_field_3d(pointer, zfp_type_, nx, ny, nz) };
-        NonNull::new(field).map(Self)
+        let field = unsafe { zfp_field_3d(array.as_mut_ptr(), array.zfp_type(), nx, ny, nz) };
+        NonNull::new(field).map(|field| Self {
+            field,
+            phantom: PhantomData,
+        })
     }
 
     pub fn new_4d(
-        data: &mut [u8],
-        zfp_type_: zfp_type,
+        array: &mut ZfpArray,
         nx: usize,
         ny: usize,
         nz: usize,
         nw: usize,
     ) -> Option<Self> {
-        if let Some(size) = zfp_type_to_size(zfp_type_) {
-            if size * nx * ny * nz * nw != data.len() {
-                return None;
-            }
-        } else {
+        if nx * ny * nz * nw != array.len() {
             return None;
         }
-        let pointer = data.as_mut_ptr().cast::<std::ffi::c_void>();
-        let field = unsafe { zfp_field_4d(pointer, zfp_type_, nx, ny, nz, nw) };
-        NonNull::new(field).map(Self)
+        let field = unsafe { zfp_field_4d(array.as_mut_ptr(), array.zfp_type(), nx, ny, nz, nw) };
+        NonNull::new(field).map(|field| Self {
+            field,
+            phantom: PhantomData,
+        })
     }
 
     pub const fn as_zfp_field(&self) -> *mut zfp_field {
-        self.0.as_ptr()
+        self.field.as_ptr()
     }
 }


### PR DESCRIPTION
Support 8/16-bit integer types with the zfp codec through promotion to 32-bit in accordance with the [zfp utility functions](https://zfp.readthedocs.io/en/release1.0.1/low-level-api.html#utility-functions).