### PR TITLE
Async API and codec encode/decode optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add `{Config,ArrayMetadataOptions}::[set_]include_zarrs_metadata` methods
  - Add `Array::set_dimension_names`
  - Add `storage::[Maybe]AsyncBytes`
+ - Add `array::{convert_from_bytes_slice,convert_to_bytes_vec}`
 
 ### Changed
  - Support `object_store` 0.9-0.10
@@ -50,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - **Breaking**: `Indices::new_with_start_end` now takes a `range` rather than a `start` and `end`
  - `RecommendedConcurrency::new` takes `impl std::ops::RangeBounds<usize>` instead of `std::ops::Range`
  - **Breaking**: Move `array::MaybeBytes` to `storage::MaybeBytes`
+ - **Breaking**: `Array` store methods now take slices instead of `Vec`s
+ - **Breaking**: Sync and async stores now consume and return `bytes::Bytes` instead of `Vec<u8>`
 
 ### Removed
  - **Breaking**: Remove re-exports of public dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add `{Array,Group}MetadataOptions::[set_]metadata_convert_version` methods
  - Add `{Config,ArrayMetadataOptions}::[set_]include_zarrs_metadata` methods
  - Add `Array::set_dimension_names`
+ - Add `storage::[Maybe]AsyncBytes`
 
 ### Changed
  - Support `object_store` 0.9-0.10
  - **Breaking**: Support `opendal` 0.46-0.47, drop support for 0.45
- - **Breaking**: Async store methods taking `bytes::Bytes` now take `Vec<u8>`
  - Rename `async_http_array_read` example to `async_http_array_read_object_store`
  - Bump `rayon` to 1.10.0
  - Bump `itertools` to 0.13
@@ -49,9 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Change internal structure of various iterators to use `std::ops::Range` and remove redundant `length`
  - **Breaking**: `Indices::new_with_start_end` now takes a `range` rather than a `start` and `end`
  - `RecommendedConcurrency::new` takes `impl std::ops::RangeBounds<usize>` instead of `std::ops::Range`
+ - **Breaking**: Move `array::MaybeBytes` to `storage::MaybeBytes`
 
 ### Removed
- - **Breaking**: Remove `bytes` dependency
  - **Breaking**: Remove re-exports of public dependencies
  - **Breaking**: Remove `Array::set_include_zarrs_metadata`. Use `{Config,ArrayMetadataOptions}::set_include_zarrs_metadata`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ zstd = ["dep:zstd"] # Enable the zstd codec
 http = ["dep:reqwest", "dep:url"] # Enable the sync HTTP store
 zip = ["dep:zip"] # Enable the zip storage adapter
 ndarray = ["dep:ndarray"] # Adds ndarray utility functions to Array
-async = ["dep:async-trait", "dep:async-recursion", "dep:async-lock", "dep:futures"] # Enable experimental async API
+async = ["dep:bytes", "dep:async-trait", "dep:async-recursion", "dep:async-lock", "dep:futures"] # Enable experimental async API
 object_store = ["dep:object_store"] # Enable object_store asynchronous stores support
 opendal = ["dep:opendal"] # Enable opendal asynchronous stores support
 
@@ -44,6 +44,7 @@ async-recursion = { version = "1.0.5", optional = true }
 async-trait = { version = "0.1.74", optional = true }
 blosc-sys = { version = "0.3.4", package = "blosc-src", features = ["snappy", "lz4", "zlib", "zstd"], optional = true }
 bytemuck = { version = "1.14.0", features = ["extern_crate_alloc"] }
+bytes = { version = "1.6.0", optional = true }
 bzip2 = { version = "0.4.4", optional = true, features = ["static"] }
 crc32c = { version = "0.6.5", optional = true }
 derive_more = "0.99.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ zstd = ["dep:zstd"] # Enable the zstd codec
 http = ["dep:reqwest", "dep:url"] # Enable the sync HTTP store
 zip = ["dep:zip"] # Enable the zip storage adapter
 ndarray = ["dep:ndarray"] # Adds ndarray utility functions to Array
-async = ["dep:bytes", "dep:async-trait", "dep:async-recursion", "dep:async-lock", "dep:futures"] # Enable experimental async API
+async = ["dep:async-trait", "dep:async-recursion", "dep:async-lock", "dep:futures"] # Enable experimental async API
 object_store = ["dep:object_store"] # Enable object_store asynchronous stores support
 opendal = ["dep:opendal"] # Enable opendal asynchronous stores support
 
@@ -44,7 +44,7 @@ async-recursion = { version = "1.0.5", optional = true }
 async-trait = { version = "0.1.74", optional = true }
 blosc-sys = { version = "0.3.4", package = "blosc-src", features = ["snappy", "lz4", "zlib", "zstd"], optional = true }
 bytemuck = { version = "1.14.0", features = ["extern_crate_alloc"] }
-bytes = { version = "1.6.0", optional = true }
+bytes = "1.6.0"
 bzip2 = { version = "0.4.4", optional = true, features = ["static"] }
 crc32c = { version = "0.6.5", optional = true }
 derive_more = "0.99.0"

--- a/examples/array_write_read.rs
+++ b/examples/array_write_read.rs
@@ -85,7 +85,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
             })?;
         array.store_chunk_elements(
             &chunk_indices,
-            vec![i as f32 * 0.1; chunk_subset.num_elements() as usize],
+            &vec![i as f32 * 0.1; chunk_subset.num_elements() as usize],
         )
     })?;
 
@@ -96,7 +96,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     // Store multiple chunks
     array.store_chunks_elements::<f32>(
         &ArraySubset::new_with_ranges(&[1..2, 0..2]),
-        vec![
+        &[
             //
             1.0, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1, 1.1, 1.0, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1, 1.1,
             //
@@ -109,7 +109,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     // Write a subset spanning multiple chunks, including updating chunks already written
     array.store_array_subset_elements::<f32>(
         &ArraySubset::new_with_ranges(&[3..6, 3..6]),
-        vec![-3.3, -3.4, -3.5, -4.3, -4.4, -4.5, -5.3, -5.4, -5.5],
+        &[-3.3, -3.4, -3.5, -4.3, -4.4, -4.5, -5.3, -5.4, -5.5],
     )?;
     let data_all = array.retrieve_array_subset_ndarray::<f32>(&subset_all)?;
     println!("store_array_subset [3..6, 3..6]:\n{data_all:+4.1}\n");
@@ -117,7 +117,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     // Store array subset
     array.store_array_subset_elements::<f32>(
         &ArraySubset::new_with_ranges(&[0..8, 6..7]),
-        vec![-0.6, -1.6, -2.6, -3.6, -4.6, -5.6, -6.6, -7.6],
+        &[-0.6, -1.6, -2.6, -3.6, -4.6, -5.6, -6.6, -7.6],
     )?;
     let data_all = array.retrieve_array_subset_ndarray::<f32>(&subset_all)?;
     println!("store_array_subset [0..8, 6..7]:\n{data_all:+4.1}\n");
@@ -128,7 +128,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         &[1, 1],
         // subset within chunk
         &ArraySubset::new_with_ranges(&[3..4, 0..4]),
-        vec![-7.4, -7.5, -7.6, -7.7],
+        &[-7.4, -7.5, -7.6, -7.7],
     )?;
     let data_all = array.retrieve_array_subset_ndarray::<f32>(&subset_all)?;
     println!("store_chunk_subset [3..4, 0..4] of chunk [1, 1]:\n{data_all:+4.1}\n");

--- a/examples/async_array_write_read.rs
+++ b/examples/async_array_write_read.rs
@@ -91,7 +91,7 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
             array
                 .async_store_chunk_elements(
                     &chunk_indices,
-                    vec![i as f32 * 0.1; chunk_subset.num_elements() as usize],
+                    &vec![i as f32 * 0.1; chunk_subset.num_elements() as usize],
                 )
                 .await
         }
@@ -111,7 +111,7 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     array
         .async_store_chunks_elements::<f32>(
             &ArraySubset::new_with_ranges(&[1..2, 0..2]),
-            vec![
+            &[
                 //
                 1.0, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1, 1.1, 1.0, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1, 1.1,
                 //
@@ -128,7 +128,7 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     array
         .async_store_array_subset_elements::<f32>(
             &ArraySubset::new_with_ranges(&[3..6, 3..6]),
-            vec![-3.3, -3.4, -3.5, -4.3, -4.4, -4.5, -5.3, -5.4, -5.5],
+            &[-3.3, -3.4, -3.5, -4.3, -4.4, -4.5, -5.3, -5.4, -5.5],
         )
         .await?;
     let data_all = array
@@ -140,7 +140,7 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     array
         .async_store_array_subset_elements::<f32>(
             &ArraySubset::new_with_ranges(&[0..8, 6..7]),
-            vec![-0.6, -1.6, -2.6, -3.6, -4.6, -5.6, -6.6, -7.6],
+            &[-0.6, -1.6, -2.6, -3.6, -4.6, -5.6, -6.6, -7.6],
         )
         .await?;
     let data_all = array
@@ -155,7 +155,7 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
             &[1, 1],
             // subset within chunk
             &ArraySubset::new_with_ranges(&[3..4, 0..4]),
-            vec![-7.4, -7.5, -7.6, -7.7],
+            &[-7.4, -7.5, -7.6, -7.7],
         )
         .await?;
     let data_all = array

--- a/examples/rectangular_array_write_read.rs
+++ b/examples/rectangular_array_write_read.rs
@@ -114,7 +114,7 @@ fn rectangular_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     // Store elements directly, in this case set the 7th column to 123.0
     array.store_array_subset_elements::<f32>(
         &ArraySubset::new_with_ranges(&[0..8, 6..7]),
-        vec![123.0; 8],
+        &[123.0; 8],
     )?;
 
     // Store elements directly in a chunk, in this case set the last row of the bottom right chunk
@@ -123,7 +123,7 @@ fn rectangular_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         &[3, 1],
         // subset within chunk
         &ArraySubset::new_with_ranges(&[1..2, 0..4]),
-        vec![-4.0; 4],
+        &[-4.0; 4],
     )?;
 
     // Read the whole array

--- a/examples/sharded_array_write_read.rs
+++ b/examples/sharded_array_write_read.rs
@@ -139,7 +139,7 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let decoded_inner_chunks_bytes = partial_decoder.partial_decode(&inner_chunks_to_decode)?;
     let decoded_inner_chunks_ndarray = decoded_inner_chunks_bytes
         .into_iter()
-        .map(|bytes| bytes_to_ndarray::<u16>(&inner_chunk_shape, bytes))
+        .map(|bytes| bytes_to_ndarray::<u16>(&inner_chunk_shape, bytes.to_vec()))
         .collect::<Result<Vec<_>, _>>()?;
     println!("Decoded inner chunks:");
     for (inner_chunk_subset, decoded_inner_chunk) in

--- a/examples/zip_array_write_read.rs
+++ b/examples/zip_array_write_read.rs
@@ -50,7 +50,7 @@ fn write_array_to_storage<TStorage: ReadableWritableStorageTraits + ?Sized + 'st
             if let Some(chunk_subset) = chunk_grid.subset(&chunk_indices, array.shape())? {
                 array.store_chunk_elements(
                     &chunk_indices,
-                    vec![i as f32; chunk_subset.num_elements() as usize],
+                    &vec![i as f32; chunk_subset.num_elements() as usize],
                 )
                 // let chunk_shape = chunk_grid.chunk_shape(&chunk_indices, &array.shape())?;
                 // let chunk_array = ndarray::ArrayD::<f32>::from_elem(chunk_shape.clone(), i as f32);
@@ -70,13 +70,13 @@ fn write_array_to_storage<TStorage: ReadableWritableStorageTraits + ?Sized + 'st
     // Write a subset spanning multiple chunks, including updating chunks already written
     array.store_array_subset_elements::<f32>(
         &ArraySubset::new_with_ranges(&[3..6, 3..6]),
-        vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+        &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
     )?;
 
     // Store elements directly, in this case set the 7th column to 123.0
     array.store_array_subset_elements::<f32>(
         &ArraySubset::new_with_ranges(&[0..8, 6..7]),
-        vec![123.0; 8],
+        &[123.0; 8],
     )?;
 
     // Store elements directly in a chunk, in this case set the last row of the bottom right chunk
@@ -85,7 +85,7 @@ fn write_array_to_storage<TStorage: ReadableWritableStorageTraits + ?Sized + 'st
         &[1, 1],
         // subset within chunk
         &ArraySubset::new_with_ranges(&[3..4, 0..4]),
-        vec![-4.0; 4],
+        &[-4.0; 4],
     )?;
 
     Ok(array)

--- a/src/array.rs
+++ b/src/array.rs
@@ -100,13 +100,6 @@ pub type ArrayShape = Vec<u64>;
 #[error("value must be non-zero")]
 pub struct NonZeroError;
 
-/// An alias for bytes which may or may not be available.
-///
-/// When a value is read from a store, it returns `MaybeBytes` which is [`None`] if the key is not available.
-/// A bytes to bytes codec only decodes `MaybeBytes` holding actual bytes, otherwise the bytes are propagated to the next decoder.
-/// An array to bytes partial decoder must take care of converting missing chunks to the fill value.
-pub type MaybeBytes = Option<Vec<u8>>;
-
 /// A Zarr array.
 ///
 /// ## Initilisation

--- a/src/array.rs
+++ b/src/array.rs
@@ -650,7 +650,7 @@ macro_rules! array_store_elements {
                 std::mem::size_of::<T>(),
             ))
         } else {
-            let $elements = crate::array::transmute_to_bytes_vec($elements);
+            let $elements = crate::array::convert_to_bytes_vec($elements);
             $self.$func($($arg)*)
         }
     };
@@ -685,7 +685,7 @@ macro_rules! array_async_store_elements {
                 std::mem::size_of::<T>(),
             ))
         } else {
-            let $elements = crate::array::transmute_to_bytes_vec($elements);
+            let $elements = crate::array::convert_to_bytes_vec($elements);
             $self.$func($($arg)*).await
         }
     };
@@ -729,16 +729,28 @@ mod array_async_readable_writable;
 
 /// Transmute from `Vec<u8>` to `Vec<T>`.
 #[must_use]
+pub fn convert_from_bytes_slice<T: bytemuck::Pod>(from: &[u8]) -> Vec<T> {
+    bytemuck::allocation::pod_collect_to_vec(from)
+}
+
+/// Transmute from `Vec<u8>` to `Vec<T>`.
+#[must_use]
 pub fn transmute_from_bytes_vec<T: bytemuck::Pod>(from: Vec<u8>) -> Vec<T> {
     bytemuck::allocation::try_cast_vec(from)
-        .unwrap_or_else(|(_err, from)| bytemuck::allocation::pod_collect_to_vec(&from))
+        .unwrap_or_else(|(_err, from)| convert_from_bytes_slice(&from))
+}
+
+/// Convert from `&[T]` to `Vec<u8>`.
+#[must_use]
+pub fn convert_to_bytes_vec<T: bytemuck::NoUninit>(from: &[T]) -> Vec<u8> {
+    bytemuck::allocation::pod_collect_to_vec(from)
 }
 
 /// Transmute from `Vec<T>` to `Vec<u8>`.
 #[must_use]
 pub fn transmute_to_bytes_vec<T: bytemuck::NoUninit>(from: Vec<T>) -> Vec<u8> {
     bytemuck::allocation::try_cast_vec(from)
-        .unwrap_or_else(|(_err, from)| bytemuck::allocation::pod_collect_to_vec(&from))
+        .unwrap_or_else(|(_err, from)| convert_to_bytes_vec(&from))
 }
 
 /// Unravel a linearised index to ND indices.
