### PR TITLE
Add `ArrayShardedExt::effective_inner_chunk_shape`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - Add `ArrayShardedExt::effective_inner_chunk_shape`
+   - This is the effective inner chunk shape (i.e. read granularity) of a sharded array
+   - It is equal to the inner chunk shape unless the `transpose` codec precedes `sharding_indexed`
+ - **Breaking**: Add `ArrayToArrayCodecTraits::compute_decoded_shape()`
+   - Needed for `ArrayShardedExt::effective_inner_chunk_shape`
+
+### Fixed
+ - Fix `ArrayShardedExt::inner_chunk_grid` when applied on a sharded array with the `transpose` codec preceding `sharding_indexed`
+
 ## [0.17.0-beta.0] - 2024-09-06
 
 ### Highlights / Major Changes

--- a/zarrs/src/array/array_sharded_ext.rs
+++ b/zarrs/src/array/array_sharded_ext.rs
@@ -5,12 +5,21 @@ pub trait ArrayShardedExt {
     /// Returns true if the array to bytes codec of the array is `sharding_indexed`.
     fn is_sharded(&self) -> bool;
 
-    /// Return the inner chunk shape.
+    /// Return the inner chunk shape as defined in the `sharding_indexed` codec metadata.
     ///
-    /// Returns [`None`] for an unsharded array.
+    /// Returns [`None`] for an unsharded array or an array.
     fn inner_chunk_shape(&self) -> Option<ChunkShape>;
 
+    /// The effective inner chunk shape.
+    ///
+    /// The effective inner chunk shape is the "read granularity" of the sharded array that accounts for array-to-array codecs preceding the sharding codec.
+    /// For example, the transpose codec changes the shape of an array subset that corresponds to a single inner chunk.
+    /// The effective inner chunk shape is used when determining the inner chunk grid of a sharded array.
+    fn effective_inner_chunk_shape(&self) -> Option<ChunkShape>;
+
     /// Retrieve the inner chunk grid.
+    ///
+    /// This uses the effective inner shape so that reading an inner chunk reads only one contiguous byte range.
     ///
     /// Returns the normal chunk grid for an unsharded array.
     fn inner_chunk_grid(&self) -> ChunkGrid;
@@ -46,8 +55,22 @@ impl<TStorage: ?Sized> ArrayShardedExt for Array<TStorage> {
         }
     }
 
+    fn effective_inner_chunk_shape(&self) -> Option<ChunkShape> {
+        let inner_chunk_shape = self.inner_chunk_shape();
+        if let Some(mut inner_chunk_shape) = inner_chunk_shape {
+            for codec in self.codecs().array_to_array_codecs().iter().rev() {
+                inner_chunk_shape = codec
+                    .compute_decoded_shape(inner_chunk_shape)
+                    .expect("the inner chunk shape is compatible");
+            }
+            Some(inner_chunk_shape)
+        } else {
+            None
+        }
+    }
+
     fn inner_chunk_grid(&self) -> ChunkGrid {
-        if let Some(inner_chunk_shape) = self.inner_chunk_shape() {
+        if let Some(inner_chunk_shape) = self.effective_inner_chunk_shape() {
             ChunkGrid::new(crate::array::chunk_grid::RegularChunkGrid::new(
                 inner_chunk_shape,
             ))

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -456,6 +456,16 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         decoded_representation: &ChunkRepresentation,
     ) -> Result<ChunkRepresentation, CodecError>;
 
+    /// Returns the size of the decoded representation given a size of the encoded representation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`CodecError`] if the encoded representation is not supported by this codec.
+    fn compute_decoded_shape(
+        &self,
+        encoded_representation: ChunkShape,
+    ) -> Result<ChunkShape, CodecError>;
+
     /// Encode a chunk.
     ///
     /// # Errors

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -6,7 +6,7 @@ use crate::{
             options::CodecOptions, ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits,
             ArrayToArrayCodecTraits, CodecError, CodecTraits, RecommendedConcurrency,
         },
-        ArrayMetadataOptions, ChunkRepresentation, DataType,
+        ArrayMetadataOptions, ChunkRepresentation, ChunkShape, DataType,
     },
     config::global_config,
     metadata::v3::MetadataV3,
@@ -167,5 +167,9 @@ impl ArrayToArrayCodecTraits for BitroundCodec {
                 IDENTIFIER.to_string(),
             )),
         }
+    }
+
+    fn compute_decoded_shape(&self, encoded_shape: ChunkShape) -> Result<ChunkShape, CodecError> {
+        Ok(encoded_shape)
     }
 }

--- a/zarrs/src/array/codec/array_to_array/transpose.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose.rs
@@ -89,9 +89,9 @@ fn transpose_array(
     }
 }
 
-fn permute<T: Copy>(v: &[T], order: &TransposeOrder) -> Vec<T> {
+fn permute<T: Copy>(v: &[T], order: &[usize]) -> Vec<T> {
     let mut vec = Vec::<T>::with_capacity(v.len());
-    for axis in &order.0 {
+    for axis in order {
         vec.push(v[*axis]);
     }
     vec

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
@@ -52,8 +52,8 @@ fn get_decoded_regions_transposed(
 ) -> Vec<ArraySubset> {
     let mut decoded_regions_transposed = Vec::with_capacity(decoded_regions.len());
     for decoded_region in decoded_regions {
-        let start = permute(decoded_region.start(), order);
-        let size = permute(decoded_region.shape(), order);
+        let start = permute(decoded_region.start(), &order.0);
+        let size = permute(decoded_region.shape(), &order.0);
         let decoded_region_transpose =
             unsafe { ArraySubset::new_with_start_shape_unchecked(start, size) };
         decoded_regions_transposed.push(decoded_region_transpose);
@@ -90,7 +90,7 @@ fn do_transpose<'a>(
                     let data_type_size = decoded_representation.data_type().fixed_size().unwrap();
                     let bytes = transpose_array(
                         &order_decode,
-                        &permute(subset.shape(), order),
+                        &permute(subset.shape(), &order.0),
                         data_type_size,
                         &bytes,
                     )


### PR DESCRIPTION
Fixes the inner chunk grid calculation for the case where the `transpose` codec precedes `sharding_indexed`