### PR TITLE
Add partial encoding support (sync only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a `makefile` and simplify `BUILD.md`
 - Add chunk-by-chunk update example in `Array` docs
 - Add `array::copy_fill_value_into()`
+- Add experimental partial encoding support (sync only):
+  - Enables writing shards incrementally
+  - With `{CodecOptions,Config}::experimental_partial_encoding` enabled, `Array::store_{array,chunk}_subset` will use partial encoding
+  - This is an experimental feature for now until it has more comprehensively tested and support is added in the async API
+  - Adds `ArrayPartialEncoderTraits`, `BytesPartialEncoderTraits`, `StoragePartialEncoder`, `ArrayPartialEncoderDefault`, `BytesPartialEncoderDefault`
+  - **Breaking**: Add `{ArrayToArray,ArrayToBytes,BytesToBytes}CodecTraits::partial_encoder`
 
 ### Changed
 - Bump `unsafe_cell_slice` to 0.2.0

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -171,6 +171,7 @@ pub fn chunk_shape_to_array_shape(chunk_shape: &[std::num::NonZeroU64]) -> Array
 ///  - [`ReadableWritableStorageTraits`](crate::storage::ReadableWritableStorageTraits): store operations requiring reading *and* writing
 ///    - [`store_chunk_subset`](Array::store_chunk_subset)
 ///    - [`store_array_subset`](Array::store_array_subset)
+///    - [`partial_encoder`](Array::partial_encoder)
 ///
 /// Many `retrieve` and `store` methods have multiple variants:
 ///   - Standard variants store or retrieve data represented as [`ArrayBytes`] (representing fixed or variable length bytes).

--- a/zarrs/src/array/array_async_readable_writable.rs
+++ b/zarrs/src/array/array_async_readable_writable.rs
@@ -150,6 +150,8 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
             // let mutex = self.storage.mutex(&key).await?;
             // let _lock = mutex.lock();
 
+            // TODO: Add async partial encoding
+
             // Decode the entire chunk
             let chunk_bytes_old = self
                 .async_retrieve_chunk_opt(chunk_indices, options)

--- a/zarrs/src/array/array_sync_readable_writable.rs
+++ b/zarrs/src/array/array_sync_readable_writable.rs
@@ -1,10 +1,20 @@
+use std::sync::Arc;
+
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-use crate::{array::ArrayBytes, array_subset::ArraySubset, storage::ReadableWritableStorageTraits};
+use crate::{
+    array::ArrayBytes,
+    array_subset::ArraySubset,
+    storage::{ReadableWritableStorageTraits, StorageHandle},
+};
 
 use super::{
-    array_bytes::update_array_bytes, codec::options::CodecOptions,
-    concurrency::concurrency_chunks_and_codec, Array, ArrayError, Element,
+    codec::{
+        options::CodecOptions, ArrayPartialEncoderTraits, ArrayToBytesCodecTraits,
+        StoragePartialDecoder, StoragePartialEncoder,
+    },
+    concurrency::concurrency_chunks_and_codec,
+    update_array_bytes, Array, ArrayError, Element,
 };
 
 impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage> {
@@ -180,23 +190,29 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
             // let mutex = self.storage.mutex(&key)?;
             // let _lock = mutex.lock();
 
-            // Decode the entire chunk
-            let chunk_bytes_old = self.retrieve_chunk_opt(chunk_indices, options)?;
-            chunk_bytes_old.validate(chunk_shape.iter().product(), self.data_type().size())?;
+            if options.experimental_partial_encoding() {
+                let partial_encoder = self.partial_encoder(chunk_indices, options)?;
+                Ok(partial_encoder
+                    .partial_encode(&[(chunk_subset, chunk_subset_bytes)], options)?)
+            } else {
+                // Decode the entire chunk
+                let chunk_bytes_old = self.retrieve_chunk_opt(chunk_indices, options)?;
+                chunk_bytes_old.validate(chunk_shape.iter().product(), self.data_type().size())?;
 
-            // Update the chunk
-            let chunk_bytes_new = unsafe {
-                update_array_bytes(
-                    chunk_bytes_old,
-                    &chunk_shape,
-                    chunk_subset,
-                    &chunk_subset_bytes,
-                    self.data_type().size(),
-                )
-            };
+                // Update the chunk
+                let chunk_bytes_new = unsafe {
+                    update_array_bytes(
+                        chunk_bytes_old,
+                        &chunk_shape,
+                        chunk_subset,
+                        &chunk_subset_bytes,
+                        self.data_type().size(),
+                    )
+                };
 
-            // Store the updated chunk
-            self.store_chunk_opt(chunk_indices, chunk_bytes_new, options)
+                // Store the updated chunk
+                self.store_chunk_opt(chunk_indices, chunk_bytes_new, options)
+            }
         }
     }
 
@@ -351,5 +367,43 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         )?;
         let subset_array = super::ndarray_into_vec(subset_array);
         self.store_array_subset_elements_opt(&subset, &subset_array, options)
