### PR TITLE
Add `ReadableWritableStorageTraits` automatically for all implementations

### DIFF
--- a/src/storage/storage_handle.rs
+++ b/src/storage/storage_handle.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 use crate::byte_range::ByteRange;
 
 use super::{
-    Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, ReadableWritableStorageTraits,
-    StorageError, StoreKey, StorePrefix, WritableStorageTraits,
+    Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
+    StorePrefix, WritableStorageTraits,
 };
 
 #[cfg(feature = "async")]
 use super::{
-    AsyncBytes, AsyncListableStorageTraits, AsyncReadableStorageTraits, AsyncWritableStorageTraits,
-    MaybeAsyncBytes,
+    AsyncBytes, AsyncListableStorageTraits, AsyncReadableStorageTraits,
+    AsyncReadableWritableStorageTraits, AsyncWritableStorageTraits, MaybeAsyncBytes,
 };
 
 /// A storage handle.

--- a/src/storage/storage_handle.rs
+++ b/src/storage/storage_handle.rs
@@ -9,8 +9,8 @@ use super::{
 
 #[cfg(feature = "async")]
 use super::{
-    AsyncBytes, AsyncListableStorageTraits, AsyncReadableStorageTraits,
-    AsyncReadableWritableStorageTraits, AsyncWritableStorageTraits, MaybeAsyncBytes,
+    AsyncBytes, AsyncListableStorageTraits, AsyncReadableStorageTraits, AsyncWritableStorageTraits,
+    MaybeAsyncBytes,
 };
 
 /// A storage handle.
@@ -102,14 +102,6 @@ impl<TStorage: ?Sized + WritableStorageTraits> WritableStorageTraits for Storage
     fn erase_prefix(&self, prefix: &super::StorePrefix) -> Result<(), super::StorageError> {
         self.0.erase_prefix(prefix)
     }
-}
-
-impl<TStorage: ?Sized + ReadableWritableStorageTraits> ReadableWritableStorageTraits
-    for StorageHandle<TStorage>
-{
-    // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError> {
-    //     self.0.mutex(key)
-    // }
 }
 
 #[cfg(feature = "async")]

--- a/src/storage/storage_sync.rs
+++ b/src/storage/storage_sync.rs
@@ -257,14 +257,7 @@ pub trait ReadableWritableStorageTraits: ReadableStorageTraits + WritableStorage
     // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError>;
 }
 
-impl<T> ReadableWritableStorageTraits for T
-where
-    T: ReadableStorageTraits + WritableStorageTraits,
-{
-    // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError> {
-    //     self.0.mutex(key)
-    // }
-}
+impl<T> ReadableWritableStorageTraits for T where T: ReadableStorageTraits + WritableStorageTraits {}
 
 /// A supertrait of [`ReadableStorageTraits`] and [`ListableStorageTraits`].
 pub trait ReadableListableStorageTraits: ReadableStorageTraits + ListableStorageTraits {}

--- a/src/storage/storage_sync.rs
+++ b/src/storage/storage_sync.rs
@@ -257,6 +257,15 @@ pub trait ReadableWritableStorageTraits: ReadableStorageTraits + WritableStorage
     // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError>;
 }
 
+impl<T> ReadableWritableStorageTraits for T
+where
+    T: ReadableStorageTraits + WritableStorageTraits,
+{
+    // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError> {
+    //     self.0.mutex(key)
+    // }
+}
+
 /// A supertrait of [`ReadableStorageTraits`] and [`ListableStorageTraits`].
 pub trait ReadableListableStorageTraits: ReadableStorageTraits + ListableStorageTraits {}
 

--- a/src/storage/storage_transformer/performance_metrics.rs
+++ b/src/storage/storage_transformer/performance_metrics.rs
@@ -5,9 +5,8 @@ use crate::{
     storage::{
         Bytes, ListableStorage, ListableStorageTraits, MaybeBytes, ReadableListableStorage,
         ReadableStorage, ReadableStorageTraits, ReadableWritableListableStorage,
-        ReadableWritableStorage, ReadableWritableStorageTraits, StorageError, StoreKey,
-        StoreKeyRange, StoreKeyStartValue, StoreKeys, StoreKeysPrefixes, StorePrefix,
-        WritableStorage, WritableStorageTraits,
+        ReadableWritableStorage, StorageError, StoreKey, StoreKeyRange, StoreKeyStartValue,
+        StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorage, WritableStorageTraits,
     },
 };
 
