### PR TITLE
Initial direct I/O support in `FilesystemStore`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,12 +57,14 @@ half = { version = "2.0.0", features = ["bytemuck"] }
 inventory = "0.3.0"
 itertools = "0.13.0"
 lru = "0.12.4"
+libc = "0.2.158"
 moka = { version = "0.12.8", features = ["sync"] }
 monostate = "0.1.0"
 ndarray = { version = ">=0.15.0,<17", optional = true }
 num = { version = "0.4.1" }
 object_store = { version = ">=0.9.0,<0.12", default-features = false, optional = true }
 opendal = { version = ">=0.46,<0.50", default-features = false, optional = true }
+page_size = "0.6.0"
 parking_lot = "0.12.0"
 pathdiff = "0.2.0"
 pco = { version = "0.3.1", optional = true }

--- a/src/storage/store.rs
+++ b/src/storage/store.rs
@@ -8,7 +8,9 @@ mod store_async;
 mod store_sync;
 // mod store_plugin;
 
-pub use store_sync::filesystem_store::{FilesystemStore, FilesystemStoreCreateError};
+pub use store_sync::filesystem_store::{
+    FilesystemStore, FilesystemStoreCreateError, FilesystemStoreOptions,
+};
 pub use store_sync::memory_store::MemoryStore;
 
 #[cfg(feature = "http")]

