### PR TITLE
add `Array::store_encoded_chunk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Add `ArrayChunkCacheExt` extension trait for `Array`
    - Add traits: `ChunkCache`, `ChunkCacheType` (implemented by `ChunkCacheType{Encoded,Decoded}`)
    - Add chunk cache implementations: `ChunkCache{En,De}codedLru{Size,Chunk}Limit[ThreadLocal]`
+ - Add direct I/O support in `FilesystemStore` by [@sk1p]
+    - Copy to aligned buffer if not already aligned to page size
+    - Add `Array::{async_,}store_encoded_chunk` for writing already-encoded chunks
 
 ### Changed
  - **Breaking**: `Arc` instead of `Box` partial decoders
@@ -1011,3 +1014,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [@LDeakin]: https://github.com/LDeakin
 [@lorenzocerrone]: https://github.com/lorenzocerrone
 [@dustinlagoy]: https://github.com/dustinlagoy
+[@sk1p]: https://github.com/sk1p

--- a/src/array/array_async_writable.rs
+++ b/src/array/array_async_writable.rs
@@ -235,7 +235,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
         Ok(())
     }
 
-    /// Async variant of [`store_encoded_chunk`](Array::store_encoded_chunk)0
+    /// Async variant of [`store_encoded_chunk`](Array::store_encoded_chunk)
     #[allow(clippy::missing_errors_doc)]
     pub async unsafe fn async_store_encoded_chunk(
         &self,

--- a/src/array/array_async_writable.rs
+++ b/src/array/array_async_writable.rs
@@ -236,7 +236,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
     }
 
     /// Async variant of [`store_encoded_chunk`](Array::store_encoded_chunk)
-    #[allow(clippy::missing_errors_doc)]
+    #[allow(clippy::missing_errors_doc, clippy::missing_safety_doc)]
     pub async unsafe fn async_store_encoded_chunk(
         &self,
         chunk_indices: &[u64],

--- a/src/array/array_sync_writable.rs
+++ b/src/array/array_sync_writable.rs
@@ -277,6 +277,41 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> Array<TStorage> {
         Ok(())
     }
 
+    /// Store `encoded_chunk_bytes` at `chunk_indices`
+    ///
+    /// # Safety
+    /// The responsibility is on the caller to ensure the chunk is encoded correctly
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] if there is an underlying store error.
+    pub unsafe fn store_encoded_chunk(
+        &self,
+        chunk_indices: &[u64],
+        encoded_chunk_bytes: bytes::Bytes,
+    ) -> Result<(), ArrayError> {
+        // Validation
+        // let chunk_array_representation = self.chunk_array_representation(chunk_indices)?;
+
+        // chunk_bytes.validate(
+        //     chunk_array_representation.num_elements(),
+        //     chunk_array_representation.data_type().size(),
+        // )?;
+
+        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
+        let storage_transformer = self
+            .storage_transformers()
+            .create_writable_transformer(storage_handle);
+        crate::storage::store_chunk(
+            &*storage_transformer,
+            self.path(),
+            chunk_indices,
+            self.chunk_key_encoding(),
+            encoded_chunk_bytes,
+        )?;
+
+        Ok(())
+    }
+
     /// Explicit options version of [`store_chunk_elements`](Array::store_chunk_elements).
     #[allow(clippy::missing_errors_doc)]
     pub fn store_chunk_elements_opt<T: Element>(


### PR DESCRIPTION
As discussed in, and on top of, #58.

* Don't copy in `FilesystemStorage` if the `value` is already properly aligned
* Add  `Array::store_encoded_chunk`

From a first test, this hits the spot and is as fast as the manual direct I/O. Didn't profile yet. Maybe needs a companion that can tell us if the array (metadata) indicates that this method can be used.