### PR TITLE
`std::mem::size_of` is not in the prelude of the MSRV

### DIFF
--- a/src/array/chunk_cache/chunk_cache_lru.rs
+++ b/src/array/chunk_cache/chunk_cache_lru.rs
@@ -359,7 +359,7 @@ impl ChunkCache<ChunkCacheTypeDecoded> for ChunkCacheDecodedLruSizeLimitThreadLo
 mod tests {
     use super::*;
 
-    use std::sync::Arc;
+    use std::{mem::size_of, sync::Arc};
 
     use crate::{
         array::{


### PR DESCRIPTION
Probably #60 depends on this