+    }
+
+    /// Initialises a partial encoder for the chunk at `chunk_indices`.
+    ///
+    /// # Errors
+    /// Returns an [`ArrayError`] if initialisation of the partial encoder fails.
+    pub fn partial_encoder(
+        &self,
+        chunk_indices: &[u64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, ArrayError> {
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
+
+        // Input
+        let storage_transformer_read = self
+            .storage_transformers()
+            .create_readable_transformer(storage_handle.clone())?;
+        let input_handle = Arc::new(StoragePartialDecoder::new(
+            storage_transformer_read,
+            self.chunk_key(chunk_indices),
+        ));
+        let chunk_representation = self.chunk_array_representation(chunk_indices)?;
+
+        // Output
+        let storage_transformer_write = self
+            .storage_transformers()
+            .create_writable_transformer(storage_handle)?;
+        let output_handle = Arc::new(StoragePartialEncoder::new(
+            storage_transformer_write,
+            self.chunk_key(chunk_indices),
+        ));
+
+        Ok(self.codecs.clone().partial_encoder(
+            input_handle,
+            output_handle,
+            &chunk_representation,
+            options,
+        )?)
     }
 }

--- a/zarrs/src/array/codec/array_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/array_partial_encoder_default.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use crate::{
+    array::{array_bytes::update_array_bytes, ArrayBytes, ArraySize, ChunkRepresentation},
+    array_subset::ArraySubset,
+};
+
+use super::{
+    ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+    BytesPartialEncoderTraits,
+};
+
+/// The default array (chunk) partial encoder. Decodes the entire chunk, updates it, and writes the entire chunk.
+pub struct ArrayPartialEncoderDefault {
+    input_handle: Arc<dyn BytesPartialDecoderTraits>,
+    output_handle: Arc<dyn BytesPartialEncoderTraits>,
+    decoded_representation: ChunkRepresentation,
+    codec: Arc<dyn ArrayToBytesCodecTraits>,
+}
+
+impl ArrayPartialEncoderDefault {
+    /// Create a new [`ArrayPartialEncoderDefault`].
+    #[must_use]
+    pub fn new(
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: ChunkRepresentation,
+        codec: Arc<dyn ArrayToBytesCodecTraits>,
+    ) -> Self {
+        Self {
+            input_handle,
+            output_handle,
+            decoded_representation,
+            codec,
+        }
+    }
+}
+
+impl ArrayPartialEncoderTraits for ArrayPartialEncoderDefault {
+    fn erase(&self) -> Result<(), super::CodecError> {
+        self.output_handle.erase()
+    }
+
+    fn partial_encode(
+        &self,
+        subsets_and_bytes: &[(&ArraySubset, ArrayBytes<'_>)],
+        options: &super::CodecOptions,
+    ) -> Result<(), super::CodecError> {
+        // Read the entire chunk
+        let chunk_shape = self.decoded_representation.shape_u64();
+        let chunk_bytes = self.input_handle.decode(options)?;
+
+        // Handle a missing chunk
+        let mut chunk_bytes = if let Some(chunk_bytes) = chunk_bytes {
+            self.codec
+                .decode(chunk_bytes, &self.decoded_representation, options)?
+        } else {
+            let array_size = ArraySize::new(
+                self.decoded_representation.data_type().size(),
+                self.decoded_representation.num_elements(),
+            );
+            ArrayBytes::new_fill_value(array_size, self.decoded_representation.fill_value())
+        };
+
+        // Validate the bytes
+        chunk_bytes.validate(
+            self.decoded_representation.num_elements(),
+            self.decoded_representation.data_type().size(),
+        )?;
+
+        // Update the chunk
+        // TODO: More efficient update for multiple chunk subsets?
+        for (chunk_subset, chunk_subset_bytes) in subsets_and_bytes {
+            chunk_subset_bytes.validate(
+                chunk_subset.num_elements(),
+                self.decoded_representation.data_type().size(),
+            )?;
+
+            chunk_bytes = unsafe {
+                update_array_bytes(
+                    chunk_bytes,
+                    &chunk_shape,
+                    chunk_subset,
+                    chunk_subset_bytes,
+                    self.decoded_representation.data_type().size(),
+                )
+            };
+        }
+
+        let is_fill_value = !options.store_empty_chunks()
+            && chunk_bytes.is_fill_value(self.decoded_representation.fill_value());
+        if is_fill_value {
+            self.output_handle.erase()
+        } else {
+            // Store the updated chunk
+            let chunk_bytes =
+                self.codec
+                    .encode(chunk_bytes, &self.decoded_representation, options)?;
+            self.output_handle
+                .partial_encode(&[(0, chunk_bytes)], options)
+        }
+    }
+}

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -4,7 +4,8 @@ use crate::{
     array::{
         codec::{
             options::CodecOptions, ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits,
-            ArrayToArrayCodecTraits, CodecError, CodecTraits, RecommendedConcurrency,
+            ArrayPartialEncoderTraits, ArrayToArrayCodecTraits, ArrayToArrayPartialEncoderDefault,
+            CodecError, CodecTraits, RecommendedConcurrency,
         },
         ArrayMetadataOptions, ChunkRepresentation, ChunkShape, DataType,
     },
@@ -128,6 +129,21 @@ impl ArrayToArrayCodecTraits for BitroundCodec {
                 self.keepbits,
             )?,
         ))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
+        output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+        decoded_representation: &ChunkRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(ArrayToArrayPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            decoded_representation.clone(),
+            self,
+        )))
     }
 
     #[cfg(feature = "async")]

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
@@ -4,7 +4,8 @@ use crate::{
     array::{
         codec::{
             options::CodecOptions, ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits,
-            ArrayToArrayCodecTraits, CodecError, CodecTraits, RecommendedConcurrency,
+            ArrayPartialEncoderTraits, ArrayToArrayCodecTraits, ArrayToArrayPartialEncoderDefault,
+            CodecError, CodecTraits, RecommendedConcurrency,
         },
         ArrayMetadataOptions, ChunkRepresentation, ChunkShape,
     },
@@ -194,6 +195,21 @@ impl ArrayToArrayCodecTraits for TransposeCodec {
                 self.order.clone(),
             ),
         ))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