@@ -924,7 +936,7 @@ mod tests {
         array
             .store_array_subset_elements::<f32>(
                 &ArraySubset::new_with_ranges(&[3..6, 3..6]),
-                vec![1.0, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+                &[1.0, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
             )
             .unwrap();
 
@@ -971,7 +983,7 @@ mod tests {
 
         assert_eq!(
             &elements,
-            &vec![
+            &[
                 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, //
                 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, //
                 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, //
@@ -988,7 +1000,7 @@ mod tests {
         let store = Arc::new(FilesystemStore::new(path_out).unwrap());
         let array_out = Array::new_with_metadata(store, "/", array_in.metadata().clone()).unwrap();
         array_out
-            .store_array_subset_elements::<f32>(&subset_all, elements)
+            .store_array_subset_elements::<f32>(&subset_all, &elements)
             .unwrap();
 
         // Store V2 and V3 metadata

--- a/src/array/array_async_readable_writable.rs
+++ b/src/array/array_async_readable_writable.rs
@@ -13,7 +13,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
-        chunk_subset_bytes: Vec<u8>,
+        chunk_subset_bytes: &[u8],
     ) -> Result<(), ArrayError> {
         self.async_store_chunk_subset_opt(
             chunk_indices,
@@ -30,7 +30,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
-        chunk_subset_elements: Vec<T>,
+        chunk_subset_elements: &[T],
     ) -> Result<(), ArrayError> {
         self.async_store_chunk_subset_elements_opt(
             chunk_indices,
@@ -68,7 +68,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
     pub async fn async_store_array_subset(
         &self,
         array_subset: &ArraySubset,
-        subset_bytes: Vec<u8>,
+        subset_bytes: &[u8],
     ) -> Result<(), ArrayError> {
         self.async_store_array_subset_opt(array_subset, subset_bytes, &CodecOptions::default())
             .await
@@ -79,7 +79,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
     pub async fn async_store_array_subset_elements<T: bytemuck::Pod + Send + Sync>(
         &self,
         array_subset: &ArraySubset,
-        subset_elements: Vec<T>,
+        subset_elements: &[T],
     ) -> Result<(), ArrayError> {
         self.async_store_array_subset_elements_opt(
             array_subset,
@@ -119,7 +119,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
-        chunk_subset_bytes: Vec<u8>,
+        chunk_subset_bytes: &[u8],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
         let chunk_shape = self
@@ -175,7 +175,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
             }
 
             // Store the updated chunk
-            self.async_store_chunk_opt(chunk_indices, chunk_bytes, options)
+            self.async_store_chunk_opt(chunk_indices, &chunk_bytes, options)
                 .await
         }
     }
@@ -186,7 +186,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
-        chunk_subset_elements: Vec<T>,
+        chunk_subset_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
         array_async_store_elements!(
@@ -195,7 +195,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
             async_store_chunk_subset_opt(
                 chunk_indices,
                 chunk_subset,
-                chunk_subset_elements,
+                &chunk_subset_elements,
                 options
             )
         )
@@ -229,7 +229,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
             async_store_chunk_subset_elements_opt(
                 chunk_indices,
                 &subset,
-                chunk_subset_array,
+                &chunk_subset_array,
                 options
             )
         )
@@ -241,7 +241,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
     pub async fn async_store_array_subset_opt(
         &self,
         array_subset: &ArraySubset,
-        subset_bytes: Vec<u8>,
+        subset_bytes: &[u8],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
         // Validation
@@ -286,7 +286,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
                     unsafe { overlap.relative_to_unchecked(array_subset.start()) };
                 let chunk_subset_bytes = unsafe {
                     chunk_subset_in_array_subset.extract_bytes_unchecked(
-                        &subset_bytes,
+                        subset_bytes,
                         array_subset.shape(),
                         self.data_type().size(),
                     )
@@ -298,7 +298,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
                 self.async_store_chunk_subset_opt(
                     chunk_indices,
                     &array_subset_in_chunk_subset,
-                    chunk_subset_bytes,
+                    &chunk_subset_bytes,
                     options,
                 )
                 .await?;
@@ -328,7 +328,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
                     unsafe { overlap.relative_to_unchecked(chunk_subset_in_array.start()) };
                 let chunk_subset_bytes = unsafe {
                     chunk_subset_in_array_subset.extract_bytes_unchecked(
-                        &subset_bytes,
+                        subset_bytes,
                         array_subset.shape(),
                         self.data_type().size(),
                     )
@@ -338,7 +338,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
                     self.async_store_chunk_subset_opt(
                         &chunk_indices,
                         &array_subset_in_chunk_subset,
-                        chunk_subset_bytes,
+                        &chunk_subset_bytes,
                         &options,
                     )
                     .await
@@ -358,13 +358,13 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
     pub async fn async_store_array_subset_elements_opt<T: bytemuck::Pod + Send + Sync>(
         &self,
         array_subset: &ArraySubset,
-        subset_elements: Vec<T>,
+        subset_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
         array_async_store_elements!(
             self,
             subset_elements,
-            async_store_array_subset_opt(array_subset, subset_elements, options)
+            async_store_array_subset_opt(array_subset, &subset_elements, options)
         )
     }
 
@@ -389,7 +389,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
         array_async_store_ndarray!(
             self,
             subset_array,
-            async_store_array_subset_elements_opt(&subset, subset_array, options)
+            async_store_array_subset_elements_opt(&subset, &subset_array, options)
         )
     }
 }

--- a/src/array/array_async_writable.rs
+++ b/src/array/array_async_writable.rs
@@ -6,8 +6,8 @@ use crate::{
     array_subset::ArraySubset,
     metadata::MetadataEraseVersion,
     storage::{
-        meta_key, meta_key_v2_array, meta_key_v2_attributes, AsyncWritableStorageTraits,
-        StorageError, StorageHandle,
+        meta_key, meta_key_v2_array, meta_key_v2_attributes, AsyncBytes,
+        AsyncWritableStorageTraits, StorageError, StorageHandle,
     },
 };
 
@@ -239,6 +239,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
                 .codecs()
                 .encode(chunk_bytes, &chunk_array_representation, options)
                 .map_err(ArrayError::CodecError)?;
+            let chunk_encoded = AsyncBytes::from(chunk_encoded);
             crate::storage::async_store_chunk(
                 &*storage_transformer,
                 self.path(),

--- a/src/array/array_sync_readable.rs
+++ b/src/array/array_sync_readable.rs
@@ -166,7 +166,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
             chunk_indices,
             self.chunk_key_encoding(),
         )
-        .map(|maybe_vec| maybe_vec.map(|bytes| bytes.to_vec()))
+        .map(|maybe_bytes| maybe_bytes.map(|bytes| bytes.to_vec()))
     }
 
     /// Read and decode the chunk at `chunk_indices` into its bytes or the fill value if it does not exist with default codec options.
@@ -258,7 +258,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
                 &chunk_indices,
                 self.chunk_key_encoding(),
             )
-            .map(|maybe_vec| maybe_vec.map(|bytes| bytes.to_vec()))
+            .map(|maybe_bytes| maybe_bytes.map(|bytes| bytes.to_vec()))
         };
 
         let indices = chunks.indices();

--- a/src/array/array_sync_readable.rs
+++ b/src/array/array_sync_readable.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon_iter_concurrent_limit::iter_concurrent_limit;
@@ -166,6 +166,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
             chunk_indices,
             self.chunk_key_encoding(),
         )
+        .map(|maybe_vec| maybe_vec.map(|bytes| bytes.to_vec()))
     }
 
     /// Read and decode the chunk at `chunk_indices` into its bytes or the fill value if it does not exist with default codec options.
@@ -257,6 +258,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
                 &chunk_indices,
                 self.chunk_key_encoding(),
             )
+            .map(|maybe_vec| maybe_vec.map(|bytes| bytes.to_vec()))
         };
 
         let indices = chunks.indices();
@@ -527,12 +529,16 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
             let chunk_representation = self.chunk_array_representation(chunk_indices)?;
             let chunk_decoded = self
                 .codecs()
-                .decode(chunk_encoded, &chunk_representation, options)
+                .decode(
+                    Cow::Owned(chunk_encoded),
+                    &chunk_representation,
+                    options,
+                )
                 .map_err(ArrayError::CodecError)?;
             let chunk_decoded_size =
                 chunk_representation.num_elements_usize() * chunk_representation.data_type().size();
             if chunk_decoded.len() == chunk_decoded_size {
-                Ok(Some(chunk_decoded))
+                Ok(Some(chunk_decoded.into_owned()))
             } else {
                 Err(ArrayError::UnexpectedChunkDecodedSize(
                     chunk_decoded.len(),
@@ -655,7 +661,12 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         .map_err(ArrayError::StorageError)?;
         if let Some(chunk_encoded) = chunk_encoded {
             self.codecs()
-                .decode_into_array_view(&chunk_encoded, &chunk_representation, array_view, options)
+                .decode_into_array_view(
+                    Cow::Owned(chunk_encoded),
+                    &chunk_representation,
+                    array_view,
+                    options,
+                )
                 .map_err(ArrayError::CodecError)
         } else {
             super::fill_array_view_with_fill_value(array_view, self.fill_value());
@@ -718,7 +729,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         // Retrieve chunk bytes
         let num_chunks = chunks.num_elements_usize();
         match num_chunks {
-            0 => Ok(vec![]),
+            0 => Ok(Vec::default()),
             1 => {
                 let chunk_indices = chunks.start();
                 self.retrieve_chunk_opt(chunk_indices, options)
@@ -1134,6 +1145,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
                     .partial_decode_opt(&[chunk_subset.clone()], options)?
                     .pop()
                     .unwrap_unchecked()
+                    .into_owned()
             }
         };
 

--- a/src/array/array_sync_readable.rs
+++ b/src/array/array_sync_readable.rs
@@ -530,7 +530,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
             let chunk_decoded = self
                 .codecs()
                 .decode(
-                    Cow::Owned(chunk_encoded),
+                    Cow::Borrowed(&chunk_encoded),
                     &chunk_representation,
                     options,
                 )
@@ -662,7 +662,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         if let Some(chunk_encoded) = chunk_encoded {
             self.codecs()
                 .decode_into_array_view(
-                    Cow::Owned(chunk_encoded),
+                    Cow::Borrowed(&chunk_encoded),
                     &chunk_representation,
                     array_view,
                     options,

--- a/src/array/array_sync_readable_writable.rs
+++ b/src/array/array_sync_readable_writable.rs
@@ -25,7 +25,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
-        chunk_subset_bytes: Vec<u8>,
+        chunk_subset_bytes: &[u8],
     ) -> Result<(), ArrayError> {
         self.store_chunk_subset_opt(
             chunk_indices,
@@ -49,7 +49,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
-        chunk_subset_elements: Vec<T>,
+        chunk_subset_elements: &[T],
     ) -> Result<(), ArrayError> {
         self.store_chunk_subset_elements_opt(
             chunk_indices,
@@ -100,7 +100,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
     pub fn store_array_subset(
         &self,
         array_subset: &ArraySubset,
-        subset_bytes: Vec<u8>,
+        subset_bytes: &[u8],
     ) -> Result<(), ArrayError> {
         self.store_array_subset_opt(array_subset, subset_bytes, &CodecOptions::default())
     }
@@ -118,7 +118,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
     pub fn store_array_subset_elements<T: bytemuck::Pod>(
         &self,
         array_subset: &ArraySubset,
-        subset_elements: Vec<T>,
+        subset_elements: &[T],
     ) -> Result<(), ArrayError> {
         self.store_array_subset_elements_opt(
             array_subset,
@@ -158,7 +158,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
-        chunk_subset_bytes: Vec<u8>,
+        chunk_subset_bytes: &[u8],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
         let chunk_shape = self
@@ -212,7 +212,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
             }
 
             // Store the updated chunk
-            self.store_chunk_opt(chunk_indices, chunk_bytes, options)
+            self.store_chunk_opt(chunk_indices, &chunk_bytes, options)
         }
     }
 
@@ -222,13 +222,13 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         &self,
         chunk_indices: &[u64],
         chunk_subset: &ArraySubset,
-        chunk_subset_elements: Vec<T>,
+        chunk_subset_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
         array_store_elements!(
             self,
             chunk_subset_elements,
-            store_chunk_subset_opt(chunk_indices, chunk_subset, chunk_subset_elements, options)
+            store_chunk_subset_opt(chunk_indices, chunk_subset, &chunk_subset_elements, options)
         )
     }
 
@@ -258,7 +258,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         array_store_ndarray!(
             self,
             chunk_subset_array,
-            store_chunk_subset_elements_opt(chunk_indices, &subset, chunk_subset_array, options)
+            store_chunk_subset_elements_opt(chunk_indices, &subset, &chunk_subset_array, options)
         )
     }
 
@@ -267,7 +267,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
     pub fn store_array_subset_opt(
         &self,
         array_subset: &ArraySubset,
-        subset_bytes: Vec<u8>,
+        subset_bytes: &[u8],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
         // Validation
@@ -311,7 +311,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
                     unsafe { overlap.relative_to_unchecked(array_subset.start()) };
                 let chunk_subset_bytes = unsafe {
                     chunk_subset_in_array_subset.extract_bytes_unchecked(
-                        &subset_bytes,
+                        subset_bytes,
                         array_subset.shape(),
                         self.data_type().size(),
                     )
@@ -323,7 +323,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
                 self.store_chunk_subset_opt(
                     chunk_indices,
                     &array_subset_in_chunk_subset,
-                    chunk_subset_bytes,
+                    &chunk_subset_bytes,
                     options,
                 )?;
             }
@@ -352,7 +352,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
                     unsafe { overlap.relative_to_unchecked(chunk_subset_in_array.start()) };
                 let chunk_subset_bytes = unsafe {
                     chunk_subset_in_array_subset.extract_bytes_unchecked(
-                        &subset_bytes,
+                        subset_bytes,
                         array_subset.shape(),
                         self.data_type().size(),
                     )
@@ -360,7 +360,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
                 self.store_chunk_subset_opt(
                     &chunk_indices,
                     &array_subset_in_chunk_subset,
-                    chunk_subset_bytes,
+                    &chunk_subset_bytes,
                     &options,
                 )
             };
@@ -381,13 +381,13 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
     pub fn store_array_subset_elements_opt<T: bytemuck::Pod>(
         &self,
         array_subset: &ArraySubset,
-        subset_elements: Vec<T>,
+        subset_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
         array_store_elements!(
             self,
             subset_elements,
-            store_array_subset_opt(array_subset, subset_elements, options)
+            store_array_subset_opt(array_subset, &subset_elements, options)
         )
     }
 
@@ -412,7 +412,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         array_store_ndarray!(
             self,
             subset_array,
-            store_array_subset_elements_opt(&subset, subset_array, options)
+            store_array_subset_elements_opt(&subset, &subset_array, options)
         )
     }
 }

--- a/src/array/array_sync_sharded_readable_ext.rs
+++ b/src/array/array_sync_sharded_readable_ext.rs
@@ -237,7 +237,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayShardedReadableExt
             Ok(partial_decoder
                 .partial_decode_opt(&[shard_subset], options)?
                 .pop()
-                .expect("partial_decode_opt called with one subset, returned without error"))
+                .expect("partial_decode_opt called with one subset, returned without error")
+                .into_owned())
         } else {
             self.retrieve_chunk_opt(inner_chunk_indices, options)
         }
@@ -493,7 +494,7 @@ mod tests {
 
         array.store_array_subset_elements(
             &ArraySubset::new_with_shape(array.shape().to_vec()),
-            data,
+            &data,
         )?;
 
         let cache = ArrayShardedReadableExtCache::new(&array);

--- a/src/array/codec.rs
+++ b/src/array/codec.rs
@@ -69,6 +69,7 @@ pub use byte_interval_partial_decoder::ByteIntervalPartialDecoder;
 #[cfg(feature = "async")]
 pub use byte_interval_partial_decoder::AsyncByteIntervalPartialDecoder;
 
+use crate::storage::MaybeBytes;
 use crate::{
     array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
     byte_range::{ByteOffset, ByteRange, InvalidByteRangeError},
@@ -87,7 +88,7 @@ use std::{
 
 use super::{
     concurrency::RecommendedConcurrency, ArrayMetadataOptions, ArrayView, BytesRepresentation,
-    ChunkRepresentation, ChunkShape, DataType, MaybeBytes,
+    ChunkRepresentation, ChunkShape, DataType,
 };
 
 /// A codec plugin.
@@ -587,7 +588,8 @@ impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
         Ok(self
             .storage
             .get_partial_values_key(&self.key, decoded_regions)
-            .await?)
+            .await?
+            .map(|vec_bytes| vec_bytes.into_iter().map(|bytes| bytes.to_vec()).collect()))
     }
 }
 

--- a/src/array/codec.rs
+++ b/src/array/codec.rs
@@ -69,7 +69,6 @@ pub use byte_interval_partial_decoder::ByteIntervalPartialDecoder;
 #[cfg(feature = "async")]
 pub use byte_interval_partial_decoder::AsyncByteIntervalPartialDecoder;
 
-use crate::storage::MaybeBytes;
 use crate::{
     array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
     byte_range::{ByteOffset, ByteRange, InvalidByteRangeError},
@@ -81,6 +80,7 @@ use crate::{
 #[cfg(feature = "async")]
 use crate::storage::AsyncReadableStorage;
 
+use std::borrow::Cow;
 use std::{
     collections::{BTreeMap, BTreeSet},
     io::{Read, Seek, SeekFrom},
@@ -212,23 +212,23 @@ pub trait ArrayCodecTraits: CodecTraits {
     ///
     /// # Errors
     /// Returns [`CodecError`] if a codec fails or `decoded_value` is incompatible with `decoded_representation`.
-    fn encode(
+    fn encode<'a>(
         &self,
-        decoded_value: Vec<u8>,
+        decoded_value: Cow<'a, [u8]>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError>;
+    ) -> Result<Cow<'a, [u8]>, CodecError>;
 
     /// Decode a chunk.
     ///
     /// # Errors
     /// Returns [`CodecError`] if a codec fails or the decoded output is incompatible with `decoded_representation`.
-    fn decode(
+    fn decode<'a>(
         &self,
-        encoded_value: Vec<u8>,
+        encoded_value: Cow<'a, [u8]>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError>;
+    ) -> Result<Cow<'a, [u8]>, CodecError>;
 
     /// Decode into the subset of an array.
     ///
@@ -239,12 +239,12 @@ pub trait ArrayCodecTraits: CodecTraits {
     /// Returns an error if the internal call to [`decode`](ArrayCodecTraits::decode) fails.
     fn decode_into_array_view(
         &self,
-        encoded_value: &[u8],
+        encoded_value: Cow<'_, [u8]>,
         decoded_representation: &ChunkRepresentation,
         array_view: &ArrayView,
         options: &CodecOptions,
     ) -> Result<(), CodecError> {
-        let decoded_bytes = self.decode(encoded_value.to_vec(), decoded_representation, options)?;
+        let decoded_bytes = self.decode(encoded_value, decoded_representation, options)?;
         let contiguous_indices = unsafe {
             array_view
                 .subset()
@@ -291,7 +291,7 @@ pub trait BytesPartialDecoderTraits: Send + Sync {
         &self,
         decoded_regions: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError>;
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError>;
 
     /// Partially decode bytes and concatenate.
     ///
@@ -305,10 +305,10 @@ pub trait BytesPartialDecoderTraits: Send + Sync {
         &self,
         decoded_regions: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<u8>>, CodecError> {
+    ) -> Result<Option<Cow<'_, [u8]>>, CodecError> {
         Ok(self
             .partial_decode(decoded_regions, options)?
-            .map(|vecs| vecs.concat()))
+            .map(|vecs| Cow::Owned(vecs.concat())))
     }
 
     /// Decode all bytes.
@@ -317,7 +317,7 @@ pub trait BytesPartialDecoderTraits: Send + Sync {
     ///
     /// # Errors
     /// Returns [`CodecError`] if a codec fails.
-    fn decode(&self, options: &CodecOptions) -> Result<MaybeBytes, CodecError> {
+    fn decode(&self, options: &CodecOptions) -> Result<Option<Cow<'_, [u8]>>, CodecError> {
         Ok(self
             .partial_decode(&[ByteRange::FromStart(0, None)], options)?
             .map(|mut v| v.remove(0)))
@@ -338,7 +338,7 @@ pub trait AsyncBytesPartialDecoderTraits: Send + Sync {
         &self,
         decoded_regions: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError>;
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError>;
 
     /// Partially decode bytes and concatenate.
     ///
@@ -350,12 +350,12 @@ pub trait AsyncBytesPartialDecoderTraits: Send + Sync {
         &self,
         decoded_regions: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<u8>>, CodecError> {
+    ) -> Result<Option<Cow<'_, [u8]>>, CodecError> {
         // FIXME: Remove default implementation in the next major release and implement for each codec to reduce internal allocations
         Ok(self
             .partial_decode(decoded_regions, options)
             .await?
-            .map(|vecs| vecs.concat()))
+            .map(|vecs| Cow::Owned(vecs.concat())))
     }
 
     /// Decode all bytes.
@@ -364,7 +364,7 @@ pub trait AsyncBytesPartialDecoderTraits: Send + Sync {
     ///
     /// # Errors
     /// Returns [`CodecError`] if a codec fails.
-    async fn decode(&self, options: &CodecOptions) -> Result<MaybeBytes, CodecError> {
+    async fn decode(&self, options: &CodecOptions) -> Result<Option<Cow<'_, [u8]>>, CodecError> {
         Ok(self
             .partial_decode(&[ByteRange::FromStart(0, None)], options)
             .await?
@@ -384,7 +384,10 @@ pub trait ArrayPartialDecoderTraits: Send + Sync {
     ///
     /// # Errors
     /// Returns [`CodecError`] if a codec fails or an array subset is invalid.
-    fn partial_decode(&self, array_subsets: &[ArraySubset]) -> Result<Vec<Vec<u8>>, CodecError> {
+    fn partial_decode(
+        &self,
+        array_subsets: &[ArraySubset],
+    ) -> Result<Vec<Cow<'_, [u8]>>, CodecError> {
         self.partial_decode_opt(array_subsets, &CodecOptions::default())
     }
 
@@ -394,7 +397,7 @@ pub trait ArrayPartialDecoderTraits: Send + Sync {
         &self,
         array_subsets: &[ArraySubset],
         options: &CodecOptions,
-    ) -> Result<Vec<Vec<u8>>, CodecError>;
+    ) -> Result<Vec<Cow<'_, [u8]>>, CodecError>;
 
     /// Partially decode a subset of an array into an array view with default codec options.
     ///
@@ -468,7 +471,7 @@ pub trait AsyncArrayPartialDecoderTraits: Send + Sync {
     async fn partial_decode(
         &self,
         array_subsets: &[ArraySubset],
-    ) -> Result<Vec<Vec<u8>>, CodecError> {
+    ) -> Result<Vec<Cow<'_, [u8]>>, CodecError> {
         self.partial_decode_opt(array_subsets, &CodecOptions::default())
             .await
     }
@@ -478,7 +481,7 @@ pub trait AsyncArrayPartialDecoderTraits: Send + Sync {
         &self,
         array_subsets: &[ArraySubset],
         options: &CodecOptions,
-    ) -> Result<Vec<Vec<u8>>, CodecError>;
+    ) -> Result<Vec<Cow<'_, [u8]>>, CodecError>;
 
     /// Partially decode a subset of an array into an array view with default codec options.
     ///
@@ -555,10 +558,16 @@ impl BytesPartialDecoderTraits for StoragePartialDecoder {
         &self,
         decoded_regions: &[ByteRange],
         _options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
         Ok(self
             .storage
-            .get_partial_values_key(&self.key, decoded_regions)?)
+            .get_partial_values_key(&self.key, decoded_regions)?
+            .map(|vec_bytes| {
+                vec_bytes
+                    .into_iter()
+                    .map(|bytes| Cow::Owned(bytes.to_vec()))
+                    .collect()
+            }))
     }
 }
 
@@ -584,12 +593,17 @@ impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
         &self,
         decoded_regions: &[ByteRange],
         _options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
         Ok(self
             .storage
             .get_partial_values_key(&self.key, decoded_regions)
             .await?
-            .map(|vec_bytes| vec_bytes.into_iter().map(|bytes| bytes.to_vec()).collect()))
+            .map(|vec_bytes| {
+                vec_bytes
+                    .into_iter()
+                    .map(|bytes| Cow::Owned(bytes.to_vec()))
+                    .collect()
+            }))
     }
 }
 
@@ -702,19 +716,22 @@ pub trait BytesToBytesCodecTraits: CodecTraits + dyn_clone::DynClone + core::fmt
     ///
     /// # Errors
     /// Returns [`CodecError`] if a codec fails.
-    fn encode(&self, decoded_value: Vec<u8>, options: &CodecOptions)
-        -> Result<Vec<u8>, CodecError>;
+    fn encode<'a>(
+        &self,
+        decoded_value: Cow<'a, [u8]>,
+        options: &CodecOptions,
+    ) -> Result<Cow<'a, [u8]>, CodecError>;
 
     /// Decode chunk bytes.
     //
     /// # Errors
     /// Returns [`CodecError`] if a codec fails.
-    fn decode(
+    fn decode<'a>(
         &self,
-        encoded_value: Vec<u8>,
+        encoded_value: Cow<'a, [u8]>,
         decoded_representation: &BytesRepresentation,
         options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError>;
+    ) -> Result<Cow<'a, [u8]>, CodecError>;
 
     /// Initialises a partial decoder.
     ///
@@ -747,11 +764,28 @@ impl BytesPartialDecoderTraits for std::io::Cursor<&[u8]> {
         &self,
         decoded_regions: &[ByteRange],
         _parallel: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        Ok(Some(extract_byte_ranges_read_seek(
-            &mut self.clone(),
-            decoded_regions,
-        )?))
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
+        Ok(Some(
+            extract_byte_ranges_read_seek(&mut self.clone(), decoded_regions)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
+        ))
+    }
+}
+
+impl BytesPartialDecoderTraits for std::io::Cursor<Cow<'_, [u8]>> {
+    fn partial_decode(
+        &self,
+        decoded_regions: &[ByteRange],
+        _parallel: &CodecOptions,
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
+        Ok(Some(
+            extract_byte_ranges_read_seek(&mut self.clone(), decoded_regions)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
+        ))
     }
 }
 
@@ -760,11 +794,13 @@ impl BytesPartialDecoderTraits for std::io::Cursor<Vec<u8>> {
         &self,
         decoded_regions: &[ByteRange],
         _parallel: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        Ok(Some(extract_byte_ranges_read_seek(
-            &mut self.clone(),
-            decoded_regions,
-        )?))
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
+        Ok(Some(
+            extract_byte_ranges_read_seek(&mut self.clone(), decoded_regions)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
+        ))
     }
 }
 
@@ -775,11 +811,30 @@ impl AsyncBytesPartialDecoderTraits for std::io::Cursor<&[u8]> {
         &self,
         decoded_regions: &[ByteRange],
         _parallel: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        Ok(Some(extract_byte_ranges_read_seek(
-            &mut self.clone(),
-            decoded_regions,
-        )?))
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
+        Ok(Some(
+            extract_byte_ranges_read_seek(&mut self.clone(), decoded_regions)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
+        ))
+    }
+}
+
+#[cfg(feature = "async")]
+#[async_trait::async_trait]
+impl AsyncBytesPartialDecoderTraits for std::io::Cursor<Cow<'_, [u8]>> {
+    async fn partial_decode(
+        &self,
+        decoded_regions: &[ByteRange],
+        _parallel: &CodecOptions,
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
+        Ok(Some(
+            extract_byte_ranges_read_seek(&mut self.clone(), decoded_regions)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
+        ))
     }
 }
 
@@ -790,11 +845,13 @@ impl AsyncBytesPartialDecoderTraits for std::io::Cursor<Vec<u8>> {
         &self,
         decoded_regions: &[ByteRange],
         _parallel: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
-        Ok(Some(extract_byte_ranges_read_seek(
-            &mut self.clone(),
-            decoded_regions,
-        )?))
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
+        Ok(Some(
+            extract_byte_ranges_read_seek(&mut self.clone(), decoded_regions)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
+        ))
     }
 }
 

--- a/src/array/codec/array_to_array/bitround.rs
+++ b/src/array/codec/array_to_array/bitround.rs
@@ -340,7 +340,7 @@ mod tests {
             ArraySubset::new_with_ranges(&[3..5]),
             ArraySubset::new_with_ranges(&[17..21]),
         ];
-        let input_handle = Box::new(std::io::Cursor::new(encoded.to_vec()));
+        let input_handle = Box::new(std::io::Cursor::new(encoded));
         let bytes_codec = BytesCodec::default();
         let input_handle = bytes_codec
             .partial_decoder(
@@ -394,7 +394,7 @@ mod tests {
             ArraySubset::new_with_ranges(&[3..5]),
             ArraySubset::new_with_ranges(&[17..21]),
         ];
-        let input_handle = Box::new(std::io::Cursor::new(encoded.to_vec()));
+        let input_handle = Box::new(std::io::Cursor::new(encoded));
         let bytes_codec = BytesCodec::default();
         let input_handle = bytes_codec
             .async_partial_decoder(

--- a/src/array/codec/array_to_array/bitround.rs
+++ b/src/array/codec/array_to_array/bitround.rs
@@ -175,7 +175,7 @@ fn round_bytes(bytes: &mut [u8], data_type: &DataType, keepbits: u32) -> Result<
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU64;
+    use std::{borrow::Cow, num::NonZeroU64};
 
     use array_representation::ChunkRepresentation;
     use itertools::Itertools;
@@ -223,19 +223,19 @@ mod tests {
 
         let encoded = codec
             .encode(
-                bytes.clone(),
+                Cow::Borrowed(&bytes),
                 &chunk_representation,
                 &CodecOptions::default(),
             )
             .unwrap();
         let decoded = codec
             .decode(
-                encoded.clone(),
+                Cow::Borrowed(&encoded),
                 &chunk_representation,
                 &CodecOptions::default(),
             )
             .unwrap();
-        let decoded_elements = crate::array::transmute_from_bytes_vec::<f32>(decoded);
+        let decoded_elements = crate::array::transmute_from_bytes_vec::<f32>(decoded.to_vec());
         assert_eq!(decoded_elements, &[0.0f32, 1.25f32, -8.0f32, 98304.0f32]);
     }
 
@@ -256,19 +256,19 @@ mod tests {
 
         let encoded = codec
             .encode(
-                bytes.clone(),
+                Cow::Borrowed(&bytes),
                 &chunk_representation,
                 &CodecOptions::default(),
             )
             .unwrap();
         let decoded = codec
             .decode(
-                encoded.clone(),
+                Cow::Borrowed(&encoded),
                 &chunk_representation,
                 &CodecOptions::default(),
             )
             .unwrap();
-        let decoded_elements = crate::array::transmute_from_bytes_vec::<u32>(decoded);
+        let decoded_elements = crate::array::transmute_from_bytes_vec::<u32>(decoded.to_vec());
         for element in &decoded_elements {
             println!("{element} -> {element:#b}");
         }
@@ -295,19 +295,19 @@ mod tests {
 
         let encoded = codec
             .encode(
-                bytes.clone(),
+                Cow::Borrowed(&bytes),
                 &chunk_representation,
                 &CodecOptions::default(),
             )
             .unwrap();
         let decoded = codec
             .decode(
-                encoded.clone(),
+                Cow::Borrowed(&encoded),
                 &chunk_representation,
                 &CodecOptions::default(),
             )
             .unwrap();
-        let decoded_elements = crate::array::transmute_from_bytes_vec::<u32>(decoded);
+        let decoded_elements = crate::array::transmute_from_bytes_vec::<u32>(decoded.to_vec());
         for element in &decoded_elements {
             println!("{element} -> {element:#b}");
         }
@@ -331,7 +331,7 @@ mod tests {
 
         let encoded = codec
             .encode(
-                bytes.clone(),
+                Cow::Borrowed(&bytes),
                 &chunk_representation,
                 &CodecOptions::default(),
             )
@@ -340,7 +340,7 @@ mod tests {
             ArraySubset::new_with_ranges(&[3..5]),
             ArraySubset::new_with_ranges(&[17..21]),
         ];
-        let input_handle = Box::new(std::io::Cursor::new(encoded));
+        let input_handle = Box::new(std::io::Cursor::new(encoded.to_vec()));
         let bytes_codec = BytesCodec::default();
         let input_handle = bytes_codec
             .partial_decoder(
@@ -361,7 +361,7 @@ mod tests {
             .unwrap();
         let decoded_partial_chunk = decoded_partial_chunk
             .into_iter()
-            .map(|bytes| crate::array::transmute_from_bytes_vec::<f32>(bytes))
+            .map(|bytes| crate::array::convert_from_bytes_slice::<f32>(&bytes))
             .collect_vec();
         let answer: &[Vec<f32>] = &[vec![3.0, 4.0], vec![16.0, 16.0, 20.0, 20.0]];
         assert_eq!(answer, decoded_partial_chunk);
@@ -385,7 +385,7 @@ mod tests {
 
         let encoded = codec
             .encode(
-                bytes.clone(),
+                Cow::Borrowed(&bytes),
                 &chunk_representation,
                 &CodecOptions::default(),
             )
@@ -394,7 +394,7 @@ mod tests {
             ArraySubset::new_with_ranges(&[3..5]),
             ArraySubset::new_with_ranges(&[17..21]),
         ];
-        let input_handle = Box::new(std::io::Cursor::new(encoded));
+        let input_handle = Box::new(std::io::Cursor::new(encoded.to_vec()));
         let bytes_codec = BytesCodec::default();
         let input_handle = bytes_codec
             .async_partial_decoder(
@@ -418,7 +418,7 @@ mod tests {
             .unwrap();
         let decoded_partial_chunk = decoded_partial_chunk
             .into_iter()
-            .map(|bytes| crate::array::transmute_from_bytes_vec::<f32>(bytes))
+            .map(|bytes| crate::array::convert_from_bytes_slice::<f32>(&bytes))
             .collect_vec();
         let answer: &[Vec<f32>] = &[vec![3.0, 4.0], vec![16.0, 16.0, 20.0, 20.0]];
         assert_eq!(answer, decoded_partial_chunk);

--- a/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     array::{
         codec::{
@@ -75,26 +77,26 @@ impl ArrayCodecTraits for BitroundCodec {
         Ok(RecommendedConcurrency::new_maximum(1))
     }
 
-    fn encode(
+    fn encode<'a>(
         &self,
-        mut decoded_value: Vec<u8>,
+        mut decoded_value: Cow<'a, [u8]>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
         round_bytes(
-            &mut decoded_value,
+            decoded_value.to_mut(),
             decoded_representation.data_type(),
             self.keepbits,
         )?;
         Ok(decoded_value)
     }
 
-    fn decode(
+    fn decode<'a>(
         &self,
-        encoded_value: Vec<u8>,
+        encoded_value: Cow<'a, [u8]>,
         _decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
         Ok(encoded_value)
     }
 }

--- a/src/array/codec/array_to_array/bitround/bitround_partial_decoder.rs
+++ b/src/array/codec/array_to_array/bitround/bitround_partial_decoder.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     array::{
         codec::{ArrayPartialDecoderTraits, CodecError, CodecOptions},
@@ -59,13 +61,13 @@ impl ArrayPartialDecoderTraits for BitroundPartialDecoder<'_> {
         &self,
         array_subsets: &[ArraySubset],
         options: &CodecOptions,
-    ) -> Result<Vec<Vec<u8>>, CodecError> {
+    ) -> Result<Vec<Cow<'_, [u8]>>, CodecError> {
         let mut bytes = self
             .input_handle
             .partial_decode_opt(array_subsets, options)?;
 
         for bytes in &mut bytes {
-            round_bytes(bytes, &self.data_type, self.keepbits)?;
+            round_bytes(bytes.to_mut(), &self.data_type, self.keepbits)?;
         }
 
         Ok(bytes)
@@ -124,14 +126,14 @@ impl AsyncArrayPartialDecoderTraits for AsyncBitroundPartialDecoder<'_> {
         &self,
         array_subsets: &[ArraySubset],
         options: &CodecOptions,
-    ) -> Result<Vec<Vec<u8>>, CodecError> {
+    ) -> Result<Vec<Cow<'_, [u8]>>, CodecError> {
         let mut bytes = self
             .input_handle
             .partial_decode_opt(array_subsets, options)
             .await?;
 
         for bytes in &mut bytes {
-            round_bytes(bytes, &self.data_type, self.keepbits)?;
+            round_bytes(bytes.to_mut(), &self.data_type, self.keepbits)?;
         }
 
         Ok(bytes)

--- a/src/array/codec/array_to_array/transpose.rs
+++ b/src/array/codec/array_to_array/transpose.rs
@@ -56,7 +56,6 @@ fn calculate_order_decode(order: &TransposeOrder, array_dimensions: usize) -> Ve
     permutation_decode
 }
 
-// TODO: Optimise this to use cow and be pass through for an identity permutation
 fn transpose_array(
     transpose_order: &[usize],
     untransposed_shape: &[u64],

--- a/src/array/codec/array_to_bytes/bytes.rs
+++ b/src/array/codec/array_to_bytes/bytes.rs
@@ -71,7 +71,7 @@ pub fn reverse_endianness(v: &mut [u8], data_type: &DataType) {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU64;
+    use std::{borrow::Cow, num::NonZeroU64};
 
     use crate::{
         array::{
@@ -131,14 +131,14 @@ mod tests {
         let codec = BytesCodec::new(endianness);
 
         let encoded = codec.encode(
-            bytes.clone(),
+            Cow::Borrowed(&bytes),
             &chunk_representation,
             &CodecOptions::default(),
         )?;
         let decoded = codec
             .decode(encoded, &chunk_representation, &CodecOptions::default())
             .unwrap();
-        assert_eq!(bytes, decoded);
+        assert_eq!(bytes, decoded.to_vec());
         Ok(())
     }
 
@@ -264,7 +264,11 @@ mod tests {
         let codec = BytesCodec::new(None);
 
         let encoded = codec
-            .encode(bytes, &chunk_representation, &CodecOptions::default())
+            .encode(
+                Cow::Borrowed(&bytes),
+                &chunk_representation,
+                &CodecOptions::default(),
+            )
             .unwrap();
         let decoded_regions = [ArraySubset::new_with_ranges(&[1..3, 0..1])];
         let input_handle = Box::new(std::io::Cursor::new(encoded));
@@ -281,6 +285,7 @@ mod tests {
 
         let decoded_partial_chunk: Vec<u8> = decoded_partial_chunk
             .into_iter()
+            .map(|v| v.to_vec())
             .flatten()
             .collect::<Vec<_>>()
             .chunks(std::mem::size_of::<u8>())
@@ -303,7 +308,11 @@ mod tests {
         let codec = BytesCodec::new(None);
 
         let encoded = codec
-            .encode(bytes, &chunk_representation, &CodecOptions::default())
+            .encode(
+                Cow::Borrowed(&bytes),
+                &chunk_representation,
+                &CodecOptions::default(),
+            )
             .unwrap();
         let decoded_regions = [ArraySubset::new_with_ranges(&[1..3, 0..1])];
         let input_handle = Box::new(std::io::Cursor::new(encoded));
@@ -322,6 +331,7 @@ mod tests {
 
         let decoded_partial_chunk: Vec<u8> = decoded_partial_chunk
             .into_iter()
+            .map(|v| v.to_vec())
             .flatten()
             .collect::<Vec<_>>()
             .chunks(std::mem::size_of::<u8>())

--- a/src/array/codec/array_to_bytes/pcodec.rs
+++ b/src/array/codec/array_to_bytes/pcodec.rs
@@ -51,7 +51,7 @@ pub(crate) fn create_codec_pcodec(metadata: &MetadataV3) -> Result<Codec, Plugin
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU64;
+    use std::{borrow::Cow, num::NonZeroU64};
 
     use crate::{
         array::{
@@ -90,7 +90,7 @@ mod tests {
 
         let max_encoded_size = codec.compute_encoded_size(&chunk_representation)?;
         let encoded = codec.encode(
-            bytes.clone(),
+            Cow::Borrowed(&bytes),
             &chunk_representation,
             &CodecOptions::default(),
         )?;
@@ -98,7 +98,7 @@ mod tests {
         let decoded = codec
             .decode(encoded, &chunk_representation, &CodecOptions::default())
             .unwrap();
-        assert_eq!(bytes, decoded);
+        assert_eq!(bytes, decoded.to_vec());
         Ok(())
     }
 
@@ -207,7 +207,11 @@ mod tests {
         let codec = PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap());
 
         let encoded = codec
-            .encode(bytes, &chunk_representation, &CodecOptions::default())
+            .encode(
+                Cow::Borrowed(&bytes),
+                &chunk_representation,
+                &CodecOptions::default(),
+            )
             .unwrap();
         let decoded_regions = [ArraySubset::new_with_ranges(&[1..3, 0..1])];
         let input_handle = Box::new(std::io::Cursor::new(encoded));
@@ -224,6 +228,7 @@ mod tests {
 
         let decoded_partial_chunk: Vec<u8> = decoded_partial_chunk
             .into_iter()
+            .map(|v| v.to_vec())
             .flatten()
             .collect::<Vec<_>>()
             .chunks(std::mem::size_of::<u8>())
@@ -249,7 +254,11 @@ mod tests {
         let codec = PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap());
 
         let encoded = codec
-            .encode(bytes, &chunk_representation, &CodecOptions::default())
+            .encode(
+                Cow::Borrowed(&bytes),
+                &chunk_representation,
+                &CodecOptions::default(),
+            )
             .unwrap();
         let decoded_regions = [ArraySubset::new_with_ranges(&[1..3, 0..1])];
         let input_handle = Box::new(std::io::Cursor::new(encoded));
@@ -268,6 +277,7 @@ mod tests {
 
         let decoded_partial_chunk: Vec<u8> = decoded_partial_chunk
             .into_iter()
+            .map(|v| v.to_vec())
             .flatten()
             .collect::<Vec<_>>()
             .chunks(std::mem::size_of::<u8>())

--- a/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
+++ b/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
@@ -9,7 +9,7 @@ use crate::{
             BytesPartialDecoderTraits, CodecError, CodecOptions, CodecTraits,
             RecommendedConcurrency,
         },
-        transmute_from_bytes_vec, transmute_to_bytes_vec, ArrayMetadataOptions,
+        convert_from_bytes_slice, transmute_to_bytes_vec, ArrayMetadataOptions,
         BytesRepresentation, ChunkRepresentation, DataType,
     },
     metadata::v3::MetadataV3,
@@ -107,7 +107,7 @@ impl ArrayCodecTraits for PcodecCodec {
         macro_rules! pcodec_encode {
             ( $t:ty ) => {
                 pco::standalone::simple_compress(
-                    &transmute_from_bytes_vec::<$t>(decoded_value.to_vec()) /* FIXME: transmute from bytes slice */,
+                    &convert_from_bytes_slice::<$t>(&decoded_value),
                     &self.chunk_config,
                 )
                 .map(Cow::Owned)

--- a/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
+++ b/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     array::{
         codec::{
@@ -31,11 +33,11 @@ impl<'a> PcodecPartialDecoder<'a> {
     }
 }
 
-fn do_partial_decode(
-    decoded: Option<Vec<u8>>,
+fn do_partial_decode<'a>(
+    decoded: Option<Cow<'a, [u8]>>,
     decoded_regions: &[ArraySubset],
     decoded_representation: &ChunkRepresentation,
-) -> Result<Vec<Vec<u8>>, CodecError> {
+) -> Result<Vec<Cow<'a, [u8]>>, CodecError> {
     let mut decoded_bytes = Vec::with_capacity(decoded_regions.len());
     let chunk_shape = decoded_representation.shape_u64();
     match decoded {
@@ -45,16 +47,15 @@ fn do_partial_decode(
                     .fill_value()
                     .as_ne_bytes()
                     .repeat(array_subset.num_elements_usize());
-                decoded_bytes.push(bytes_subset);
+                decoded_bytes.push(bytes_subset.into());
             }
         }
         Some(decoded_value) => {
             macro_rules! pcodec_partial_decode {
                 ( $t:ty ) => {
-                    let decoded_chunk =
-                        pco::standalone::simple_decompress(decoded_value.as_slice())
-                            .map(|bytes| crate::array::transmute_to_bytes_vec::<$t>(bytes))
-                            .map_err(|err| CodecError::Other(err.to_string()))?;
+                    let decoded_chunk = pco::standalone::simple_decompress(&decoded_value)
+                        .map(|bytes| crate::array::transmute_to_bytes_vec::<$t>(bytes))
+                        .map_err(|err| CodecError::Other(err.to_string()))?;
                     for array_subset in decoded_regions {
                         let bytes_subset = array_subset
                             .extract_bytes(
@@ -68,7 +69,7 @@ fn do_partial_decode(
                                     decoded_representation.shape_u64(),
                                 ))
                             })?;
-                        decoded_bytes.push(bytes_subset);
+                        decoded_bytes.push(bytes_subset.into());
                     }
                 };
             }
@@ -114,7 +115,7 @@ impl ArrayPartialDecoderTraits for PcodecPartialDecoder<'_> {
         &self,
         decoded_regions: &[ArraySubset],
         options: &CodecOptions,
-    ) -> Result<Vec<Vec<u8>>, CodecError> {
+    ) -> Result<Vec<Cow<'_, [u8]>>, CodecError> {
         let decoded = self.input_handle.decode(options)?;
         do_partial_decode(decoded, decoded_regions, &self.decoded_representation)
     }
@@ -152,7 +153,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncPCodecPartialDecoder<'_> {
         &self,
         decoded_regions: &[ArraySubset],
         options: &CodecOptions,
-    ) -> Result<Vec<Vec<u8>>, CodecError> {
+    ) -> Result<Vec<Cow<'_, [u8]>>, CodecError> {
         for array_subset in decoded_regions {
             if array_subset.dimensionality() != self.decoded_representation.dimensionality() {
                 return Err(CodecError::InvalidArraySubsetDimensionalityError(

--- a/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
+++ b/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
@@ -47,7 +47,7 @@ fn do_partial_decode<'a>(
                     .fill_value()
                     .as_ne_bytes()
                     .repeat(array_subset.num_elements_usize());
-                decoded_bytes.push(bytes_subset.into());
+                decoded_bytes.push(Cow::Owned(bytes_subset));
             }
         }
         Some(decoded_value) => {
@@ -69,7 +69,7 @@ fn do_partial_decode<'a>(
                                     decoded_representation.shape_u64(),
                                 ))
                             })?;
-                        decoded_bytes.push(bytes_subset.into());
+                        decoded_bytes.push(Cow::Owned(bytes_subset));
                     }
                 };
             }

--- a/src/array/codec/array_to_bytes/zfp/zfp_bitstream.rs
+++ b/src/array/codec/array_to_bytes/zfp/zfp_bitstream.rs
@@ -14,7 +14,7 @@ impl Drop for ZfpBitstream {
 }
 
 impl ZfpBitstream {
-    pub fn new(buffer: &mut Vec<u8>) -> Option<Self> {
+    pub fn new(buffer: &mut [u8]) -> Option<Self> {
         let stream =
             unsafe { stream_open(buffer.as_mut_ptr().cast::<std::ffi::c_void>(), buffer.len()) };
         NonNull::new(stream).map(Self)

--- a/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -137,7 +137,7 @@ impl ArrayCodecTraits for ZfpCodec {
         _options: &CodecOptions,
     ) -> Result<Cow<'a, [u8]>, CodecError> {
         let mut decoded_value_promoted =
-            promote_before_zfp_encoding(decoded_value.to_vec(), decoded_representation)?;
+            promote_before_zfp_encoding(&decoded_value, decoded_representation)?;
         let zfp_type = decoded_value_promoted.zfp_type();
         let Some(field) = ZfpField::new(
             &mut decoded_value_promoted,
@@ -191,7 +191,7 @@ impl ArrayCodecTraits for ZfpCodec {
     ) -> Result<Cow<'a, [u8]>, CodecError> {
         zfp_decode(
             &self.mode,
-            &mut encoded_value.to_vec(),
+            &mut encoded_value.to_vec(), // FIXME: Does zfp **really** need the encoded value as mutable?
             decoded_representation,
             false, // FIXME
         )

--- a/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
+++ b/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
@@ -68,7 +68,7 @@ impl ArrayPartialDecoderTraits for ZfpPartialDecoder<'_> {
             Some(mut encoded_value) => {
                 let decoded_value = zfp_decode(
                     &self.mode,
-                    encoded_value.to_mut(),
+                    encoded_value.to_mut(), // FIXME: Does zfp **really** need the encoded value as mutable?
                     &self.decoded_representation,
                     false, // FIXME
                 )?;
@@ -158,7 +158,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder<'_> {
             Some(mut encoded_value) => {
                 let decoded_value = zfp_decode(
                     &self.mode,
-                    encoded_value.to_mut(),
+                    encoded_value.to_mut(), // FIXME: Does zfp **really** need the encoded value as mutable?
                     &self.decoded_representation,
                     false, // FIXME
                 )?;

--- a/src/array/codec/byte_interval_partial_decoder.rs
+++ b/src/array/codec/byte_interval_partial_decoder.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::byte_range::{ByteLength, ByteOffset, ByteRange};
 
 use super::{BytesPartialDecoderTraits, CodecError, CodecOptions};
@@ -34,7 +36,7 @@ impl<'a> BytesPartialDecoderTraits for ByteIntervalPartialDecoder<'a> {
         &self,
         byte_ranges: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
         let byte_ranges: Vec<ByteRange> = byte_ranges
             .iter()
             .map(|byte_range| match byte_range {
@@ -90,7 +92,7 @@ impl<'a> AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder<'a> 
         &self,
         byte_ranges: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
         let byte_ranges: Vec<ByteRange> = byte_ranges
             .iter()
             .map(|byte_range| match byte_range {

--- a/src/array/codec/bytes_partial_decoder_cache.rs
+++ b/src/array/codec/bytes_partial_decoder_cache.rs
@@ -3,8 +3,8 @@
 use std::marker::PhantomData;
 
 use crate::{
-    array::MaybeBytes,
     byte_range::{extract_byte_ranges, ByteRange},
+    storage::MaybeBytes,
 };
 
 use super::{BytesPartialDecoderTraits, CodecError, CodecOptions};

--- a/src/array/codec/bytes_to_bytes/blosc.rs
+++ b/src/array/codec/bytes_to_bytes/blosc.rs
@@ -227,6 +227,8 @@ fn blosc_decompress_bytes_partial(
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use crate::{
         array::{
             codec::{BytesToBytesCodecTraits, CodecOptions},
@@ -282,12 +284,12 @@ mod tests {
         let codec = BloscCodec::new_with_configuration(&codec_configuration).unwrap();
 
         let encoded = codec
-            .encode(bytes.clone(), &CodecOptions::default())
+            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
             .unwrap();
         let decoded = codec
             .decode(encoded, &bytes_representation, &CodecOptions::default())
             .unwrap();
-        assert_eq!(bytes, decoded);
+        assert_eq!(bytes, decoded.to_vec());
     }
 
     #[test]
@@ -343,7 +345,9 @@ mod tests {
             serde_json::from_str(JSON_VALID2).unwrap();
         let codec = BloscCodec::new_with_configuration(&codec_configuration).unwrap();
 
-        let encoded = codec.encode(bytes, &CodecOptions::default()).unwrap();
+        let encoded = codec
+            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .unwrap();
         let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(
                 array_representation.shape(),
@@ -359,15 +363,13 @@ mod tests {
             )
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
         let decoded: Vec<u16> = decoded
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .chunks(std::mem::size_of::<u16>())
+            .to_vec()
+            .chunks_exact(std::mem::size_of::<u16>())
             .map(|b| u16::from_ne_bytes(b.try_into().unwrap()))
             .collect();
 
@@ -391,7 +393,9 @@ mod tests {
             serde_json::from_str(JSON_VALID2).unwrap();
         let codec = BloscCodec::new_with_configuration(&codec_configuration).unwrap();
 
-        let encoded = codec.encode(bytes, &CodecOptions::default()).unwrap();
+        let encoded = codec
+            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .unwrap();
         let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(
                 array_representation.shape(),
@@ -408,16 +412,14 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();
 
         let decoded: Vec<u16> = decoded
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .chunks(std::mem::size_of::<u16>())
+            .to_vec()
+            .chunks_exact(std::mem::size_of::<u16>())
             .map(|b| u16::from_ne_bytes(b.try_into().unwrap()))
             .collect();
 

--- a/src/array/codec/bytes_to_bytes/blosc/blosc_codec.rs
+++ b/src/array/codec/bytes_to_bytes/blosc/blosc_codec.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_char;
+use std::{borrow::Cow, ffi::c_char};
 
 use blosc_sys::{blosc_get_complib_info, BLOSC_MAX_OVERHEAD};
 
@@ -168,33 +168,33 @@ impl BytesToBytesCodecTraits for BloscCodec {
         Ok(RecommendedConcurrency::new_maximum(1))
     }
 
-    fn encode(
+    fn encode<'a>(
         &self,
-        decoded_value: Vec<u8>,
+        decoded_value: Cow<'a, [u8]>,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
         // let n_threads = std::cmp::min(
         //     options.concurrent_limit(),
         //     std::thread::available_parallelism().unwrap(),
         // )
         // .get();
         let n_threads = 1;
-        self.do_encode(&decoded_value, n_threads)
+        Ok(Cow::Owned(self.do_encode(&decoded_value, n_threads)?))
     }
 
-    fn decode(
+    fn decode<'a>(
         &self,
-        encoded_value: Vec<u8>,
+        encoded_value: Cow<'a, [u8]>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
         // let n_threads = std::cmp::min(
         //     options.concurrent_limit(),
         //     std::thread::available_parallelism().unwrap(),
         // )
         // .get();
         let n_threads = 1;
-        Self::do_decode(&encoded_value, n_threads)
+        Ok(Cow::Owned(Self::do_decode(&encoded_value, n_threads)?))
     }
 
     fn partial_decoder<'a>(

--- a/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
+++ b/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     array::codec::{
         bytes_to_bytes::blosc::blosc_nbytes, BytesPartialDecoderTraits, CodecError, CodecOptions,
@@ -26,7 +28,7 @@ impl BytesPartialDecoderTraits for BloscPartialDecoder<'_> {
         &self,
         decoded_regions: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options)?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
@@ -48,6 +50,7 @@ impl BytesPartialDecoderTraits for BloscPartialDecoder<'_> {
                             end - start,
                             typesize,
                         )
+                        .map(Cow::Owned)
                         .map_err(|err| CodecError::from(err.to_string()))?,
                     );
                 }
@@ -78,7 +81,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder<'_> {
         &self,
         decoded_regions: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options).await?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
@@ -99,6 +102,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder<'_> {
                             end - start,
                             typesize,
                         )
+                        .map(Cow::Owned)
                         .map_err(|err| CodecError::from(err.to_string()))?,
                     );
                 }

--- a/src/array/codec/bytes_to_bytes/bz2/bz2_codec.rs
+++ b/src/array/codec/bytes_to_bytes/bz2/bz2_codec.rs
@@ -1,4 +1,7 @@
-use std::io::Read;
+use std::{
+    borrow::Cow,
+    io::{Cursor, Read},
+};
 
 use crate::{
     array::{
@@ -69,27 +72,27 @@ impl BytesToBytesCodecTraits for Bz2Codec {
         Ok(RecommendedConcurrency::new_maximum(1))
     }
 
-    fn encode(
+    fn encode<'a>(
         &self,
-        decoded_value: Vec<u8>,
+        decoded_value: Cow<'a, [u8]>,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
-        let mut encoder = bzip2::read::BzEncoder::new(decoded_value.as_slice(), self.compression);
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
+        let mut encoder = bzip2::read::BzEncoder::new(Cursor::new(decoded_value), self.compression);
         let mut out: Vec<u8> = Vec::new();
         encoder.read_to_end(&mut out)?;
-        Ok(out)
+        Ok(Cow::Owned(out))
     }
 
-    fn decode(
+    fn decode<'a>(
         &self,
-        encoded_value: Vec<u8>,
+        encoded_value: Cow<'a, [u8]>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
-        let mut decoder = bzip2::read::BzDecoder::new(encoded_value.as_slice());
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
+        let mut decoder = bzip2::read::BzDecoder::new(Cursor::new(encoded_value));
         let mut out: Vec<u8> = Vec::new();
         decoder.read_to_end(&mut out)?;
-        Ok(out)
+        Ok(Cow::Owned(out))
     }
 
     fn partial_decoder<'a>(

--- a/src/array/codec/bytes_to_bytes/crc32c/crc32c_partial_decoder.rs
+++ b/src/array/codec/bytes_to_bytes/crc32c/crc32c_partial_decoder.rs
@@ -36,20 +36,23 @@ impl BytesPartialDecoderTraits for Crc32cPartialDecoder<'_> {
         // Drop trailing checksum
         let mut output = Vec::with_capacity(bytes.len());
         for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions) {
-            let mut bytes = bytes.to_vec();
-            match byte_range {
-                ByteRange::FromStart(_, Some(_)) => {}
+            let bytes = match byte_range {
+                ByteRange::FromStart(_, Some(_)) => bytes,
                 ByteRange::FromStart(_, None) => {
-                    bytes.resize(bytes.len() - CHECKSUM_SIZE, 0);
+                    let length = bytes.len() - CHECKSUM_SIZE;
+                    Cow::Owned(bytes[..length].to_vec())
                 }
                 ByteRange::FromEnd(offset, _) => {
                     if *offset < CHECKSUM_SIZE as u64 {
                         let length = bytes.len() as u64 - (CHECKSUM_SIZE as u64 - offset);
-                        bytes.resize(usize::try_from(length).unwrap(), 0);
+                        let length = usize::try_from(length).unwrap();
+                        Cow::Owned(bytes[..length].to_vec())
+                    } else {
+                        bytes
                     }
                 }
             };
-            output.push(Cow::Owned(bytes));
+            output.push(bytes);
         }
 
         Ok(Some(output))
@@ -89,20 +92,23 @@ impl AsyncBytesPartialDecoderTraits for AsyncCrc32cPartialDecoder<'_> {
         // Drop trailing checksum
         let mut output = Vec::with_capacity(bytes.len());
         for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions) {
-            let mut bytes = bytes.to_vec();
-            match byte_range {
-                ByteRange::FromStart(_, Some(_)) => {}
+            let bytes = match byte_range {
+                ByteRange::FromStart(_, Some(_)) => bytes,
                 ByteRange::FromStart(_, None) => {
-                    bytes.resize(bytes.len() - CHECKSUM_SIZE, 0);
+                    let length = bytes.len() - CHECKSUM_SIZE;
+                    Cow::Owned(bytes[..length].to_vec())
                 }
                 ByteRange::FromEnd(offset, _) => {
                     if *offset < CHECKSUM_SIZE as u64 {
                         let length = bytes.len() as u64 - (CHECKSUM_SIZE as u64 - offset);
-                        bytes.resize(usize::try_from(length).unwrap(), 0);
+                        let length = usize::try_from(length).unwrap();
+                        Cow::Owned(bytes[..length].to_vec())
+                    } else {
+                        bytes
                     }
                 }
             };
-            output.push(Cow::Owned(bytes));
+            output.push(bytes);
         }
 
         Ok(Some(output))

--- a/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
+++ b/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
@@ -1,4 +1,7 @@
-use std::io::{Cursor, Read};
+use std::{
+    borrow::Cow,
+    io::{Cursor, Read},
+};
 
 use flate2::bufread::{GzDecoder, GzEncoder};
 
@@ -73,30 +76,30 @@ impl BytesToBytesCodecTraits for GzipCodec {
         Ok(RecommendedConcurrency::new_maximum(1))
     }
 
-    fn encode(
+    fn encode<'a>(
         &self,
-        decoded_value: Vec<u8>,
+        decoded_value: Cow<'a, [u8]>,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
         let mut encoder = GzEncoder::new(
             Cursor::new(decoded_value),
             flate2::Compression::new(self.compression_level.as_u32()),
         );
         let mut out: Vec<u8> = Vec::new();
         encoder.read_to_end(&mut out)?;
-        Ok(out)
+        Ok(Cow::Owned(out))
     }
 
-    fn decode(
+    fn decode<'a>(
         &self,
-        encoded_value: Vec<u8>,
+        encoded_value: Cow<'a, [u8]>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
         let mut decoder = GzDecoder::new(Cursor::new(encoded_value));
         let mut out: Vec<u8> = Vec::new();
         decoder.read_to_end(&mut out)?;
-        Ok(out)
+        Ok(Cow::Owned(out))
     }
 
     fn partial_decoder<'a>(

--- a/src/array/codec/bytes_to_bytes/test_unbounded.rs
+++ b/src/array/codec/bytes_to_bytes/test_unbounded.rs
@@ -9,6 +9,8 @@ pub use test_unbounded_codec::TestUnboundedCodec;
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use crate::{
         array::{
             codec::{BytesToBytesCodecTraits, CodecOptions},
@@ -28,12 +30,12 @@ mod tests {
         let codec: TestUnboundedCodec = TestUnboundedCodec::new();
 
         let encoded = codec
-            .encode(bytes.clone(), &CodecOptions::default())
+            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
             .unwrap();
         let decoded = codec
             .decode(encoded, &bytes_representation, &CodecOptions::default())
             .unwrap();
-        assert_eq!(bytes, decoded);
+        assert_eq!(bytes, decoded.to_vec());
     }
 
     #[test]
@@ -44,7 +46,9 @@ mod tests {
 
         let codec: TestUnboundedCodec = TestUnboundedCodec::new();
 
-        let encoded = codec.encode(bytes, &CodecOptions::default()).unwrap();
+        let encoded = codec
+            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),
             ByteRange::FromStart(10, Some(2)),
@@ -59,15 +63,13 @@ mod tests {
             )
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
         let decoded_partial_chunk: Vec<u16> = decoded_partial_chunk
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .chunks(std::mem::size_of::<u16>())
+            .to_vec()
+            .chunks_exact(std::mem::size_of::<u16>())
             .map(|b| u16::from_ne_bytes(b.try_into().unwrap()))
             .collect();
         let answer: Vec<u16> = vec![2, 3, 5];
@@ -85,7 +87,9 @@ mod tests {
 
         let codec: TestUnboundedCodec = TestUnboundedCodec::new();
 
-        let encoded = codec.encode(bytes, &CodecOptions::default()).unwrap();
+        let encoded = codec
+            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),
             ByteRange::FromStart(10, Some(2)),
@@ -101,16 +105,14 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();
 
         let decoded_partial_chunk: Vec<u16> = decoded_partial_chunk
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .chunks(std::mem::size_of::<u16>())
+            .to_vec()
+            .chunks_exact(std::mem::size_of::<u16>())
             .map(|b| u16::from_ne_bytes(b.try_into().unwrap()))
             .collect();
         let answer: Vec<u16> = vec![2, 3, 5];

--- a/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
+++ b/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     array::{
         codec::{
@@ -52,20 +54,20 @@ impl BytesToBytesCodecTraits for TestUnboundedCodec {
         Ok(RecommendedConcurrency::new_maximum(1))
     }
 
-    fn encode(
+    fn encode<'a>(
         &self,
-        decoded_value: Vec<u8>,
+        decoded_value: Cow<'a, [u8]>,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
         Ok(decoded_value)
     }
 
-    fn decode(
+    fn decode<'a>(
         &self,
-        encoded_value: Vec<u8>,
+        encoded_value: Cow<'a, [u8]>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
+    ) -> Result<Cow<'a, [u8]>, CodecError> {
         Ok(encoded_value)
     }
 

--- a/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
+++ b/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     array::codec::{BytesPartialDecoderTraits, CodecError, CodecOptions},
     byte_range::{extract_byte_ranges, ByteRange},
@@ -23,7 +25,7 @@ impl BytesPartialDecoderTraits for TestUnboundedPartialDecoder<'_> {
         &self,
         decoded_regions: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options)?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
@@ -31,7 +33,10 @@ impl BytesPartialDecoderTraits for TestUnboundedPartialDecoder<'_> {
 
         Ok(Some(
             extract_byte_ranges(&encoded_value, decoded_regions)
-                .map_err(CodecError::InvalidByteRangeError)?,
+                .map_err(CodecError::InvalidByteRangeError)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
         ))
     }
 }
@@ -57,7 +62,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder<'_> {
         &self,
         decoded_regions: &[ByteRange],
         options: &CodecOptions,
-    ) -> Result<Option<Vec<Vec<u8>>>, CodecError> {
+    ) -> Result<Option<Vec<Cow<'_, [u8]>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options).await?;
         let Some(encoded_value) = encoded_value else {
             return Ok(None);
@@ -65,7 +70,10 @@ impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder<'_> {
 
         Ok(Some(
             extract_byte_ranges(&encoded_value, decoded_regions)
-                .map_err(CodecError::InvalidByteRangeError)?,
+                .map_err(CodecError::InvalidByteRangeError)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
         ))
     }
 }

--- a/src/array/codec/bytes_to_bytes/zstd.rs
+++ b/src/array/codec/bytes_to_bytes/zstd.rs
@@ -39,6 +39,8 @@ pub(crate) fn create_codec_zstd(metadata: &MetadataV3) -> Result<Codec, PluginCr
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use crate::{
         array::{
             codec::{BytesToBytesCodecTraits, CodecOptions},
@@ -65,16 +67,12 @@ mod tests {
         let codec = ZstdCodec::new_with_configuration(&configuration);
 
         let encoded = codec
-            .encode(bytes.clone(), &CodecOptions::default())
+            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
             .unwrap();
         let decoded = codec
             .decode(encoded, &bytes_representation, &CodecOptions::default())
             .unwrap();
-        assert_eq!(bytes, decoded);
-
-        // let encoded = codec.par_encode(bytes.clone()).unwrap();
-        // let decoded = codec.par_decode(encoded, &bytes_representation).unwrap();
-        // assert_eq!(bytes, decoded);
+        assert_eq!(bytes, decoded.to_vec());
     }
 
     #[test]
@@ -87,7 +85,9 @@ mod tests {
         let configuration: ZstdCodecConfiguration = serde_json::from_str(JSON_VALID).unwrap();
         let codec = ZstdCodec::new_with_configuration(&configuration);
 
-        let encoded = codec.encode(bytes, &CodecOptions::default()).unwrap();
+        let encoded = codec
+            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),
             ByteRange::FromStart(10, Some(2)),
@@ -102,15 +102,13 @@ mod tests {
             )
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
         let decoded_partial_chunk: Vec<u16> = decoded_partial_chunk
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .chunks(std::mem::size_of::<u16>())
+            .to_vec()
+            .chunks_exact(std::mem::size_of::<u16>())
             .map(|b| u16::from_ne_bytes(b.try_into().unwrap()))
             .collect();
         let answer: Vec<u16> = vec![2, 3, 5];
@@ -128,7 +126,9 @@ mod tests {
         let configuration: ZstdCodecConfiguration = serde_json::from_str(JSON_VALID).unwrap();
         let codec = ZstdCodec::new_with_configuration(&configuration);
 
-        let encoded = codec.encode(bytes, &CodecOptions::default()).unwrap();
+        let encoded = codec
+            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),
             ByteRange::FromStart(10, Some(2)),
@@ -144,16 +144,14 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();
 
         let decoded_partial_chunk: Vec<u16> = decoded_partial_chunk
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .chunks(std::mem::size_of::<u16>())
+            .to_vec()
+            .chunks_exact(std::mem::size_of::<u16>())
             .map(|b| u16::from_ne_bytes(b.try_into().unwrap()))
             .collect();
         let answer: Vec<u16> = vec![2, 3, 5];

--- a/src/group.rs
+++ b/src/group.rs
@@ -627,7 +627,7 @@ mod tests {
     fn group_invalid_metadata() {
         let store: std::sync::Arc<MemoryStore> = std::sync::Arc::new(MemoryStore::new());
         store
-            .set(&StoreKey::new("zarr.json").unwrap(), &[0])
+            .set(&StoreKey::new("zarr.json").unwrap(), vec![0].into())
             .unwrap();
         assert_eq!(
             Group::open(store, "/").unwrap_err().to_string(),

--- a/src/node.rs
+++ b/src/node.rs
@@ -101,7 +101,7 @@ impl Node {
         let key = meta_key(&path);
         let metadata = storage.get(&key).await?;
         let metadata: NodeMetadata = match metadata {
-            Some(metadata) => serde_json::from_slice(metadata.as_slice()).map_err(|e| {
+            Some(metadata) => serde_json::from_slice(&metadata).map_err(|e| {
                 NodeCreateError::StorageError(StorageError::InvalidMetadata(key, e.to_string()))
             })?,
             None => NodeMetadata::Group(GroupMetadataV3::default().into()),

--- a/src/node.rs
+++ b/src/node.rs
@@ -68,7 +68,7 @@ impl Node {
         let key = meta_key(&path);
         let metadata = storage.get(&key)?;
         let metadata: NodeMetadata = match metadata {
-            Some(metadata) => serde_json::from_slice(metadata.as_slice()).map_err(|e| {
+            Some(metadata) => serde_json::from_slice(&metadata).map_err(|e| {
                 NodeCreateError::StorageError(StorageError::InvalidMetadata(key, e.to_string()))
             })?,
             None => NodeMetadata::Group(GroupMetadataV3::default().into()),
@@ -340,7 +340,7 @@ mod tests {
     fn node_invalid_metadata() {
         let store: std::sync::Arc<MemoryStore> = std::sync::Arc::new(MemoryStore::new());
         store
-            .set(&StoreKey::new("node/zarr.json").unwrap(), &[0])
+            .set(&StoreKey::new("node/zarr.json").unwrap(), vec![0].into())
             .unwrap();
         assert_eq!(
             Node::new(&*store, "/node").unwrap_err().to_string(),
@@ -352,7 +352,10 @@ mod tests {
     fn node_invalid_child() {
         let store: std::sync::Arc<MemoryStore> = std::sync::Arc::new(MemoryStore::new());
         store
-            .set(&StoreKey::new("node/array/zarr.json").unwrap(), &[0])
+            .set(
+                &StoreKey::new("node/array/zarr.json").unwrap(),
+                vec![0].into(),
+            )
             .unwrap();
         assert_eq!(
             Node::new(&*store, "/node").unwrap_err().to_string(),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -99,6 +99,8 @@ pub type AsyncReadableListableStorage = Arc<dyn AsyncReadableListableStorageTrai
 /// [`Arc`] wrapped asynchronous readable, writable and listable storage.
 pub type AsyncReadableWritableListableStorage = Arc<dyn AsyncReadableWritableListableStorageTraits>;
 
+/// The type for bytes used in synchronous store set and get methods.
+///
 /// An alias for [`bytes::Bytes`].
 pub type Bytes = bytes::Bytes;
 
@@ -111,6 +113,8 @@ pub type Bytes = bytes::Bytes;
 pub type MaybeBytes = Option<Bytes>;
 
 #[cfg(feature = "async")]
+/// The type for bytes used in asynchronous store set and get methods.
+///
 /// An alias for [`bytes::Bytes`].
 pub type AsyncBytes = bytes::Bytes;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -99,6 +99,24 @@ pub type AsyncReadableListableStorage = Arc<dyn AsyncReadableListableStorageTrai
 /// [`Arc`] wrapped asynchronous readable, writable and listable storage.
 pub type AsyncReadableWritableListableStorage = Arc<dyn AsyncReadableWritableListableStorageTraits>;
 
+/// An alias for bytes which may or may not be available.
+///
+/// When a value is read from a store, it returns `MaybeBytes` which is [`None`] if the key is not available.
+///
+/// A bytes to bytes codec only decodes `MaybeBytes` holding actual bytes, otherwise the bytes are propagated to the next decoder.
+/// An array to bytes partial decoder must take care of converting missing chunks to the fill value.
+pub type MaybeBytes = Option<Vec<u8>>;
+
+#[cfg(feature = "async")]
+/// An alias for [`bytes::Bytes`].
+pub type AsyncBytes = bytes::Bytes;
+
+#[cfg(feature = "async")]
+/// An alias for bytes which may or may not be available.
+///
+/// When a value is read from a store, it returns `MaybeAsyncBytes` which is [`None`] if the key is not available.
+pub type MaybeAsyncBytes = Option<AsyncBytes>;
+
 /// A [`StoreKey`] and [`ByteRange`].
 #[derive(Debug, Clone)]
 pub struct StoreKeyRange {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -99,8 +99,8 @@ pub type AsyncReadableListableStorage = Arc<dyn AsyncReadableListableStorageTrai
 /// [`Arc`] wrapped asynchronous readable, writable and listable storage.
 pub type AsyncReadableWritableListableStorage = Arc<dyn AsyncReadableWritableListableStorageTraits>;
 
-/// An alias for [`Vec<u8>`].
-pub type Bytes = Vec<u8>;
+/// An alias for [`bytes::Bytes`].
+pub type Bytes = bytes::Bytes;
 
 /// An alias for bytes which may or may not be available.
 ///

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -99,13 +99,16 @@ pub type AsyncReadableListableStorage = Arc<dyn AsyncReadableListableStorageTrai
 /// [`Arc`] wrapped asynchronous readable, writable and listable storage.
 pub type AsyncReadableWritableListableStorage = Arc<dyn AsyncReadableWritableListableStorageTraits>;
 
+/// An alias for [`Vec<u8>`].
+pub type Bytes = Vec<u8>;
+
 /// An alias for bytes which may or may not be available.
 ///
 /// When a value is read from a store, it returns `MaybeBytes` which is [`None`] if the key is not available.
 ///
 /// A bytes to bytes codec only decodes `MaybeBytes` holding actual bytes, otherwise the bytes are propagated to the next decoder.
 /// An array to bytes partial decoder must take care of converting missing chunks to the fill value.
-pub type MaybeBytes = Option<Vec<u8>>;
+pub type MaybeBytes = Option<Bytes>;
 
 #[cfg(feature = "async")]
 /// An alias for [`bytes::Bytes`].
@@ -359,7 +362,7 @@ mod tests {
 
         (0..10).into_par_iter().for_each(|i| {
             transformer
-                .set(&StoreKey::new(&i.to_string()).unwrap(), &[i; 5])
+                .set(&StoreKey::new(&i.to_string()).unwrap(), vec![i; 5].into())
                 .unwrap();
         });
 

--- a/src/storage/storage_adapter/zip.rs
+++ b/src/storage/storage_adapter/zip.rs
@@ -356,10 +356,7 @@ mod tests {
             &"/a/b".try_into()?
         )?);
 
-        assert_eq!(
-            store.get(&"a/b".try_into()?)?.unwrap(),
-            Bytes::from(vec![0, 1, 2, 3])
-        );
+        assert_eq!(store.get(&"a/b".try_into()?)?.unwrap(), vec![0, 1, 2, 3]);
         assert_eq!(
             store.get(&"a/c".try_into()?)?.unwrap(),
             Vec::<u8>::new().as_slice()
@@ -413,10 +410,7 @@ mod tests {
             &"/b".try_into()?
         )?);
 
-        assert_eq!(
-            store.get(&"b".try_into()?)?.unwrap(),
-            Bytes::from(vec![0, 1, 2, 3])
-        );
+        assert_eq!(store.get(&"b".try_into()?)?.unwrap(), vec![0, 1, 2, 3]);
         // assert_eq!(store.get(&"c".try_into()?)?, Vec::<u8>::new().as_slice());
 
         Ok(())

--- a/src/storage/storage_adapter/zip.rs
+++ b/src/storage/storage_adapter/zip.rs
@@ -4,7 +4,7 @@ use crate::{
     array::codec::extract_byte_ranges_read,
     byte_range::ByteRange,
     storage::{
-        storage_value_io::StorageValueIO, ListableStorageTraits, ReadableStorageTraits,
+        storage_value_io::StorageValueIO, Bytes, ListableStorageTraits, ReadableStorageTraits,
         StorageError, StoreKey, StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes,
     },
 };
@@ -68,7 +68,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ZipStorageAdapter<TStorage> {
         &self,
         key: &StoreKey,
         byte_ranges: &[ByteRange],
-    ) -> Result<Option<Vec<Vec<u8>>>, StorageError> {
+    ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let mut zip_archive = self.zip_archive.lock();
         let mut zip_name = self.zip_path.clone();
         zip_name.push(key.as_str());
@@ -85,7 +85,10 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ZipStorageAdapter<TStorage> {
         };
         let size = file.size();
 
-        let out = extract_byte_ranges_read(&mut file, size, byte_ranges)?;
+        let out = extract_byte_ranges_read(&mut file, size, byte_ranges)?
+            .into_iter()
+            .map(Bytes::from)
+            .collect();
         Ok(Some(out))
     }
 
@@ -102,7 +105,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
         &self,
         key: &StoreKey,
         byte_ranges: &[ByteRange],
-    ) -> Result<Option<Vec<Vec<u8>>>, StorageError> {
+    ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.get_impl(key, byte_ranges)
     }
 
@@ -271,13 +274,13 @@ mod tests {
         let tmp_path = tempfile::TempDir::new()?;
         let tmp_path = tmp_path.path();
         let store = FilesystemStore::new(tmp_path)?.sorted();
-        store.set(&"a/b".try_into()?, &[0, 1, 2, 3])?;
-        store.set(&"a/c".try_into()?, &[])?;
-        store.set(&"a/d/e".try_into()?, &[])?;
-        store.set(&"a/f/g".try_into()?, &[])?;
-        store.set(&"a/f/h".try_into()?, &[])?;
-        store.set(&"b/c/d".try_into()?, &[])?;
-        store.set(&"c".try_into()?, &[])?;
+        store.set(&"a/b".try_into()?, vec![0, 1, 2, 3].into())?;
+        store.set(&"a/c".try_into()?, vec![].into())?;
+        store.set(&"a/d/e".try_into()?, vec![].into())?;
+        store.set(&"a/f/g".try_into()?, vec![].into())?;
+        store.set(&"a/f/h".try_into()?, vec![].into())?;
+        store.set(&"b/c/d".try_into()?, vec![].into())?;
+        store.set(&"c".try_into()?, vec![].into())?;
 
         let walkdir = WalkDir::new(tmp_path);
 
@@ -353,7 +356,10 @@ mod tests {
             &"/a/b".try_into()?
         )?);
 
-        assert_eq!(store.get(&"a/b".try_into()?)?.unwrap(), &[0, 1, 2, 3]);
+        assert_eq!(
+            store.get(&"a/b".try_into()?)?.unwrap(),
+            Bytes::from(vec![0, 1, 2, 3])
+        );
         assert_eq!(
             store.get(&"a/c".try_into()?)?.unwrap(),
             Vec::<u8>::new().as_slice()
@@ -407,7 +413,10 @@ mod tests {
             &"/b".try_into()?
         )?);
 
-        assert_eq!(store.get(&"b".try_into()?)?.unwrap(), &[0, 1, 2, 3]);
+        assert_eq!(
+            store.get(&"b".try_into()?)?.unwrap(),
+            Bytes::from(vec![0, 1, 2, 3])
+        );
         // assert_eq!(store.get(&"c".try_into()?)?, Vec::<u8>::new().as_slice());
 
         Ok(())

--- a/src/storage/storage_handle.rs
+++ b/src/storage/storage_handle.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
-use crate::{array::MaybeBytes, byte_range::ByteRange};
+use crate::byte_range::ByteRange;
 
 use super::{
-    ListableStorageTraits, ReadableStorageTraits, ReadableWritableStorageTraits, StorageError,
-    StoreKey, StorePrefix, WritableStorageTraits,
+    ListableStorageTraits, MaybeBytes, ReadableStorageTraits, ReadableWritableStorageTraits,
+    StorageError, StoreKey, StorePrefix, WritableStorageTraits,
 };
 
 #[cfg(feature = "async")]
 use super::{
-    AsyncListableStorageTraits, AsyncReadableStorageTraits, AsyncReadableWritableStorageTraits,
-    AsyncWritableStorageTraits,
+    AsyncBytes, AsyncListableStorageTraits, AsyncReadableStorageTraits,
+    AsyncReadableWritableStorageTraits, AsyncWritableStorageTraits, MaybeAsyncBytes,
 };
 
 /// A storage handle.
@@ -117,7 +117,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits> ReadableWritableStorageTr
 impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
     for StorageHandle<TStorage>
 {
-    async fn get(&self, key: &super::StoreKey) -> Result<MaybeBytes, super::StorageError> {
+    async fn get(&self, key: &super::StoreKey) -> Result<MaybeAsyncBytes, super::StorageError> {
         self.0.get(key).await
     }
 
@@ -125,14 +125,14 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
         &self,
         key: &StoreKey,
         byte_ranges: &[ByteRange],
-    ) -> Result<Option<Vec<Vec<u8>>>, StorageError> {
+    ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges).await
     }
 
     async fn get_partial_values(
         &self,
         key_ranges: &[super::StoreKeyRange],
-    ) -> Result<Vec<MaybeBytes>, StorageError> {
+    ) -> Result<Vec<MaybeAsyncBytes>, StorageError> {
         self.0.get_partial_values(key_ranges).await
     }
 
@@ -178,7 +178,7 @@ impl<TStorage: ?Sized + AsyncListableStorageTraits> AsyncListableStorageTraits
 impl<TStorage: ?Sized + AsyncWritableStorageTraits> AsyncWritableStorageTraits
     for StorageHandle<TStorage>
 {
-    async fn set(&self, key: &StoreKey, value: Vec<u8>) -> Result<(), StorageError> {
+    async fn set(&self, key: &StoreKey, value: AsyncBytes) -> Result<(), StorageError> {
         self.0.set(key, value).await
     }
 

--- a/src/storage/storage_handle.rs
+++ b/src/storage/storage_handle.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::byte_range::ByteRange;
 
 use super::{
-    ListableStorageTraits, MaybeBytes, ReadableStorageTraits, ReadableWritableStorageTraits,
+    Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, ReadableWritableStorageTraits,
     StorageError, StoreKey, StorePrefix, WritableStorageTraits,
 };
 
@@ -35,7 +35,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits for Storage
         &self,
         key: &StoreKey,
         byte_ranges: &[ByteRange],
-    ) -> Result<Option<Vec<Vec<u8>>>, StorageError> {
+    ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges)
     }
 
@@ -80,7 +80,7 @@ impl<TStorage: ?Sized + ListableStorageTraits> ListableStorageTraits for Storage
 }
 
 impl<TStorage: ?Sized + WritableStorageTraits> WritableStorageTraits for StorageHandle<TStorage> {
-    fn set(&self, key: &super::StoreKey, value: &[u8]) -> Result<(), super::StorageError> {
+    fn set(&self, key: &super::StoreKey, value: Bytes) -> Result<(), super::StorageError> {
         self.0.set(key, value)
     }
 

--- a/src/storage/storage_sync.rs
+++ b/src/storage/storage_sync.rs
@@ -8,9 +8,9 @@ use crate::{
 };
 
 use super::{
-    data_key, meta_key, meta_key_v2_array, meta_key_v2_attributes, meta_key_v2_group, MaybeBytes,
-    StorageError, StoreKey, StoreKeyRange, StoreKeyStartValue, StoreKeys, StoreKeysPrefixes,
-    StorePrefix, StorePrefixes,
+    data_key, meta_key, meta_key_v2_array, meta_key_v2_attributes, meta_key_v2_group, Bytes,
+    MaybeBytes, StorageError, StoreKey, StoreKeyRange, StoreKeyStartValue, StoreKeys,
+    StoreKeysPrefixes, StorePrefix, StorePrefixes,
 };
 
 /// Readable storage traits.
@@ -37,7 +37,7 @@ pub trait ReadableStorageTraits: Send + Sync {
         &self,
         key: &StoreKey,
         byte_ranges: &[ByteRange],
-    ) -> Result<Option<Vec<Vec<u8>>>, StorageError>;
+    ) -> Result<Option<Vec<Bytes>>, StorageError>;
 
     /// Retrieve partial bytes from a list of [`StoreKeyRange`].
     ///
@@ -172,7 +172,7 @@ pub fn store_set_partial_values<T: ReadableWritableStorageTraits>(
             // let _lock = mutex.lock();
 
             // Read the store key
-            let mut bytes = store.get(&key)?.unwrap_or_default();
+            let mut bytes = store.get(&key)?.unwrap_or_default().to_vec();
 
             // Expand the store key if needed
             let end_max =
@@ -189,7 +189,7 @@ pub fn store_set_partial_values<T: ReadableWritableStorageTraits>(
             }
 
             // Write the store key
-            store.set(&key, &bytes)
+            store.set(&key, bytes.into())
         })?;
     Ok(())
 }
@@ -200,7 +200,7 @@ pub trait WritableStorageTraits: Send + Sync {
     ///
     /// # Errors
     /// Returns a [`StorageError`] on failure to store.
-    fn set(&self, key: &StoreKey, value: &[u8]) -> Result<(), StorageError>;
+    fn set(&self, key: &StoreKey, value: Bytes) -> Result<(), StorageError>;
 
     /// Store bytes according to a list of [`StoreKeyStartValue`].
     ///
@@ -272,7 +272,7 @@ pub fn get_child_nodes<TStorage: ?Sized + ReadableStorageTraits + ListableStorag
         let key = meta_key(&prefix.try_into()?);
         let child_metadata = match storage.get(&key)? {
             Some(child_metadata) => {
-                let metadata: NodeMetadata = serde_json::from_slice(child_metadata.as_slice())
+                let metadata: NodeMetadata = serde_json::from_slice(&child_metadata)
                     .map_err(|err| StorageError::InvalidMetadata(key, err.to_string()))?;
                 metadata
             }
@@ -302,7 +302,7 @@ pub fn create_group(
             let key = meta_key(path);
             let json = serde_json::to_vec_pretty(group)
                 .map_err(|err| StorageError::InvalidMetadata(key.clone(), err.to_string()))?;
-            storage.set(&meta_key(path), &json)
+            storage.set(&meta_key(path), json.into())
         }
         GroupMetadata::V2(group) => {
             let mut group = group.clone();
@@ -312,7 +312,7 @@ pub fn create_group(
                 let key = meta_key_v2_attributes(path);
                 let json = serde_json::to_vec_pretty(&group.attributes)
                     .map_err(|err| StorageError::InvalidMetadata(key.clone(), err.to_string()))?;
-                storage.set(&key, &json)?;
+                storage.set(&key, json.into())?;
 
                 group.attributes = serde_json::Map::default();
             }
@@ -321,7 +321,7 @@ pub fn create_group(
             let key = meta_key_v2_group(path);
             let json = serde_json::to_vec_pretty(&group)
                 .map_err(|err| StorageError::InvalidMetadata(key.clone(), err.to_string()))?;
-            storage.set(&key, &json)?;
+            storage.set(&key, json.into())?;
             Ok(())
         }
     }
@@ -341,7 +341,7 @@ pub fn create_array(
             let key = meta_key(path);
             let json = serde_json::to_vec_pretty(array)
                 .map_err(|err| StorageError::InvalidMetadata(key.clone(), err.to_string()))?;
-            storage.set(&key, &json)
+            storage.set(&key, json.into())
         }
         ArrayMetadata::V2(array) => {
             let mut array = array.clone();
@@ -351,7 +351,7 @@ pub fn create_array(
                 let key = meta_key_v2_attributes(path);
                 let json = serde_json::to_vec_pretty(&array.attributes)
                     .map_err(|err| StorageError::InvalidMetadata(key.clone(), err.to_string()))?;
-                storage.set(&meta_key_v2_attributes(path), &json)?;
+                storage.set(&meta_key_v2_attributes(path), json.into())?;
 
                 array.attributes = serde_json::Map::default();
             }
@@ -360,7 +360,7 @@ pub fn create_array(
             let key = meta_key_v2_array(path);
             let json = serde_json::to_vec_pretty(&array)
                 .map_err(|err| StorageError::InvalidMetadata(key.clone(), err.to_string()))?;
-            storage.set(&key, &json)
+            storage.set(&key, json.into())
         }
     }
 }
@@ -374,7 +374,7 @@ pub fn store_chunk(
     array_path: &NodePath,
     chunk_grid_indices: &[u64],
     chunk_key_encoding: &ChunkKeyEncoding,
-    chunk_serialised: &[u8],
+    chunk_serialised: Bytes,
 ) -> Result<(), StorageError> {
     storage.set(
         &data_key(array_path, chunk_grid_indices, chunk_key_encoding),

--- a/src/storage/storage_sync.rs
+++ b/src/storage/storage_sync.rs
@@ -1,16 +1,16 @@
 use itertools::Itertools;
 
 use crate::{
-    array::{ArrayMetadata, ChunkKeyEncoding, MaybeBytes},
+    array::{ArrayMetadata, ChunkKeyEncoding},
     byte_range::ByteRange,
     group::{GroupMetadata, GroupMetadataV3},
     node::{Node, NodeMetadata, NodePath},
 };
 
 use super::{
-    data_key, meta_key, meta_key_v2_array, meta_key_v2_attributes, meta_key_v2_group, StorageError,
-    StoreKey, StoreKeyRange, StoreKeyStartValue, StoreKeys, StoreKeysPrefixes, StorePrefix,
-    StorePrefixes,
+    data_key, meta_key, meta_key_v2_array, meta_key_v2_attributes, meta_key_v2_group, MaybeBytes,
+    StorageError, StoreKey, StoreKeyRange, StoreKeyStartValue, StoreKeys, StoreKeysPrefixes,
+    StorePrefix, StorePrefixes,
 };
 
 /// Readable storage traits.

--- a/src/storage/store/store_async.rs
+++ b/src/storage/store/store_async.rs
@@ -74,7 +74,10 @@ mod test_util {
     ) -> Result<(), Box<dyn Error>> {
         assert!(store.get(&"notfound".try_into()?).await?.is_none());
         assert!(store.size_key(&"notfound".try_into()?).await?.is_none());
-        assert_eq!(store.get(&"a/b".try_into()?).await?, Some(vec![0, 1, 2]));
+        assert_eq!(
+            store.get(&"a/b".try_into()?).await?,
+            Some(vec![0, 1, 2].into())
+        );
         assert_eq!(store.size_key(&"a/b".try_into()?).await?, Some(3));
         assert_eq!(store.size_key(&"a/c".try_into()?).await?, Some(1));
         assert_eq!(store.size_key(&"i/j/k".try_into()?).await?, Some(2));
@@ -88,7 +91,7 @@ mod test_util {
                     ]
                 )
                 .await?,
-            Some(vec![vec![1], vec![2]])
+            Some(vec![vec![1].into(), vec![2].into()])
         );
         assert_eq!(
             store
@@ -98,7 +101,11 @@ mod test_util {
                     StoreKeyRange::new("i/j/k".try_into()?, ByteRange::FromStart(1, Some(1))),
                 ])
                 .await?,
-            vec![Some(vec![1, 2]), Some(vec![0, 1]), Some(vec![1])]
+            vec![
+                Some(vec![1, 2].into()),
+                Some(vec![0, 1].into()),
+                Some(vec![1].into())
+            ]
         );
         assert!(store
             .get_partial_values(&[StoreKeyRange::new(

--- a/src/storage/store/store_sync.rs
+++ b/src/storage/store/store_sync.rs
@@ -34,25 +34,25 @@ mod test_util {
     pub fn store_write<T: WritableStorageTraits>(store: &T) -> Result<(), Box<dyn Error>> {
         store.erase_prefix(&StorePrefix::root())?;
 
-        store.set(&"a/b".try_into()?, &[0, 0, 0])?;
+        store.set(&"a/b".try_into()?, vec![0, 0, 0].into())?;
         store.set_partial_values(&[StoreKeyStartValue::new("a/b".try_into()?, 1, &[1, 2])])?;
 
-        store.set(&"a/c".try_into()?, &[0])?;
-        store.set(&"a/d/e".try_into()?, &[])?;
-        store.set(&"a/f/g".try_into()?, &[])?;
-        store.set(&"a/f/h".try_into()?, &[])?;
-        store.set(&"i/j/k".try_into()?, &[0, 1])?;
+        store.set(&"a/c".try_into()?, vec![0].into())?;
+        store.set(&"a/d/e".try_into()?, vec![].into())?;
+        store.set(&"a/f/g".try_into()?, vec![].into())?;
+        store.set(&"a/f/h".try_into()?, vec![].into())?;
+        store.set(&"i/j/k".try_into()?, vec![0, 1].into())?;
 
-        store.set(&"erase".try_into()?, &[])?;
+        store.set(&"erase".try_into()?, vec![].into())?;
         store.erase(&"erase".try_into()?)?;
         store.erase(&"erase".try_into()?)?; // succeeds
 
-        store.set(&"erase_values_0".try_into()?, &[])?;
-        store.set(&"erase_values_1".try_into()?, &[])?;
+        store.set(&"erase_values_0".try_into()?, vec![].into())?;
+        store.set(&"erase_values_1".try_into()?, vec![].into())?;
         store.erase_values(&["erase_values_0".try_into()?, "erase_values_1".try_into()?])?;
 
-        store.set(&"erase_prefix/0".try_into()?, &[])?;
-        store.set(&"erase_prefix/1".try_into()?, &[])?;
+        store.set(&"erase_prefix/0".try_into()?, vec![].into())?;
+        store.set(&"erase_prefix/1".try_into()?, vec![].into())?;
         store.erase_prefix(&"erase_prefix/".try_into()?)?;
 
         Ok(())
@@ -63,7 +63,7 @@ mod test_util {
     ) -> Result<(), Box<dyn Error>> {
         assert!(store.get(&"notfound".try_into()?)?.is_none());
         assert!(store.size_key(&"notfound".try_into()?)?.is_none());
-        assert_eq!(store.get(&"a/b".try_into()?)?, Some(vec![0, 1, 2]));
+        assert_eq!(store.get(&"a/b".try_into()?)?, Some(vec![0, 1, 2].into()));
         assert_eq!(store.size_key(&"a/b".try_into()?)?, Some(3));
         assert_eq!(store.size_key(&"a/c".try_into()?)?, Some(1));
         assert_eq!(store.size_key(&"i/j/k".try_into()?)?, Some(2));
@@ -75,7 +75,7 @@ mod test_util {
                     ByteRange::FromEnd(0, Some(1))
                 ]
             )?,
-            Some(vec![vec![1], vec![2]])
+            Some(vec![vec![1].into(), vec![2].into()])
         );
         assert_eq!(
             store.get_partial_values(&[
@@ -83,7 +83,11 @@ mod test_util {
                 StoreKeyRange::new("a/b".try_into()?, ByteRange::FromEnd(1, Some(2))),
                 StoreKeyRange::new("i/j/k".try_into()?, ByteRange::FromStart(1, Some(1))),
             ])?,
-            vec![Some(vec![1, 2]), Some(vec![0, 1]), Some(vec![1])]
+            vec![
+                Some(vec![1, 2].into()),
+                Some(vec![0, 1].into()),
+                Some(vec![1].into())
+            ]
         );
         assert!(store
             .get_partial_values(&[StoreKeyRange::new(

--- a/src/storage/store/store_sync/filesystem_store.rs
+++ b/src/storage/store/store_sync/filesystem_store.rs
@@ -5,7 +5,7 @@
 use crate::{
     byte_range::{ByteOffset, ByteRange},
     storage::{
-        store_set_partial_values, ListableStorageTraits, ReadableStorageTraits,
+        store_set_partial_values, Bytes, ListableStorageTraits, ReadableStorageTraits,
         ReadableWritableStorageTraits, StorageError, StoreKey, StoreKeyError, StoreKeyStartValue,
         StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes, WritableStorageTraits,
     },
@@ -208,7 +208,7 @@ impl ReadableStorageTraits for FilesystemStore {
         &self,
         key: &StoreKey,
         byte_ranges: &[ByteRange],
-    ) -> Result<Option<Vec<Vec<u8>>>, StorageError> {
+    ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let file = self.get_file_mutex(key);
         let _lock = file.read();
 
@@ -249,7 +249,7 @@ impl ReadableStorageTraits for FilesystemStore {
                     }
                 }
             };
-            out.push(bytes);
+            out.push(Bytes::from(bytes));
         }
 
         Ok(Some(out))
@@ -262,11 +262,11 @@ impl ReadableStorageTraits for FilesystemStore {
 }
 
 impl WritableStorageTraits for FilesystemStore {
-    fn set(&self, key: &StoreKey, value: &[u8]) -> Result<(), StorageError> {
+    fn set(&self, key: &StoreKey, value: Bytes) -> Result<(), StorageError> {
         if self.readonly {
             Err(StorageError::ReadOnly)
         } else {
-            Self::set_impl(self, key, value, None, true)
+            Self::set_impl(self, key, &value, None, true)
         }
     }
 

--- a/src/storage/store/store_sync/http_store.rs
+++ b/src/storage/store/store_sync/http_store.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     byte_range::ByteRange,
-    storage::{MaybeBytes, ReadableStorageTraits, StorageError, StoreKey},
+    storage::{Bytes, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey},
 };
 
 use itertools::Itertools;
@@ -91,7 +91,7 @@ impl ReadableStorageTraits for HTTPStore {
         &self,
         key: &StoreKey,
         byte_ranges: &[ByteRange],
-    ) -> Result<Option<Vec<Vec<u8>>>, StorageError> {
+    ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let url = self.key_to_url(key)?;
         let client = reqwest::blocking::Client::new();
         let Some(size) = self.size_key(key)? else {
@@ -119,8 +119,8 @@ impl ReadableStorageTraits for HTTPStore {
                     let mut out = Vec::with_capacity(byte_ranges.len());
                     for byte_range in byte_ranges {
                         let bytes_range =
-                            bytes.split_to(usize::try_from(byte_range.length(size)).unwrap());
-                        out.push(bytes_range.to_vec());
+                            bytes.split_to(usize::try_from(byte_range.length(size)).unwrap()).to_vec();
+                        out.push(bytes_range);
                     }
                     Ok(Some(out))
                 } else {
@@ -136,7 +136,7 @@ impl ReadableStorageTraits for HTTPStore {
                 for byte_range in byte_ranges {
                     let start = usize::try_from(byte_range.start(size)).unwrap();
                     let end = usize::try_from(byte_range.end(size)).unwrap();
-                    out.push(bytes[start..end].to_vec());
+                    out.push(bytes.slice(start..end).to_vec());
                 }
                 Ok(Some(out))
             }

--- a/src/storage/store/store_sync/http_store.rs
+++ b/src/storage/store/store_sync/http_store.rs
@@ -78,7 +78,7 @@ impl ReadableStorageTraits for HTTPStore {
         let client = reqwest::blocking::Client::new();
         let response = client.get(url).send()?;
         match response.status() {
-            StatusCode::OK => Ok(Some(response.bytes()?.to_vec())),
+            StatusCode::OK => Ok(Some(response.bytes()?)),
             StatusCode::NOT_FOUND => Ok(None),
             _ => Err(StorageError::from(format!(
                 "http unexpected status code: {}",
@@ -119,7 +119,7 @@ impl ReadableStorageTraits for HTTPStore {
                     let mut out = Vec::with_capacity(byte_ranges.len());
                     for byte_range in byte_ranges {
                         let bytes_range =
-                            bytes.split_to(usize::try_from(byte_range.length(size)).unwrap()).to_vec();
+                            bytes.split_to(usize::try_from(byte_range.length(size)).unwrap());
                         out.push(bytes_range);
                     }
                     Ok(Some(out))
@@ -136,7 +136,7 @@ impl ReadableStorageTraits for HTTPStore {
                 for byte_range in byte_ranges {
                     let start = usize::try_from(byte_range.start(size)).unwrap();
                     let end = usize::try_from(byte_range.end(size)).unwrap();
-                    out.push(bytes.slice(start..end).to_vec());
+                    out.push(bytes.slice(start..end));
                 }
                 Ok(Some(out))
             }

--- a/src/storage/store/store_sync/http_store.rs
+++ b/src/storage/store/store_sync/http_store.rs
@@ -1,9 +1,8 @@
 //! A synchronous HTTP store.
 
 use crate::{
-    array::MaybeBytes,
     byte_range::ByteRange,
-    storage::{ReadableStorageTraits, StorageError, StoreKey},
+    storage::{MaybeBytes, ReadableStorageTraits, StorageError, StoreKey},
 };
 
 use itertools::Itertools;

--- a/src/storage/store/store_sync/memory_store.rs
+++ b/src/storage/store/store_sync/memory_store.rs
@@ -4,10 +4,9 @@ use parking_lot::RwLock;
 use std::sync::Mutex;
 
 use crate::{
-    array::MaybeBytes,
     byte_range::{ByteOffset, ByteRange, InvalidByteRangeError},
     storage::{
-        store_set_partial_values, ListableStorageTraits, ReadableStorageTraits,
+        store_set_partial_values, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
         ReadableWritableStorageTraits, StorageError, StoreKey, StoreKeyStartValue, StoreKeys,
         StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
     },

--- a/src/storage/store/store_sync/memory_store.rs
+++ b/src/storage/store/store_sync/memory_store.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 use crate::{
     byte_range::{ByteOffset, ByteRange, InvalidByteRangeError},
     storage::{
-        store_set_partial_values, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
+        store_set_partial_values, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
         ReadableWritableStorageTraits, StorageError, StoreKey, StoreKeyStartValue, StoreKeys,
         StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
     },
@@ -81,7 +81,7 @@ impl ReadableStorageTraits for MemoryStore {
             let data = data.clone();
             drop(data_map);
             let data = data.read();
-            Ok(Some(data.clone()))
+            Ok(Some(data.clone().into()))
         } else {
             Ok(None)
         }
@@ -91,7 +91,7 @@ impl ReadableStorageTraits for MemoryStore {
         &self,
         key: &StoreKey,
         byte_ranges: &[ByteRange],
-    ) -> Result<Option<Vec<Vec<u8>>>, StorageError> {
+    ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let data_map = self.data_map.lock().unwrap();
         let data = data_map.get(key);
         if let Some(data) = data {
@@ -106,7 +106,7 @@ impl ReadableStorageTraits for MemoryStore {
                     return Err(InvalidByteRangeError::new(*byte_range, data.len() as u64).into());
                 }
                 let bytes = data[start..end].to_vec();
-                out.push(bytes);
+                out.push(bytes.into());
             }
             Ok(Some(out))
         } else {
@@ -123,8 +123,8 @@ impl ReadableStorageTraits for MemoryStore {
 }
 
 impl WritableStorageTraits for MemoryStore {
-    fn set(&self, key: &StoreKey, value: &[u8]) -> Result<(), StorageError> {
-        Self::set_impl(self, key, value, None, true);
+    fn set(&self, key: &StoreKey, value: Bytes) -> Result<(), StorageError> {
+        Self::set_impl(self, key, &value, None, true);
         Ok(())
     }
 

--- a/src/storage/store/store_sync/opendal.rs
+++ b/src/storage/store/store_sync/opendal.rs
@@ -1,11 +1,10 @@
 use opendal::BlockingOperator;
 
 use crate::{
-    array::MaybeBytes,
     byte_range::{ByteRange, InvalidByteRangeError},
     storage::{
-        ListableStorageTraits, ReadableStorageTraits, ReadableWritableStorageTraits, StorageError,
-        StoreKey, StoreKeyStartValue, StoreKeys, StoreKeysPrefixes, StorePrefix,
+        ListableStorageTraits, MaybeBytes, ReadableStorageTraits, ReadableWritableStorageTraits,
+        StorageError, StoreKey, StoreKeyStartValue, StoreKeys, StoreKeysPrefixes, StorePrefix,
         WritableStorageTraits,
     },
 };

--- a/src/storage/store/store_sync/opendal.rs
+++ b/src/storage/store/store_sync/opendal.rs
@@ -53,7 +53,7 @@ impl ReadableStorageTraits for OpendalStore {
         handle_result(
             self.operator
                 .read(key.as_str())
-                .map(|buf| buf.to_vec() /* FIXME: opendal fast variant */),
+                .map(|buf| buf.to_bytes() /* FIXME: opendal fast variant */),
         )
     }
 
@@ -73,7 +73,7 @@ impl ReadableStorageTraits for OpendalStore {
                     return Err(InvalidByteRangeError::new(*byte_range, size).into());
                 }
                 bytes.push(
-                    reader.read(byte_range_opendal)?.to_vec(), /* FIXME: opendal fast variant */
+                    reader.read(byte_range_opendal)?.to_bytes(), /* FIXME: opendal fast variant */
                 );
             }
             Ok(Some(bytes))

--- a/tests/array_async.rs
+++ b/tests/array_async.rs
@@ -46,9 +46,9 @@ async fn array_async_read(shard: bool) -> Result<(), Box<dyn std::error::Error>>
     // -----|-----
     // 9 10 | 0  0
     // 0  0 | 0  0
-    array.async_store_chunk(&[0, 0], vec![1, 2, 0, 0]).await?;
-    array.async_store_chunk(&[0, 1], vec![3, 4, 7, 8]).await?;
-    array.async_store_array_subset(&ArraySubset::new_with_ranges(&[1..3, 0..2]), vec![5, 6, 9, 10]).await?;
+    array.async_store_chunk(&[0, 0], &[1, 2, 0, 0]).await?;
+    array.async_store_chunk(&[0, 1], &[3, 4, 7, 8]).await?;
+    array.async_store_array_subset(&ArraySubset::new_with_ranges(&[1..3, 0..2]), &[5, 6, 9, 10]).await?;
 
     assert!(array.async_retrieve_chunk(&[0, 0, 0]).await.is_err());
     assert_eq!(array.async_retrieve_chunk(&[0, 0]).await?, [1, 2, 5, 6]);

--- a/tests/array_sync.rs
+++ b/tests/array_sync.rs
@@ -18,9 +18,9 @@ fn array_sync_read(array: Array<MemoryStore>) -> Result<(), Box<dyn std::error::
     // -----|-----
     // 9 10 | 0  0
     // 0  0 | 0  0
-    array.store_chunk(&[0, 0], vec![1, 2, 0, 0])?;
-    array.store_chunk(&[0, 1], vec![3, 4, 7, 8])?;
-    array.store_array_subset(&ArraySubset::new_with_ranges(&[1..3, 0..2]), vec![5, 6, 9, 10])?;
+    array.store_chunk(&[0, 0], &[1, 2, 0, 0])?;
+    array.store_chunk(&[0, 1], &[3, 4, 7, 8])?;
+    array.store_array_subset(&ArraySubset::new_with_ranges(&[1..3, 0..2]), &[5, 6, 9, 10])?;
 
     assert!(array.retrieve_chunk(&[0, 0, 0]).is_err());
     assert_eq!(array.retrieve_chunk(&[0, 0])?, [1, 2, 5, 6]);

--- a/tests/round_trips.rs
+++ b/tests/round_trips.rs
@@ -55,7 +55,10 @@ fn group_metadata_round_trip_memory() -> Result<(), Box<dyn Error>> {
 fn metadata_round_trip_memory() -> Result<(), Box<dyn Error>> {
     let store = MemoryStore::new();
     let metadata_in = include_bytes!("data/array_metadata.json");
-    store.set(&meta_key(&"/group/array".try_into()?), metadata_in)?;
+    store.set(
+        &meta_key(&"/group/array".try_into()?),
+        metadata_in.to_vec().into(),
+    )?;
     let metadata_out = store.get(&meta_key(&"/group/array".try_into()?))?.unwrap();
     assert_eq!(metadata_in.as_slice(), metadata_out);
     Ok(())
@@ -67,7 +70,10 @@ fn metadata_round_trip_filesystem() -> Result<(), Box<dyn Error>> {
     let path = tempfile::TempDir::new()?;
     let store = FilesystemStore::new(path.path())?;
     let metadata_in = include_bytes!("data/array_metadata.json");
-    store.set(&meta_key(&"/group/array".try_into()?), metadata_in)?;
+    store.set(
+        &meta_key(&"/group/array".try_into()?),
+        metadata_in.to_vec().into(),
+    )?;
     let metadata_out = store.get(&meta_key(&"/group/array".try_into()?))?.unwrap();
     assert_eq!(metadata_in.as_slice(), metadata_out);
     Ok(())
@@ -81,7 +87,7 @@ fn filesystem_chunk_round_trip_impl(
     let data_serialised_in: Vec<u8> = vec![0, 1, 2];
     store.set(
         &data_key(&"/group/array".try_into()?, &[0, 0, 0], chunk_key_encoding),
-        &data_serialised_in,
+        data_serialised_in.clone().into(),
     )?;
     let data_serialised_out = store
         .get(&data_key(
@@ -89,7 +95,8 @@ fn filesystem_chunk_round_trip_impl(
             &[0, 0, 0],
             chunk_key_encoding,
         ))?
-        .unwrap();
+        .unwrap()
+        .to_vec();
     assert_eq!(data_serialised_in, data_serialised_out);
     Ok(())
 }


### PR DESCRIPTION
All to save some allocations!

- Change store interfaces to use `bytes::Bytes`
- Change codec encode/decode methods to take `Cow<'_, [u8]>` to improve lazy allocation
- Add fast paths in some codecs
- Other minor optimisations