@@ -287,15 +286,6 @@ impl<TStorage: ?Sized + WritableStorageTraits> WritableStorageTraits
     fn erase_prefix(&self, prefix: &StorePrefix) -> Result<(), StorageError> {
         self.storage.erase_prefix(prefix)
     }
-}
-
-impl<TStorage: ?Sized + ReadableWritableStorageTraits> ReadableWritableStorageTraits
-    for PerformanceMetricsStorageTransformerImpl<TStorage>
-{
-    // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError> {
-    //     self.transformer.locks.fetch_add(1, Ordering::Relaxed);
-    //     self.storage.mutex(key)
-    // }
 }
 
 #[cfg(feature = "async")]

--- a/src/storage/storage_transformer/usage_log.rs
+++ b/src/storage/storage_transformer/usage_log.rs
@@ -13,9 +13,8 @@ use crate::{
     storage::{
         Bytes, ListableStorage, ListableStorageTraits, MaybeBytes, ReadableListableStorage,
         ReadableStorage, ReadableStorageTraits, ReadableWritableListableStorage,
-        ReadableWritableStorage, ReadableWritableStorageTraits, StorageError, StoreKey,
-        StoreKeyRange, StoreKeyStartValue, StoreKeys, StoreKeysPrefixes, StorePrefix,
-        WritableStorage, WritableStorageTraits,
+        ReadableWritableStorage, StorageError, StoreKey, StoreKeyRange, StoreKeyStartValue,
+        StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorage, WritableStorageTraits,
     },
 };
 
@@ -367,21 +366,6 @@ impl<TStorage: ?Sized + WritableStorageTraits> WritableStorageTraits
         )?;
         result
     }
-}
-
-impl<TStorage: ?Sized + ReadableWritableStorageTraits> ReadableWritableStorageTraits
-    for UsageLogStorageTransformerImpl<TStorage>
-{
-    // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError> {
-    //     let result = self.storage.mutex(key);
-    //     writeln!(
-    //         self.handle.lock().unwrap(),
-    //         "{}mutex({key}) -> {:?}",
-    //         (self.prefix_func)(),
-    //         result.as_ref().map_or((), |_| ())
-    //     )?;
-    //     result
-    // }
 }
 
 #[cfg(feature = "async")]

--- a/src/storage/store/store_sync/filesystem_store.rs
+++ b/src/storage/store/store_sync/filesystem_store.rs
@@ -6,8 +6,8 @@ use crate::{
     byte_range::{ByteOffset, ByteRange},
     storage::{
         store_set_partial_values, Bytes, ListableStorageTraits, ReadableStorageTraits,
-        ReadableWritableStorageTraits, StorageError, StoreKey, StoreKeyError, StoreKeyStartValue,
-        StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes, WritableStorageTraits,
+        StorageError, StoreKey, StoreKeyError, StoreKeyStartValue, StoreKeys, StoreKeysPrefixes,
+        StorePrefix, StorePrefixes, WritableStorageTraits,
     },
 };
 
@@ -317,12 +317,6 @@ impl WritableStorageTraits for FilesystemStore {
             Ok(())
         }
     }
-}
-
-impl ReadableWritableStorageTraits for FilesystemStore {
-    // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError> {
-    //     Ok(self.locks.mutex(key))
-    // }
 }
 
 impl ListableStorageTraits for FilesystemStore {

--- a/src/storage/store/store_sync/memory_store.rs
+++ b/src/storage/store/store_sync/memory_store.rs
@@ -6,9 +6,8 @@ use std::sync::Mutex;
 use crate::{
     byte_range::{ByteOffset, ByteRange, InvalidByteRangeError},
     storage::{
-        Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
-        ReadableWritableStorageTraits, StorageError, StoreKey, StoreKeyStartValue, StoreKeys,
-        StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
+        Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
+        StoreKeyStartValue, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
     },
 };
 
@@ -172,12 +171,6 @@ impl WritableStorageTraits for MemoryStore {
         }
         Ok(())
     }