+        output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+        decoded_representation: &ChunkRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(ArrayToArrayPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            decoded_representation.clone(),
+            self,
+        )))
     }
 
     fn compute_encoded_size(

--- a/zarrs/src/array/codec/array_to_array_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/array_to_array_partial_encoder_default.rs
@@ -1,0 +1,113 @@
+use std::sync::Arc;
+
+use crate::{
+    array::{array_bytes::update_array_bytes, ArrayBytes, ChunkRepresentation},
+    array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
+};
+
+use super::{
+    ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, ArrayToArrayCodecTraits, CodecError,
+};
+
+/// The default array (chunk) partial encoder. Decodes the entire chunk, updates it, and writes the entire chunk.
+pub struct ArrayToArrayPartialEncoderDefault {
+    input_handle: Arc<dyn ArrayPartialDecoderTraits>,
+    output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+    decoded_representation: ChunkRepresentation,
+    codec: Arc<dyn ArrayToArrayCodecTraits>,
+}
+
+impl ArrayToArrayPartialEncoderDefault {
+    /// Create a new [`ArrayToArrayPartialEncoderDefault`].
+    #[must_use]
+    pub fn new(
+        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
+        output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+        decoded_representation: ChunkRepresentation,
+        codec: Arc<dyn ArrayToArrayCodecTraits>,
+    ) -> Self {
+        Self {
+            input_handle,
+            output_handle,
+            decoded_representation,
+            codec,
+        }
+    }
+}
+
+impl ArrayPartialEncoderTraits for ArrayToArrayPartialEncoderDefault {
+    fn erase(&self) -> Result<(), super::CodecError> {
+        self.output_handle.erase()
+    }
+
+    fn partial_encode(
+        &self,
+        subsets_and_bytes: &[(&ArraySubset, ArrayBytes<'_>)],
+        options: &super::CodecOptions,
+    ) -> Result<(), super::CodecError> {
+        // Read the entire chunk
+        let chunk_shape = self.decoded_representation.shape_u64();
+        let array_subset_all = ArraySubset::new_with_shape(chunk_shape.clone());
+        let encoded_value = self
+            .input_handle
+            .partial_decode(&[array_subset_all.clone()], options)?
+            .pop()
+            .unwrap();
+        let mut decoded_value =
+            self.codec
+                .decode(encoded_value, &self.decoded_representation, options)?;
+
+        // Validate the bytes
+        decoded_value.validate(
+            self.decoded_representation.num_elements(),
+            self.decoded_representation.data_type().size(),
+        )?;
+
+        // Update the chunk
+        // TODO: More efficient update for multiple chunk subsets?
+        for (chunk_subset, chunk_subset_bytes) in subsets_and_bytes {
+            // Check the subset is within the chunk shape
+            if chunk_subset
+                .end_exc()
+                .iter()
+                .zip(self.decoded_representation.shape())
+                .any(|(a, b)| *a > b.get())
+            {
+                return Err(CodecError::InvalidArraySubsetError(
+                    IncompatibleArraySubsetAndShapeError::new(
+                        (*chunk_subset).clone(),
+                        self.decoded_representation.shape_u64(),
+                    ),
+                ));
+            }
+
+            chunk_subset_bytes.validate(
+                chunk_subset.num_elements(),
+                self.decoded_representation.data_type().size(),
+            )?;
+
+            decoded_value = unsafe {
+                update_array_bytes(
+                    decoded_value,
+                    &chunk_shape,
+                    chunk_subset,
+                    chunk_subset_bytes,
+                    self.decoded_representation.data_type().size(),
+                )
+            };
+        }
+
+        let is_fill_value = !options.store_empty_chunks()
+            && decoded_value.is_fill_value(self.decoded_representation.fill_value());
+        if is_fill_value {
+            self.output_handle.erase()
+        } else {
+            // Store the updated chunk
+            let encoded_value =
+                self.codec
+                    .encode(decoded_value, &self.decoded_representation, options)?;
+            self.output_handle
+                .partial_encode(&[(&array_subset_all, encoded_value)], options)
+        }
+    }
+}

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 use crate::{
     array::{
         codec::{
-            ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-            BytesPartialDecoderTraits, CodecError, CodecOptions, CodecTraits,
+            ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderDefault,
+            ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+            BytesPartialEncoderTraits, CodecError, CodecOptions, CodecTraits,
             RecommendedConcurrency,
         },
         ArrayBytes, ArrayMetadataOptions, BytesRepresentation, ChunkRepresentation, DataTypeSize,
@@ -181,6 +182,21 @@ impl ArrayToBytesCodecTraits for BytesCodec {
             input_handle,
             decoded_representation.clone(),
             self.endian,
+        )))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &ChunkRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(ArrayPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            decoded_representation.clone(),
+            self,
         )))
     }
 

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
@@ -5,8 +5,9 @@ use pco::{standalone::guarantee::file_size, ChunkConfig, ModeSpec, PagingSpec};
 use crate::{
     array::{
         codec::{
-            ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-            BytesPartialDecoderTraits, CodecError, CodecOptions, CodecTraits, RawBytes,
+            ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderDefault,
+            ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+            BytesPartialEncoderTraits, CodecError, CodecOptions, CodecTraits, RawBytes,
             RecommendedConcurrency,
         },
         convert_from_bytes_slice, transmute_to_bytes_vec, ArrayMetadataOptions,
@@ -240,6 +241,21 @@ impl ArrayToBytesCodecTraits for PcodecCodec {
         Ok(Arc::new(pcodec_partial_decoder::PcodecPartialDecoder::new(
             input_handle,
             decoded_representation.clone(),
+        )))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &ChunkRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(ArrayPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            decoded_representation.clone(),
+            self,
         )))
     }
 

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -13,6 +13,7 @@
 mod sharding_codec;
 mod sharding_codec_builder;
 mod sharding_partial_decoder;
