### PR TITLE
Make `StoreKeysPrefixes` constructible

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -181,6 +181,12 @@ pub struct StoreKeysPrefixes {
 }
 
 impl StoreKeysPrefixes {
+    /// Create a new [`StoreKeysPrefixes`].
+    #[must_use]
+    pub fn new(keys: StoreKeys, prefixes: StorePrefixes) -> Self {
+        Self { keys, prefixes }
+    }
+
     /// Returns the keys.
     #[must_use]
     pub const fn keys(&self) -> &StoreKeys {


### PR DESCRIPTION
`StoreKeysPrefixes` is returned by `ListableStorageTraits::list_dir`, but it can't be constructed outside of `zarrs`. This adds a pub constructor.