--- a/src/storage/store/store_sync/filesystem_store.rs
+++ b/src/storage/store/store_sync/filesystem_store.rs
@@ -158,30 +158,7 @@ impl FilesystemStore {
     ///   - is not valid, or
     ///   - it points to an existing file rather than a directory.
     pub fn new<P: AsRef<Path>>(base_path: P) -> Result<Self, FilesystemStoreCreateError> {
-        let base_path = base_path.as_ref().to_path_buf();
-        if base_path.to_str().is_none() {
-            return Err(FilesystemStoreCreateError::InvalidBasePath(base_path));
-        }
-
-        let readonly = if base_path.exists() {
-            // the path already exists, check if it is read only
-            let md = std::fs::metadata(&base_path).map_err(FilesystemStoreCreateError::IOError)?;
-            md.permissions().readonly()
-        } else {
-            // the path does not exist, so try and create it. If this succeeds, the filesystem is not read only
-            std::fs::create_dir_all(&base_path).map_err(FilesystemStoreCreateError::IOError)?;
-            std::fs::remove_dir(&base_path)?;
-            false
-        };
-
-        Ok(Self {
-            base_path,
-            sort: false,
-            options: FilesystemStoreOptions::default(),
-            readonly,
-            files: Mutex::default(),
-        })
-        // Self::new_with_locks(base_path, Arc::new(DefaultStoreLocks::default()))
+        Self::new_with_options(base_path, FilesystemStoreOptions::default())
     }
 
     /// Create a new file system store at a given `base_path` and `options`.

--- a/src/storage/store/store_sync/filesystem_store.rs
+++ b/src/storage/store/store_sync/filesystem_store.rs
@@ -50,12 +50,12 @@ use std::{
 
 /// For `O_DIRECT`, we need a buffer that is aligned to the page size and is a
 /// multiple of the page size.
-struct PageAlinedBuffer {
+struct PageAlignedBuffer {
     buf: *mut u8,
     layout: Layout,
 }
 
-impl PageAlinedBuffer {
+impl PageAlignedBuffer {
     /// Allocate a new page-size aligned buffer of `size` bytes. The actual size
     /// will be rounded up to the next largest multiple of the page size.
     pub fn new(size: usize) -> Self {
@@ -78,7 +78,7 @@ impl PageAlinedBuffer {
     }
 }
 
-impl Deref for PageAlinedBuffer {
+impl Deref for PageAlignedBuffer {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -99,7 +99,7 @@ impl Deref for PageAlinedBuffer {
     }
 }
 
-impl DerefMut for PageAlinedBuffer {
+impl DerefMut for PageAlignedBuffer {
     fn deref_mut(&mut self) -> &mut Self::Target {
         // SAFETY: see `deref` with the following modification:
         // "The memory referenced by the returned slice must not be accessed
@@ -110,7 +110,7 @@ impl DerefMut for PageAlinedBuffer {
     }
 }
 
-impl Drop for PageAlinedBuffer {
+impl Drop for PageAlignedBuffer {
     fn drop(&mut self) {
         // SAFETY: 
         // * "ptr must denote a block of memory currently allocated via this allocator,"
@@ -320,7 +320,7 @@ impl FilesystemStore {
 
         // Write
         if enable_direct {
-            let mut buf = PageAlinedBuffer::new(value.len());
+            let mut buf = PageAlignedBuffer::new(value.len());
             buf[0..value.len()].copy_from_slice(value);
             file.write_all(&buf)?;
             file.set_len(value.len() as u64)?;


### PR DESCRIPTION
Refs #53. I've updated the example in https://github.com/LiberTEM/zarr-dio-proto/ with a case that uses this branch for writing. Let me know if a discussion directly on the PR works for you, otherwise I can move this to the issue. Performance already looks better than the buffered case:

| Method | Time (s) |
|--------- | -------- |
| Direct I/O (manual) | 6.14 |
| Direct I/O (this PR) | 17.71 |
| Buffered | 38.91s |

(performance in the buffered case also depends on if we are overwriting an existing array, in that case it takes ~51s)

# Open questions

- [x] Should this rather be its own `FilesystemDIOStore` or an stay option, as implemented now?
- [x] What's the preferred API for keeping `new_with_options` forwards-compatible? Should it use a builder or is that overkill for now?
- [x] How much of the implementation/optimization should happen in this PR, vs. incremental improvements?
- [x] Thoughts on error handling - should there be a fall back to buffered I/O in case the `Layout` can't be constructed? Is `panic!` in case of allocation failure OK?
- [x] I have not yet looked into the read-path of things - as I understand, `seek` also has to be page-size aligned, which is a bit annoying. One could maybe return the buffers with padding and deref to the actually requested `Bytes` somehow?

# Profile discussion

An annotated flamegraph of running the example code:

![2024-08-26_14-25-zarrs-direct-i-o-profile-round1](https://github.com/user-attachments/assets/821a3cd0-fcf5-4e3c-87fc-142b545e367e)

From left to right:

* The leftmost `memcpy` comes from [`Bytes::from(chunk_encoded.into_owned())`](https://github.com/LDeakin/zarrs/blob/0c08caefa4b8feb723bfdcf756727576436e4962/src/array/array_sync_writable.rs#L274), as far as I can see
* For `PageAlignedBuffer::drop`, see below
* Then we have a copy into the `PageAlignedBuffer` and its initialization to zero beforehand
* Only the rightmost part of the profile is performing actual I/O (`mkdir`, `stat`, `open`, `write` etc.)

There are two parts to the remaining overhead: 1) the fact that we have to touch the memory three times (initialization and two copies), and 2) that the allocations aren't re-used and a significant amount of time is spent in page faults and free'ing memory back to the operating system.

The page faults and the cost of `PageAlignedBuffer::drop` are caused by the default system-wide `malloc` not re-using large allocations by default; re-running with `MALLOC_TRIM_THRESHOLD_=18388608 MALLOC_MMAP_THRESHOLD_=18388608` (which happen to be thresholds larger than the per-chunk buffers) reduces the total run time to ~11.7s. This is great, that's already within 2x of the "ideal". It has the following profile:

![image](https://github.com/user-attachments/assets/77ef14de-e917-414b-9c84-f8c41f781f68)

As it is hard to control these thresholds from a library, an alternative would be to explicitly re-use buffers across multiple chunk writes, but I'm not yet sure how to do this in a non-hacky way (a hacky way: just keep the buffer around in a thread-local `RefCell`... works, but also never `free`'s). Maybe one of the arena crates can be used?

As for the memory copies and initialization:

* Zero-initialization of `PageAlignedBuffer` can be amortized by re-using the initialized buffer over the life of, for example, the `FilesystemStore`, and/or initializing directly from the given slice of bytes
* Instead of passing slices of already allocated buffers down the "codec chain", and having ad-hoc allocations in the individual codec steps, can we invert it somehow that buffers are managed by the lower levels of the codec chain? Then, the previous-to-last codec step would ask the `FilesystemStore` for a suitable buffer, which would already be page-size aligned (removing the last copy)
* Instead of passing some user-allocated memory into `store_chunk_elements`, maybe the user could instead be presented with a mutable slice (or `ArrayViewMut<T>` or similar) where they write the data, which is backed by a suitable buffer. I think this would get rid of the copy by `into_owned`, as the buffer would be managed by the `FilesystemStore`.

For the last point, a sketch of an API could be:

```rust
// like `store_chunk_elements`, but provides a buffer to write to
// (might need to also have a `num_elements` parameter, if this is a border chunk?)
array.store_chunk_bikeshed(&chunk_indices, |buf: &mut [T]| {
    // just as an example - some code that fills up `buf`
    my_decoder.decode(&input, &mut buf);
})
```

In the uncompressed case, `buf` would then be handed down without copying all the way to the `FilesystemStore`, where it can be directly used for I/O. Thoughts?

For comparison, a before-profile using buffered I/O:

![image](https://github.com/user-attachments/assets/15e2c2ef-36e8-4c62-b263-57bfa2eafb3b)

(all profiles taken on Linux 6.1 / Debian stable with `perf record --call-graph=dwarf -F 1234 <bin>`, converted using `perf script -F +pid` and visualized using https://profiler.firefox.com/)