+mod sharding_partial_encoder;
 
 use std::{borrow::Cow, num::NonZeroU64, sync::Arc};
 

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -1,0 +1,286 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::{Arc, Mutex},
+};
+
+use itertools::Itertools;
+
+use crate::{
+    array::{
+        array_bytes::update_array_bytes,
+        chunk_grid::{ChunkGridTraits, RegularChunkGrid},
+        codec::{
+            array_to_bytes::sharding::{calculate_chunks_per_shard, compute_index_encoded_size},
+            ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+            BytesPartialEncoderTraits, CodecError, CodecOptions,
+        },
+        ravel_indices, transmute_to_bytes, ArrayBytes, ArraySize, ChunkRepresentation, ChunkShape,
+        CodecChain, RawBytes,
+    },
+    array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
+    byte_range::ByteRange,
+};
+
+use super::{sharding_index_decoded_representation, ShardingIndexLocation};
+
+pub struct ShardingPartialEncoder {
+    input_handle: Arc<dyn BytesPartialDecoderTraits>,
+    output_handle: Arc<dyn BytesPartialEncoderTraits>,
+    decoded_representation: ChunkRepresentation,
+    chunk_grid: RegularChunkGrid,
+    inner_codecs: Arc<CodecChain>,
+    index_codecs: Arc<CodecChain>,
+    index_location: ShardingIndexLocation,
+    index_decoded_representation: ChunkRepresentation,
+    inner_chunk_representation: ChunkRepresentation,
+    shard_index: Arc<Mutex<Vec<u64>>>,
+}
+
+impl ShardingPartialEncoder {
+    /// Create a new partial encoder for the sharding codec.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: ChunkRepresentation,
+        chunk_shape: ChunkShape,
+        inner_codecs: Arc<CodecChain>,
+        index_codecs: Arc<CodecChain>,
+        index_location: ShardingIndexLocation,
+        options: &CodecOptions,
+    ) -> Result<Self, CodecError> {
+        let chunks_per_shard =
+            &calculate_chunks_per_shard(decoded_representation.shape(), &chunk_shape)?;
+        let index_decoded_representation =
+            sharding_index_decoded_representation(chunks_per_shard.as_slice());
+        let inner_chunk_representation = ChunkRepresentation::new(
+            chunk_shape.to_vec(),
+            decoded_representation.data_type().clone(),
+            decoded_representation.fill_value().clone(),
+        )
+        .map_err(|_| CodecError::Other("Fill value and data type are incompatible?".to_string()))?;
+
+        // Decode the index
+        let shard_index = super::decode_shard_index_partial_decoder(
+            &*input_handle,
+            &index_codecs,
+            index_location,
+            inner_chunk_representation.shape(),
+            &decoded_representation,
+            options,
+        )?
+        .unwrap_or_else(|| {
+            let num_chunks =
+                usize::try_from(chunks_per_shard.iter().map(|x| x.get()).product::<u64>()).unwrap();
+            vec![u64::MAX; num_chunks * 2]
+        });
+
+        Ok(Self {
+            input_handle,
+            output_handle,
+            decoded_representation,
+            chunk_grid: RegularChunkGrid::new(chunk_shape),
+            inner_codecs,
+            index_codecs,
+            index_location,
+            index_decoded_representation,
+            inner_chunk_representation,
+            shard_index: Arc::new(Mutex::new(shard_index)),
+        })
+    }
+}
+
+impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
+    fn erase(&self) -> Result<(), super::CodecError> {
+        self.output_handle.erase()
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn partial_encode(
+        &self,
+        subsets_and_bytes: &[(&ArraySubset, ArrayBytes<'_>)],
+        options: &super::CodecOptions,
+    ) -> Result<(), super::CodecError> {
+        let mut shard_index = self.shard_index.lock().unwrap();
+
+        let chunks_per_shard = calculate_chunks_per_shard(
+            self.decoded_representation.shape(),
+            self.inner_chunk_representation.shape(),
+        )?;
+        let chunks_per_shard = chunks_per_shard.to_array_shape();
+
+        // Get the maximum offset of existing encoded chunks
+        let max_data_offset = shard_index
+            .iter()
+            .tuples()
+            .map(|(&offset, &size)| {
+                if offset == u64::MAX && size == u64::MAX {
+                    0
+                } else {
+                    offset + size
+                }
+            })
+            .max()
+            .expect("shards cannot be empty");
+
+        let mut updated_inner_chunks = HashMap::<u64, ArrayBytes>::new();
+        for (chunk_subset, chunk_subset_bytes) in subsets_and_bytes {
+            // Check the subset is within the chunk shape
+            if chunk_subset
+                .end_exc()
+                .iter()
+                .zip(self.decoded_representation.shape())
+                .any(|(a, b)| *a > b.get())
+            {
+                return Err(CodecError::InvalidArraySubsetError(
+                    IncompatibleArraySubsetAndShapeError::new(
+                        (*chunk_subset).clone(),
+                        self.decoded_representation.shape_u64(),
+                    ),
+                ));
+            }
+
+            let inner_chunks = self
+                .chunk_grid
+                .chunks_in_array_subset(chunk_subset, &chunks_per_shard)
+                .map_err(|_| {
+                    CodecError::InvalidArraySubsetError(IncompatibleArraySubsetAndShapeError::new(
+                        (*chunk_subset).clone(),
+                        chunks_per_shard.clone(),
+                    ))
+                })?
+                .ok_or_else(|| {
+                    CodecError::Other(
+                        "Cannot determine the inner chunk of a chunk subset".to_string(),
+                    )
+                })?;
+
+            let inner_chunk_fill_value = || {
+                let array_size = ArraySize::new(
+                    self.inner_chunk_representation.data_type().size(),
+                    self.inner_chunk_representation.num_elements(),
+                );
+                ArrayBytes::new_fill_value(array_size, self.inner_chunk_representation.fill_value())
+            };
+
+            for inner_chunk_indices in &inner_chunks.indices() {
+                let inner_chunk_index = ravel_indices(&inner_chunk_indices, &chunks_per_shard);
+                // Decode the inner chunk (if needed)
+                if let Entry::Vacant(entry) = updated_inner_chunks.entry(inner_chunk_index) {
+                    let inner_chunk_index_usize = usize::try_from(inner_chunk_index).unwrap();
+
+                    // Get the offset/size of the chunk and temporarily remove it from the shard index
+                    let offset = shard_index[inner_chunk_index_usize * 2];
+                    let size = shard_index[inner_chunk_index_usize * 2 + 1];
+                    shard_index[inner_chunk_index_usize * 2] = u64::MAX;
+                    shard_index[inner_chunk_index_usize * 2 + 1] = u64::MAX;
+
+                    let inner_chunk_decoded = if offset == u64::MAX && size == u64::MAX {
+                        inner_chunk_fill_value()
+                    } else {
+                        let inner_chunk_encoded = self
+                            .input_handle
+                            .partial_decode(&[ByteRange::FromStart(offset, Some(size))], options)?
+                            .map(|mut bytes| bytes.pop().unwrap());
+                        if let Some(inner_chunk_encoded) = inner_chunk_encoded {
+                            self.inner_codecs.decode(
+                                inner_chunk_encoded,
+                                &self.inner_chunk_representation,
+                                options,
+                            )?
+                        } else {
+                            inner_chunk_fill_value()
+                        }
+                    };
+                    entry.insert(inner_chunk_decoded);
+                }
+
+                let inner_chunk_decoded = updated_inner_chunks.get_mut(&inner_chunk_index).unwrap();
+
+                // Update the inner chunk
+                let inner_chunk_subset = self
+                    .chunk_grid
+                    .subset(&inner_chunk_indices, &chunks_per_shard)
+                    .expect("already validated")
+                    .expect("regular grid");
+                let inner_chunk_subset_overlap = chunk_subset.overlap(&inner_chunk_subset).unwrap();
+
+                let inner_chunk_bytes = chunk_subset_bytes.extract_array_subset(
+                    &inner_chunk_subset_overlap
+                        .relative_to(chunk_subset.start())
+                        .unwrap(),
+                    chunk_subset.shape(),
+                    self.inner_chunk_representation.data_type(),
+                )?;
+
+                *inner_chunk_decoded = unsafe {
+                    update_array_bytes(
+                        inner_chunk_decoded.clone(),
+                        &self.inner_chunk_representation.shape_u64(),
+                        &inner_chunk_subset_overlap
+                            .relative_to(inner_chunk_subset.start())
+                            .unwrap(),
+                        &inner_chunk_bytes,
+                        self.inner_chunk_representation.data_type().size(),
+                    )
+                };
+            }
+        }
+
+        // Get the offset for new data
+        let index_encoded_size = compute_index_encoded_size(
+            self.index_codecs.as_ref(),
+            &self.index_decoded_representation,
+        )?;
+        let mut offset_append = match self.index_location {
+            ShardingIndexLocation::Start => max_data_offset.max(index_encoded_size),
+            ShardingIndexLocation::End => max_data_offset,
+        };
+
+        // Write the updated chunks
+        for (inner_chunk_index, inner_chunk_decoded) in updated_inner_chunks {
+            if inner_chunk_decoded.is_fill_value(self.inner_chunk_representation.fill_value()) {
+                shard_index[usize::try_from(inner_chunk_index * 2).unwrap()] = u64::MAX;
+                shard_index[usize::try_from(inner_chunk_index * 2 + 1).unwrap()] = u64::MAX;
+            } else {
+                let inner_chunk_encoded = self.inner_codecs.encode(
+                    inner_chunk_decoded,
+                    &self.inner_chunk_representation,
+                    options,
+                )?;
+                let len = inner_chunk_encoded.len() as u64;
+                self.output_handle
+                    .partial_encode(&[(offset_append, inner_chunk_encoded)], options)?;
+
+                shard_index[usize::try_from(inner_chunk_index * 2).unwrap()] = offset_append;
+                shard_index[usize::try_from(inner_chunk_index * 2 + 1).unwrap()] = len;
+                offset_append += len;
+            }
+        }
+
+        if shard_index.iter().all(|&x| x == u64::MAX) {
+            self.output_handle.erase()?;
+        } else {
+            // Write the updated shard index
+            let shard_index_bytes: RawBytes = transmute_to_bytes(shard_index.as_slice()).into();
+            let encoded_array_index = self.index_codecs.encode(
+                shard_index_bytes.into(),
+                &self.index_decoded_representation,
+                options,
+            )?;
+            {
+                match self.index_location {
+                    ShardingIndexLocation::Start => {
+                        self.output_handle
+                            .partial_encode(&[(0, encoded_array_index)], options)?;
+                    }
+                    ShardingIndexLocation::End => {
+                        self.output_handle
+                            .partial_encode(&[(offset_append, encoded_array_index)], options)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
@@ -3,9 +3,10 @@ use std::{mem::size_of, num::NonZeroU64, sync::Arc};
 use crate::{
     array::{
         codec::{
-            ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, BytesCodec,
-            BytesPartialDecoderTraits, CodecError, CodecOptions, CodecTraits,
-            RecommendedConcurrency,
+            ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderDefault,
+            ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesCodec,
+            BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError, CodecOptions,
+            CodecTraits, RecommendedConcurrency,
         },
         transmute_to_bytes_vec, ArrayBytes, ArrayMetadataOptions, BytesRepresentation,
         ChunkRepresentation, CodecChain, DataType, DataTypeSize, Endianness, FillValue, RawBytes,
@@ -286,6 +287,21 @@ impl ArrayToBytesCodecTraits for VlenCodec {
             self.index_codecs.clone(),
             self.data_codecs.clone(),
             self.index_data_type,
+        )))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &ChunkRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(ArrayPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            decoded_representation.clone(),
+            self,
         )))
     }
 

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
@@ -5,8 +5,9 @@ use itertools::Itertools;
 use crate::{
     array::{
         codec::{
-            ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-            BytesPartialDecoderTraits, CodecError, CodecOptions, CodecTraits,
+            ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderDefault,
+            ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+            BytesPartialEncoderTraits, CodecError, CodecOptions, CodecTraits,
             RecommendedConcurrency,
         },
         ArrayBytes, ArrayMetadataOptions, BytesRepresentation, ChunkRepresentation, DataTypeSize,
@@ -134,6 +135,21 @@ impl ArrayToBytesCodecTraits for VlenV2Codec {
                 decoded_representation.clone(),
             ),
         ))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &ChunkRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(ArrayPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            decoded_representation.clone(),
+            self,
+        )))
     }
 
     #[cfg(feature = "async")]

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -12,8 +12,9 @@ use zfp_sys::{
 use crate::{
     array::{
         codec::{
-            ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-            BytesPartialDecoderTraits, CodecError, CodecOptions, CodecTraits, RawBytes,
+            ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderDefault,
+            ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+            BytesPartialEncoderTraits, CodecError, CodecOptions, CodecTraits, RawBytes,
             RecommendedConcurrency,
         },
         ArrayMetadataOptions, BytesRepresentation, ChunkRepresentation, DataType,
@@ -254,6 +255,21 @@ impl ArrayToBytesCodecTraits for ZfpCodec {
             self.mode,
             self.write_header,
         )?))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &ChunkRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(ArrayPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            decoded_representation.clone(),
+            self,
+        )))
     }
 
     #[cfg(feature = "async")]

