### PR TITLE
Iterator improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Improve various docs
  - **Breaking**: Add `MissingMetadata` to `GroupCreateError` enum
  - **Breaking**: Deprecate `{Array,Group}::new` for `open`, and add `open_opt`
+ - Change internal structure of various iterators to use `std::ops::Range` and remove redundant `length`
+ - **Breaking**: `Indices::new_with_start_end` now takes a `range` rather than a `start` and `end`
 
 ### Removed
  - **Breaking**: Remove `bytes` dependency

--- a/src/array_subset.rs
+++ b/src/array_subset.rs
@@ -68,7 +68,7 @@ impl ArraySubset {
         }
     }
 
-    /// Create a new array subset from a `ranges`.
+    /// Create a new array subset from a list of [`Range`]s.
     #[must_use]
     pub fn new_with_ranges(ranges: &[Range<u64>]) -> Self {
         let start = ranges.iter().map(|range| range.start).collect();

--- a/src/array_subset/iterators.rs
+++ b/src/array_subset/iterators.rs
@@ -110,10 +110,13 @@ mod tests {
     fn array_subset_iter_contiguous_indices2() {
         let subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
         let indices = subset.contiguous_indices(&[4, 4]).unwrap();
-        let mut iter = indices.into_iter();
+        assert_eq!(indices.len(), 2);
+        assert!(!indices.is_empty());
+        assert_eq!(indices.contiguous_elements_usize(), 2);
+        let mut iter = indices.iter();
         assert_eq!(iter.size_hint(), (2, Some(2)));
+        assert_eq!(iter.next_back(), Some((vec![2, 1], 2)));
         assert_eq!(iter.next(), Some((vec![1, 1], 2)));
-        assert_eq!(iter.next(), Some((vec![2, 1], 2)));
         assert_eq!(iter.next(), None);
     }
 
@@ -131,14 +134,17 @@ mod tests {
     fn array_subset_iter_continuous_linearised_indices() {
         let subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
         let indices = subset.contiguous_linearised_indices(&[4, 4]).unwrap();
-        let mut iter = indices.into_iter();
+        assert_eq!(indices.len(), 2);
+        assert!(!indices.is_empty());
+        assert_eq!(indices.contiguous_elements_usize(), 2);
+        let mut iter = indices.iter();
         //  0  1  2  3
         //  4  5  6  7
         //  8  9 10 11
         // 12 13 14 15
         assert_eq!(iter.size_hint(), (2, Some(2)));
+        assert_eq!(iter.next_back(), Some((9, 2)));
         assert_eq!(iter.next(), Some((5, 2)));
-        assert_eq!(iter.next(), Some((9, 2)));
         assert_eq!(iter.next(), None);
     }
 

--- a/src/array_subset/iterators.rs
+++ b/src/array_subset/iterators.rs
@@ -150,9 +150,11 @@ mod tests {
         assert!(subset.chunks(&chunk_shape_invalid).is_err());
         let chunk_shape = [NonZeroU64::new(2).unwrap(), NonZeroU64::new(2).unwrap()];
         let chunks = subset.chunks(&chunk_shape).unwrap();
-        let mut iter = chunks.into_iter();
+        assert!(!chunks.is_empty());
+        let mut iter = chunks.iter();
         assert_eq!(iter.size_hint(), (9, Some(9)));
         assert_eq!(iter.next(), Some((vec![0, 0], ArraySubset::new_with_ranges(&[0..2, 0..2]))));
+        assert_eq!(iter.next_back(), Some((vec![2, 2], ArraySubset::new_with_ranges(&[4..6, 4..6]))));
         assert_eq!(iter.next(), Some((vec![0, 1], ArraySubset::new_with_ranges(&[0..2, 2..4]))));
         assert_eq!(iter.next(), Some((vec![0, 2], ArraySubset::new_with_ranges(&[0..2, 4..6]))));
         assert_eq!(iter.next(), Some((vec![1, 0], ArraySubset::new_with_ranges(&[2..4, 0..2]))));
@@ -160,7 +162,6 @@ mod tests {
         assert_eq!(iter.next(), Some((vec![1, 2], ArraySubset::new_with_ranges(&[2..4, 4..6]))));
         assert_eq!(iter.next(), Some((vec![2, 0], ArraySubset::new_with_ranges(&[4..6, 0..2]))));
         assert_eq!(iter.next(), Some((vec![2, 1], ArraySubset::new_with_ranges(&[4..6, 2..4]))));
-        assert_eq!(iter.next(), Some((vec![2, 2], ArraySubset::new_with_ranges(&[4..6, 4..6]))));
         assert_eq!(iter.next(), None);
     }
 

--- a/src/array_subset/iterators/chunks_iterator.rs
+++ b/src/array_subset/iterators/chunks_iterator.rs
@@ -17,7 +17,7 @@ use super::{
 /// Iterates over the regular sized chunks overlapping this array subset.
 ///
 /// Iterates over the last dimension fastest (i.e. C-contiguous order).
-/// All chunks have the same size, and may extend over the bounds of the array subset.
+/// All chunks have the same size, and may extend over the bounds of the array subset since the start of the first chunk is aligned to the chunk size.
 ///
 /// The iterator item is a ([`ArrayIndices`], [`ArraySubset`]) tuple corresponding to the chunk indices and array subset.
 ///

--- a/src/array_subset/iterators/chunks_iterator.rs
+++ b/src/array_subset/iterators/chunks_iterator.rs
@@ -232,11 +232,7 @@ impl<'a> Producer for ParChunksIteratorProducer<'a> {
 
     fn into_iter(self) -> Self::IntoIter {
         ChunksIterator {
-            inner: IndicesIterator::new_with_start_end(
-                self.inner.subset,
-                self.inner.index_front,
-                self.inner.index_back,
-            ),
+            inner: IndicesIterator::new_with_start_end(self.inner.subset, self.inner.range),
             chunk_shape: self.chunk_shape,
         }
     }

--- a/src/array_subset/iterators/linearised_indices_iterator.rs
+++ b/src/array_subset/iterators/linearised_indices_iterator.rs
@@ -91,7 +91,7 @@ impl<'a> IntoIterator for &'a LinearisedIndices {
     }
 }
 
-/// Parallel linearised indices iterator.
+/// Serial linearised indices iterator.
 ///
 /// See [`LinearisedIndices`].
 pub struct LinearisedIndicesIterator<'a> {
@@ -124,3 +124,39 @@ impl DoubleEndedIterator for LinearisedIndicesIterator<'_> {
 impl ExactSizeIterator for LinearisedIndicesIterator<'_> {}
 
 impl FusedIterator for LinearisedIndicesIterator<'_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linearised_indices_iterator_partial() {
+        let indices =
+            LinearisedIndices::new(ArraySubset::new_with_ranges(&[1..3, 5..7]), vec![8, 8])
+                .unwrap();
+        assert_eq!(indices.len(), 4);
+        let mut iter = indices.iter();
+        assert_eq!(iter.next(), Some(13)); // [1,5]
+        assert_eq!(iter.next(), Some(14)); // [1,6]
+        assert_eq!(iter.next_back(), Some(22)); // [2,6]
+        assert_eq!(iter.next(), Some(21)); // [2,5]
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn linearised_indices_iterator_oob() {
+        assert!(
+            LinearisedIndices::new(ArraySubset::new_with_ranges(&[1..3, 5..7]), vec![1, 1])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn linearised_indices_iterator_empty() {
+        let indices =
+            LinearisedIndices::new(ArraySubset::new_with_ranges(&[1..1, 5..5]), vec![5, 5])
+                .unwrap();
+        assert_eq!(indices.len(), 0);
+        assert!(indices.is_empty());
+    }
+}


### PR DESCRIPTION
`Indices::new_with_start_end` now takes a `std::ops::Range` rather than a `start` and `end`

Change internal structure of various iterators to use `std::ops::Range` and remove redundant `length`