-}
-
-impl ReadableWritableStorageTraits for MemoryStore {
-    // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError> {
-    //     Ok(self.locks.mutex(key))
-    // }
 }
 
 impl ListableStorageTraits for MemoryStore {

--- a/src/storage/store/store_sync/opendal.rs
+++ b/src/storage/store/store_sync/opendal.rs
@@ -3,9 +3,8 @@ use opendal::BlockingOperator;
 use crate::{
     byte_range::{ByteRange, InvalidByteRangeError},
     storage::{
-        Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
-        ReadableWritableStorageTraits, StorageError, StoreKey, StoreKeyStartValue, StoreKeys,
-        StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
+        Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
+        StoreKeyStartValue, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
     },
 };
 
@@ -102,13 +101,6 @@ impl WritableStorageTraits for OpendalStore {
     fn erase_prefix(&self, prefix: &StorePrefix) -> Result<(), StorageError> {
         Ok(self.operator.remove_all(prefix.as_str())?)
     }
-}
-
-#[async_trait::async_trait]
-impl ReadableWritableStorageTraits for OpendalStore {
-    // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError> {
-    //     Ok(self.locks.mutex(key))
-    // }
 }
 
 #[async_trait::async_trait]

--- a/tests/array_async_to_sync.rs
+++ b/tests/array_async_to_sync.rs
@@ -1,0 +1,71 @@
+use serde_json::json;
+use std::sync::Arc;
+use zarrs::storage::{
+    storage_adapter::async_to_sync::{AsyncToSyncBlockOn, AsyncToSyncStorageAdapter},
+    ReadableWritableStorage,
+};
+use zarrs::{
+    array::{DataType, FillValue, ZARR_NAN_F32},
+    array_subset::ArraySubset,
+    storage::store,
+};
+
+pub struct TokioBlockOn(pub tokio::runtime::Runtime);
+
+impl AsyncToSyncBlockOn for TokioBlockOn {
+    fn block_on<F: core::future::Future>(&self, future: F) -> F::Output {
+        self.0.block_on(future)
+    }
+}
+
+fn readable_writable_store() -> ReadableWritableStorage {
+    let block_on = TokioBlockOn(tokio::runtime::Runtime::new().unwrap());
+    let store = object_store::memory::InMemory::new();
+    let async_store = Arc::new(store::AsyncObjectStore::new(store));
+    Arc::new(AsyncToSyncStorageAdapter::new(async_store, block_on))
+}
+
+#[test]
+fn array_read_and_write_async_storage_adapter() {
+    const GROUP_PATH: &str = "/group";
+    const ARRAY_PATH: &str = "/group/array";
+    let store = readable_writable_store();
+
+    // Create a group
+    let mut group = zarrs::group::GroupBuilder::new()
+        .build(store.clone(), GROUP_PATH)
+        .unwrap();
+    // Update group metadata
+    group
+        .attributes_mut()
+        .insert("foo".into(), serde_json::Value::String("bar".into()));
+    // Write group metadata to store
+    group.store_metadata().unwrap();
+    assert_eq!(group.attributes().get("foo"), Some(&json!("bar")));
+
+    // Create an array
+    let array = zarrs::array::ArrayBuilder::new(
+        vec![8, 8],
+        DataType::Float32,
+        vec![4, 4].try_into().unwrap(),
+        FillValue::from(ZARR_NAN_F32),
+    )
+    .dimension_names(["y", "x"].into())
+    .build(store.clone(), ARRAY_PATH)
+    .unwrap();
+    array.store_metadata().unwrap();
+    assert_eq!(array.shape(), &[8, 8]);
+
+    array
+        .store_chunk_elements::<f32>(
+            &[0, 0],
+            &[
+                0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3, 3.0, 3.1, 3.2, 3.3,
+            ],
+        )
+        .unwrap();
+
+    let subset = ArraySubset::new_with_ranges(&[2..4, 2..4]);
+    let data = array.retrieve_array_subset_ndarray::<f32>(&subset).unwrap();
+    assert_eq!(data, ndarray::array![[2.2, 2.3], [3.2, 3.3]].into_dyn());
+}


### PR DESCRIPTION
Closes #54 

As suggested, I added `ReadableWritableStorageTraits` to the default `storage_sync` implementation so that anything implementing `ReadableStorageTraits` and `WritableStorageTraits` will have this trait as well. I also added a simple test for an async storage adapter to check that it is readable and writable.

One potential issue with this approach is that it removes some of the custom commented mutex handling code in the various implementations. I'm not sure the use for that commented code. Do you think that will be a problem?

I'm happy to take a different approach here if necessary.