--- a/zarrs/src/array/codec/bytes_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/bytes_partial_encoder_default.rs
@@ -1,0 +1,80 @@
+use std::{borrow::Cow, sync::Arc};
+
+use zarrs_storage::byte_range::ByteOffset;
+
+use crate::array::BytesRepresentation;
+
+use super::{BytesPartialDecoderTraits, BytesPartialEncoderTraits, BytesToBytesCodecTraits};
+
+/// The default array (chunk) partial encoder. Decodes the entire chunk, updates it, and writes the entire chunk.
+pub struct BytesPartialEncoderDefault {
+    input_handle: Arc<dyn BytesPartialDecoderTraits>,
+    output_handle: Arc<dyn BytesPartialEncoderTraits>,
+    decoded_representation: BytesRepresentation,
+    codec: Arc<dyn BytesToBytesCodecTraits>,
+}
+
+impl BytesPartialEncoderDefault {
+    /// Create a new [`BytesPartialEncoderDefault`].
+    #[must_use]
+    pub fn new(
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: BytesRepresentation,
+        codec: Arc<dyn BytesToBytesCodecTraits>,
+    ) -> Self {
+        Self {
+            input_handle,
+            output_handle,
+            decoded_representation,
+            codec,
+        }
+    }
+}
+
+impl BytesPartialEncoderTraits for BytesPartialEncoderDefault {
+    fn erase(&self) -> Result<(), super::CodecError> {
+        self.output_handle.erase()
+    }
+
+    fn partial_encode(
+        &self,
+        offsets_and_bytes: &[(ByteOffset, crate::array::RawBytes<'_>)],
+        options: &super::CodecOptions,
+    ) -> Result<(), super::CodecError> {
+        let encoded_value = self.input_handle.decode(options)?.map(Cow::into_owned);
+
+        let mut decoded_value = if let Some(encoded_value) = encoded_value {
+            self.codec
+                .decode(
+                    Cow::Owned(encoded_value),
+                    &self.decoded_representation,
+                    options,
+                )?
+                .into_owned()
+        } else {
+            vec![]
+        };
+
+        // The decoded value must be resized to the maximum byte range end
+        let decoded_value_len = offsets_and_bytes
+            .iter()
+            .map(|(offset, bytes)| usize::try_from(offset + bytes.len() as u64).unwrap())
+            .max()
+            .unwrap();
+        decoded_value.resize(decoded_value_len, 0);
+
+        for (offset, bytes) in offsets_and_bytes {
+            let start = usize::try_from(*offset).unwrap();
+            decoded_value[start..start + bytes.len()].copy_from_slice(bytes);
+        }
+
+        let bytes_encoded = self
+            .codec
+            .encode(Cow::Owned(decoded_value), options)?
+            .into_owned();
+
+        self.output_handle
+            .partial_encode(&[(0, Cow::Owned(bytes_encoded))], options)
+    }
+}

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_codec.rs
@@ -5,8 +5,8 @@ use blosc_sys::{blosc_get_complib_info, BLOSC_MAX_OVERHEAD};
 use crate::{
     array::{
         codec::{
-            BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecError, CodecOptions,
-            CodecTraits, RecommendedConcurrency,
+            BytesPartialDecoderTraits, BytesPartialEncoderDefault, BytesPartialEncoderTraits,
+            BytesToBytesCodecTraits, CodecError, CodecOptions, CodecTraits, RecommendedConcurrency,
         },
         ArrayMetadataOptions, BytesRepresentation, RawBytes,
     },
@@ -208,6 +208,21 @@ impl BytesToBytesCodecTraits for BloscCodec {
     ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(blosc_partial_decoder::BloscPartialDecoder::new(
             input_handle,
+        )))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &BytesRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn BytesPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(BytesPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            *decoded_representation,
+            self,
         )))
     }
 

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2/bz2_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2/bz2_codec.rs
@@ -7,8 +7,8 @@ use std::{
 use crate::{
     array::{
         codec::{
-            BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecError, CodecOptions,
-            CodecTraits, RecommendedConcurrency,
+            BytesPartialDecoderTraits, BytesPartialEncoderDefault, BytesPartialEncoderTraits,
+            BytesToBytesCodecTraits, CodecError, CodecOptions, CodecTraits, RecommendedConcurrency,
         },
         ArrayMetadataOptions, BytesRepresentation, RawBytes,
     },
@@ -117,6 +117,21 @@ impl BytesToBytesCodecTraits for Bz2Codec {
     ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(bz2_partial_decoder::Bz2PartialDecoder::new(
             input_handle,
+        )))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &BytesRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn BytesPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(BytesPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            *decoded_representation,
+            self,
         )))
     }
 

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_codec.rs
@@ -3,8 +3,8 @@ use std::{borrow::Cow, sync::Arc};
 use crate::{
     array::{
         codec::{
-            BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecError, CodecOptions,
-            CodecTraits, RecommendedConcurrency,
+            BytesPartialDecoderTraits, BytesPartialEncoderDefault, BytesPartialEncoderTraits,
+            BytesToBytesCodecTraits, CodecError, CodecOptions, CodecTraits, RecommendedConcurrency,
         },
         ArrayMetadataOptions, BytesRepresentation, RawBytes,
     },
@@ -108,6 +108,21 @@ impl BytesToBytesCodecTraits for Crc32cCodec {
     ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(crc32c_partial_decoder::Crc32cPartialDecoder::new(
             input_handle,
+        )))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &BytesRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn BytesPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(BytesPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            *decoded_representation,
+            self,
         )))
     }
 

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate/gdeflate_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate/gdeflate_codec.rs
@@ -4,8 +4,8 @@ use std::{borrow::Cow, sync::Arc};
 use crate::{
     array::{
         codec::{
-            BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecError, CodecOptions,
-            CodecTraits,
+            BytesPartialDecoderTraits, BytesPartialEncoderDefault, BytesPartialEncoderTraits,
+            BytesToBytesCodecTraits, CodecError, CodecOptions, CodecTraits,
         },
         ArrayMetadataOptions, BytesRepresentation, RawBytes, RecommendedConcurrency,
     },
@@ -127,6 +127,21 @@ impl BytesToBytesCodecTraits for GDeflateCodec {
         Ok(Arc::new(
             gdeflate_partial_decoder::GDeflatePartialDecoder::new(r),
         ))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &BytesRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn BytesPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(BytesPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            *decoded_representation,
+            self,
+        )))
     }
 
     #[cfg(feature = "async")]

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
@@ -9,8 +9,8 @@ use flate2::bufread::{GzDecoder, GzEncoder};
 use crate::{
     array::{
         codec::{
-            BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecError, CodecOptions,
-            CodecTraits, RecommendedConcurrency,
+            BytesPartialDecoderTraits, BytesPartialEncoderDefault, BytesPartialEncoderTraits,
+            BytesToBytesCodecTraits, CodecError, CodecOptions, CodecTraits, RecommendedConcurrency,
         },
         ArrayMetadataOptions, BytesRepresentation, RawBytes,
     },
@@ -114,6 +114,21 @@ impl BytesToBytesCodecTraits for GzipCodec {
         _options: &CodecOptions,
     ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(gzip_partial_decoder::GzipPartialDecoder::new(r)))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &BytesRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn BytesPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(BytesPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            *decoded_representation,
+            self,
+        )))
     }
 
     #[cfg(feature = "async")]

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use crate::{
     array::{
         codec::{
-            BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecError, CodecOptions,
-            CodecTraits, RecommendedConcurrency,
+            BytesPartialDecoderTraits, BytesPartialEncoderDefault, BytesPartialEncoderTraits,
+            BytesToBytesCodecTraits, CodecError, CodecOptions, CodecTraits, RecommendedConcurrency,
         },
         ArrayMetadataOptions, BytesRepresentation, RawBytes,
     },
@@ -84,6 +84,21 @@ impl BytesToBytesCodecTraits for TestUnboundedCodec {
         Ok(Arc::new(
             test_unbounded_partial_decoder::TestUnboundedPartialDecoder::new(r),
         ))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &BytesRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn BytesPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(BytesPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            decoded_representation.clone(),
+            self,
+        )))
     }
 
     #[cfg(feature = "async")]

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd/zstd_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd/zstd_codec.rs
@@ -5,8 +5,8 @@ use zstd::zstd_safe;
 use crate::{
     array::{
         codec::{
-            BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecError, CodecOptions,
-            CodecTraits, RecommendedConcurrency,
+            BytesPartialDecoderTraits, BytesPartialEncoderDefault, BytesPartialEncoderTraits,
+            BytesToBytesCodecTraits, CodecError, CodecOptions, CodecTraits, RecommendedConcurrency,
         },
         ArrayMetadataOptions, BytesRepresentation, RawBytes,
     },
@@ -113,6 +113,21 @@ impl BytesToBytesCodecTraits for ZstdCodec {
         _options: &CodecOptions,
     ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(zstd_partial_decoder::ZstdPartialDecoder::new(r)))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        decoded_representation: &BytesRepresentation,
+        _options: &CodecOptions,
+    ) -> Result<Arc<dyn BytesPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(BytesPartialEncoderDefault::new(
+            input_handle,
+            output_handle,
+            *decoded_representation,
+            self,
+        )))
     }
 
     #[cfg(feature = "async")]

