### PR TITLE
`set_partial_values` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - **Breaking**: `Arc` instead of `Box` partial decoders
  - Expand `set_partial_values` tests
+ - Specialise `set_partial_values` for `MemoryStore`
 
 ### Fixed
  - `[async_]store_set_partial_values` no longer truncates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - **Breaking**: `Arc` instead of `Box` partial decoders
+ - Expand `set_partial_values` tests
+
+### Fixed
+ - `[async_]store_set_partial_values` no longer truncates
+   - this could corrupt values depending on the order of `set_partial_values` calls
 
 ## [0.16.3] - 2024-08-14
 

--- a/src/storage/storage_async.rs
+++ b/src/storage/storage_async.rs
@@ -171,6 +171,9 @@ pub trait AsyncListableStorageTraits: Send + Sync {
 
 /// Set partial values for an asynchronous store.
 ///
+/// This method reads entire values, updates them, and replaces them.
+/// Stores can use this internally if they do not support updating/appending without replacement.
+///
 /// # Errors
 /// Returns a [`StorageError`] if an underlying store operation fails.
 ///
@@ -179,6 +182,7 @@ pub trait AsyncListableStorageTraits: Send + Sync {
 pub async fn async_store_set_partial_values<T: AsyncReadableWritableStorageTraits>(
     store: &T,
     key_start_values: &[StoreKeyStartValue<'_>],
+    // truncate: bool
 ) -> Result<(), StorageError> {
     let groups = key_start_values
         .iter()
@@ -202,9 +206,10 @@ pub async fn async_store_set_partial_values<T: AsyncReadableWritableStorageTrait
                 usize::try_from(group.iter().map(StoreKeyStartValue::end).max().unwrap()).unwrap();
             if vec.len() < end_max {
                 vec.resize_with(end_max, Default::default);
-            } else {
-                vec.truncate(end_max);
-            };
+            }
+            // else if truncate {
+            //     vec.truncate(end_max);
+            // };
 
             // Update the store key
             for key_start_value in group {

--- a/src/storage/storage_sync.rs
+++ b/src/storage/storage_sync.rs
@@ -152,6 +152,9 @@ pub trait ListableStorageTraits: Send + Sync {
 
 /// Set partial values for a store.
 ///
+/// This method reads entire values, updates them, and replaces them.
+/// Stores can use this internally if they do not support updating/appending without replacement.
+///
 /// # Errors
 /// Returns a [`StorageError`] if an underlying store operation fails.
 ///
@@ -160,6 +163,7 @@ pub trait ListableStorageTraits: Send + Sync {
 pub fn store_set_partial_values<T: ReadableWritableStorageTraits>(
     store: &T,
     key_start_values: &[StoreKeyStartValue],
+    // truncate: bool,
 ) -> Result<(), StorageError> {
     // Group by key
     key_start_values
@@ -184,10 +188,12 @@ pub fn store_set_partial_values<T: ReadableWritableStorageTraits>(
                 vec.extend_from_slice(&bytes);
                 vec.resize_with(end_max, Default::default);
                 vec
+            // } else if truncate {
+            //     let mut bytes = bytes.to_vec();
+            //     bytes.truncate(end_max);
+            //     bytes
             } else {
-                let mut bytes = bytes.to_vec();
-                bytes.truncate(end_max);
-                bytes
+                bytes.to_vec()
             };
 
             // Update the store key


### PR DESCRIPTION
 - Expand `set_partial_values` tests
 - Specialise `set_partial_values` for `MemoryStore`
 - `[async_]store_set_partial_values` no longer truncates
   - this could corrupt values depending on the order of `set_partial_values` calls