--- a/zarrs/src/array/codec/options.rs
+++ b/zarrs/src/array/codec/options.rs
@@ -10,6 +10,7 @@ pub struct CodecOptions {
     validate_checksums: bool,
     store_empty_chunks: bool,
     concurrent_target: usize,
+    experimental_partial_encoding: bool,
 }
 
 impl Default for CodecOptions {
@@ -18,6 +19,7 @@ impl Default for CodecOptions {
             validate_checksums: global_config().validate_checksums(),
             store_empty_chunks: global_config().store_empty_chunks(),
             concurrent_target: global_config().codec_concurrent_target(),
+            experimental_partial_encoding: global_config().experimental_partial_encoding(),
         }
     }
 }
@@ -36,6 +38,7 @@ impl CodecOptions {
             validate_checksums: self.validate_checksums,
             store_empty_chunks: self.store_empty_chunks,
             concurrent_target: self.concurrent_target,
+            experimental_partial_encoding: self.experimental_partial_encoding,
         }
     }
 
@@ -74,6 +77,21 @@ impl CodecOptions {
         self.concurrent_target = concurrent_target;
         self
     }
+
+    /// Return the experimental partial encoding setting.
+    #[must_use]
+    pub fn experimental_partial_encoding(&self) -> bool {
+        self.experimental_partial_encoding
+    }
+
+    /// Set whether or not to use experimental partial encoding.
+    pub fn set_experimental_partial_encoding(
+        &mut self,
+        experimental_partial_encoding: bool,
+    ) -> &mut Self {
+        self.experimental_partial_encoding = experimental_partial_encoding;
+        self
+    }
 }
 
 /// Builder for [`CodecOptions`].
@@ -84,6 +102,7 @@ pub struct CodecOptionsBuilder {
     validate_checksums: bool,
     store_empty_chunks: bool,
     concurrent_target: usize,
+    experimental_partial_encoding: bool,
 }
 
 impl Default for CodecOptionsBuilder {
@@ -100,6 +119,7 @@ impl CodecOptionsBuilder {
             validate_checksums: global_config().validate_checksums(),
             store_empty_chunks: global_config().store_empty_chunks(),
             concurrent_target: global_config().codec_concurrent_target(),
+            experimental_partial_encoding: global_config().experimental_partial_encoding(),
         }
     }
 
@@ -110,6 +130,7 @@ impl CodecOptionsBuilder {
             validate_checksums: self.validate_checksums,
             store_empty_chunks: self.store_empty_chunks,
             concurrent_target: self.concurrent_target,
+            experimental_partial_encoding: self.experimental_partial_encoding,
         }
     }
 
@@ -131,6 +152,13 @@ impl CodecOptionsBuilder {
     #[must_use]
     pub fn concurrent_target(mut self, concurrent_target: usize) -> Self {
         self.concurrent_target = concurrent_target;
+        self
+    }
+
+    /// Set whether or not to use experimental partial encoding.
+    #[must_use]
+    pub fn experimental_partial_encoding(mut self, experimental_partial_encoding: bool) -> Self {
+        self.experimental_partial_encoding = experimental_partial_encoding;
         self
     }
 }

--- a/zarrs/src/config.rs
+++ b/zarrs/src/config.rs
@@ -95,6 +95,14 @@ use crate::array::{codec::CodecOptions, ArrayMetadataOptions};
 ///
 /// Sets the names used when serialising and deserialising the names of experimental codecs.
 /// Deserialisation also accepts the standard `IDENTIFIER` of the codec.
+///
+/// ### Experimental Partial Encoding
+/// > default: [`false`]
+///
+/// If `true`, [`Array::store_chunk_subset`](crate::array::Array::store_chunk_subset) and [`Array::store_array_subset`](crate::array::Array::store_array_subset) and variants can use partial encoding.
+/// This is relevant when using the sharding codec, as it enables inner chunks to be written without reading and writing entire shards.
+///
+/// This is an experimental feature for now until it has more comprehensively tested and support is added in the async API.
 #[derive(Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Config {
@@ -107,6 +115,7 @@ pub struct Config {
     metadata_erase_version: MetadataEraseVersion,
     include_zarrs_metadata: bool,
     experimental_codec_names: HashMap<&'static str, String>,
+    experimental_partial_encoding: bool,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -143,6 +152,7 @@ impl Default for Config {
             metadata_erase_version: MetadataEraseVersion::Default,
             include_zarrs_metadata: true,
             experimental_codec_names,
+            experimental_partial_encoding: false,
         }
     }
 }
@@ -256,6 +266,21 @@ impl Config {
     /// Get a mutable reference to the [experimental codec names](#experimental-codec-names) configuration.
     pub fn experimental_codec_names_mut(&mut self) -> &mut HashMap<&'static str, String> {
         &mut self.experimental_codec_names
+    }
+
+    /// Get the [experimental partial encoding](#experimental-partial-encoding) configuration.
+    #[must_use]
+    pub fn experimental_partial_encoding(&self) -> bool {
+        self.experimental_partial_encoding
+    }
+
+    /// Set the [experimental partial encoding](#experimental-partial-encoding) configuration.
+    pub fn set_experimental_partial_encoding(
+        &mut self,
+        experimental_partial_encoding: bool,
+    ) -> &mut Self {
+        self.experimental_partial_encoding = experimental_partial_encoding;
+        self
     }
 }
 

--- a/zarrs/tests/array_partial_encode.rs
+++ b/zarrs/tests/array_partial_encode.rs
@@ -1,0 +1,209 @@
+#![cfg(feature = "sharding")]
+
+use std::sync::Arc;
+
+use core::mem::size_of;
+use zarrs::{
+    array::{
+        codec::{
+            array_to_bytes::sharding::ShardingCodecBuilder, BytesToBytesCodecTraits,
+            CodecOptionsBuilder,
+        },
+        ArrayBuilder, DataType, FillValue,
+    },
+    array_subset::ArraySubset,
+};
+use zarrs_metadata::v3::array::codec::sharding::ShardingIndexLocation;
+use zarrs_storage::{
+    storage_adapter::performance_metrics::PerformanceMetricsStorageAdapter, store::MemoryStore,
+    ReadableStorageTraits,
+};
+
+fn array_partial_encode_sharding(
+    sharding_index_location: ShardingIndexLocation,
+    inner_bytes_to_bytes_codecs: Vec<Arc<dyn BytesToBytesCodecTraits>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let opt = CodecOptionsBuilder::new()
+        .experimental_partial_encoding(true)
+        .build();
+
+    let store = std::sync::Arc::new(MemoryStore::default());
+    // let log_writer = Arc::new(std::sync::Mutex::new(
+    //     // std::io::BufWriter::new(
+    //     std::io::stdout(),
+    //     //    )
+    // ));
+    // let store = Arc::new(zarrs_storage::usage_log::UsageLogStorageAdapter::new(
+    //     store.clone(),
+    //     log_writer,
+    //     || chrono::Utc::now().format("[%T%.3f] ").to_string(),
+    // ));
+    let store_perf = Arc::new(PerformanceMetricsStorageAdapter::new(store.clone()));
+
+    let array_path = "/";
+    let mut builder = ArrayBuilder::new(
+        vec![4, 4], // array shape
+        DataType::UInt16,
+        vec![2, 2].try_into().unwrap(), // regular chunk shape
+        FillValue::from(0u16),
+    );
+    builder
+        .array_to_bytes_codec(Arc::new(
+            ShardingCodecBuilder::new(vec![1, 1].try_into().unwrap())
+                .index_bytes_to_bytes_codecs(vec![])
+                .index_location(sharding_index_location)
+                .bytes_to_bytes_codecs(inner_bytes_to_bytes_codecs.clone())
+                .build(),
+        ))
+        .bytes_to_bytes_codecs(vec![]);
+    // .storage_transformers(vec![].into())
+
+    let array = builder.build(store_perf.clone(), array_path).unwrap();
+
+    let get_bytes_0_0 = || {
+        let key = array.chunk_key_encoding().encode(&[0, 0]);
+        store.get(&key)
+    };
+
+    let chunks_per_shard = 2 * 2;
+    let shard_index_size = size_of::<u64>() * 2 * chunks_per_shard;
+    assert!(get_bytes_0_0()?.is_none());
+    assert_eq!(store_perf.reads(), 0);
+    assert_eq!(store_perf.bytes_read(), 0);
+
+    // [1, 0]
+    // [0, 0]
+    array.store_array_subset_elements_opt::<u16>(
+        &ArraySubset::new_with_ranges(&[0..1, 0..1]),
+        &[1],
+        &opt,
+    )?;
+    assert_eq!(store_perf.reads(), 1); // index
+    assert_eq!(store_perf.writes(), 2); // 1x inner chunk + index
+    assert_eq!(store_perf.bytes_read(), 0);
+    if inner_bytes_to_bytes_codecs.is_empty() {
+        assert_eq!(
+            get_bytes_0_0()?.unwrap().len(),
+            shard_index_size + size_of::<u16>() * 1
+        );
+    }
+    store_perf.reset();
+
+    // [0, 0]
+    // [0, 0]
+    array.store_array_subset_elements_opt::<u16>(
+        &ArraySubset::new_with_ranges(&[0..1, 0..1]),
+        &[0],
+        &opt,
+    )?;
+    assert_eq!(store_perf.reads(), 2); // 1x inner chunk + index
+    assert_eq!(store_perf.writes(), 0); // 1x inner chunk + index
+    if inner_bytes_to_bytes_codecs.is_empty() {
+        assert_eq!(
+            store_perf.bytes_read(),
+            shard_index_size * 1 + size_of::<u16>() * 1
+        );
+    }
+    assert!(get_bytes_0_0()?.is_none());
+    store_perf.reset();
+
+    // [1, 2]
+    // [0, 0]
+    array.store_array_subset_elements_opt::<u16>(
+        &ArraySubset::new_with_ranges(&[0..1, 0..2]),
+        &[1, 2],
+        &opt,
+    )?;
+    assert_eq!(store_perf.reads(), 1); // index
+    assert_eq!(store_perf.writes(), 3); // 2x inner chunk + index
+    if inner_bytes_to_bytes_codecs.is_empty() {
+        assert_eq!(
+            get_bytes_0_0()?.unwrap().len(),
+            shard_index_size + size_of::<u16>() * 2
+        );
+    }
+    store_perf.reset();
+
+    assert_eq!(
+        array.retrieve_chunk_elements::<u16>(&[0, 0])?,
+        vec![1, 2, 0, 0]
+    );
+    store_perf.reset();
+
+    // [99, 2]
+    // [4, 0]
+    array.store_array_subset_elements_opt::<u16>(
+        &ArraySubset::new_with_ranges(&[0..2, 0..1]),
+        &[99, 4],
+        &opt,
+    )?;
+    assert_eq!(store_perf.reads(), 2); // index + 1x inner chunk
+    assert_eq!(store_perf.writes(), 3); // 2x inner chunk + index
+    if inner_bytes_to_bytes_codecs.is_empty() {
+        assert_eq!(
+            get_bytes_0_0()?.unwrap().len(),
+            shard_index_size + size_of::<u16>() * 4 //1 stale inner chunk + 3 inner chunks
+        );
+    }
+    store_perf.reset();
+
+    assert_eq!(
+        array.retrieve_chunk_elements::<u16>(&[0, 0])?,
+        vec![99, 2, 4, 0]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn array_partial_encode_sharding_index_start() {
+    array_partial_encode_sharding(ShardingIndexLocation::Start, vec![]).unwrap();
+}
+
+#[test]
+fn array_partial_encode_sharding_index_end() {
+    array_partial_encode_sharding(ShardingIndexLocation::End, vec![]).unwrap();
+}
+
+#[cfg(all(
+    feature = "gzip",
+    feature = "bz2",
+    feature = "blosc",
+    feature = "crc32c",
+    feature = "zstd"
+))]
+#[test]
+fn array_partial_encode_sharding_index_compressed() {
+    use zarrs_metadata::v3::array::codec::{
+        blosc::{BloscCompressionLevel, BloscCompressor, BloscShuffleMode},
+        bz2::Bz2CompressionLevel,
+    };
+
+    for index_location in &[ShardingIndexLocation::Start, ShardingIndexLocation::End] {
+        array_partial_encode_sharding(
+            *index_location,
+            vec![
+                Arc::new(zarrs::array::codec::GzipCodec::new(5).unwrap()),
+                Arc::new(zarrs::array::codec::ZstdCodec::new(
+                    5.try_into().unwrap(),
+                    true,
+                )),
+                Arc::new(zarrs::array::codec::Bz2Codec::new(
+                    Bz2CompressionLevel::try_from(5u8).unwrap(),
+                )),
+                Arc::new(
+                    zarrs::array::codec::BloscCodec::new(
+                        BloscCompressor::BloscLZ,
+                        BloscCompressionLevel::try_from(5u8).unwrap(),
+                        None,
+                        BloscShuffleMode::NoShuffle,
+                        None,
+                    )
+                    .unwrap(),
+                ),
+                Arc::new(zarrs::array::codec::Crc32cCodec::new()),
+            ],
+        )
+        .unwrap();
+    }
+}

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -206,7 +206,7 @@ pub async fn async_store_set_partial_values<T: AsyncReadableWritableStorageTrait
                 bytes.resize_with(end_max, Default::default);
             }
             // else if truncate {
-            //     vec.truncate(end_max);
+            //     bytes.truncate(end_max);
             // };
 
             // Update the store key

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -170,6 +170,7 @@ pub fn store_set_partial_values<T: ReadableWritableStorageTraits>(
 
             // Read the store key
             let bytes = store.get(&key)?.unwrap_or_default();
+            let mut bytes = Vec::<u8>::from(bytes);
 
             // Convert to a mutable vector of the required length
             let end_max = group
@@ -182,19 +183,12 @@ pub fn store_set_partial_values<T: ReadableWritableStorageTraits>(
                 })
                 .max()
                 .unwrap();
-            let mut bytes = if bytes.len() < end_max {
-                // Expand the store key if needed
-                let mut vec = Vec::with_capacity(end_max);
-                vec.extend_from_slice(&bytes);
-                vec.resize_with(end_max, Default::default);
-                vec
-            // } else if truncate {
-            //     let mut bytes = bytes.to_vec();
+            if bytes.len() < end_max {
+                bytes.resize_with(end_max, Default::default);
+            }
+            // else if truncate {
             //     bytes.truncate(end_max);
-            //     bytes
-            } else {
-                bytes.to_vec()
-            };
+            // };
 
             // Update the store key
             for key_offset_value in group {


### PR DESCRIPTION
This is mainly to support incremental writing of large shards similar to the [encoding procedure outlined in the sharding specification](https://zarr-specs.readthedocs.io/en/latest/v3/codecs/sharding-indexed/v1.0.html#implementation-notes).

Addresses <https://github.com/LDeakin/zarrs_tools/issues/9>.