### PR TITLE
Refactor partial decoder API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Breaking**: Change `Contiguous[Linearised]Indices` iterators to return indices only
+- **Breaking**: Remove lifetime constraints in partial decoder API by utilising `Arc`'d codecs
+- **Breaking**: `ShardingCodec::new` `CodecChain` parameters now must be in an `Arc`
 
 ### Fixed
 - Fixed an unnecessary copy in `Array::[async_]retrieve_chunk_if_exists_opt`

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -304,7 +304,7 @@ pub struct Array<TStorage: ?Sized> {
     /// Provides an element value to use for uninitialised portions of the Zarr array. It encodes the underlying data type.
     fill_value: FillValue,
     /// Specifies a list of codecs to be used for encoding and decoding chunks.
-    codecs: CodecChain,
+    codecs: Arc<CodecChain>,
     // /// Optional user defined attributes.
     // attributes: serde_json::Map<String, serde_json::Value>,
     /// An optional list of storage transformers.
@@ -352,8 +352,10 @@ impl<TStorage: ?Sized> Array<TStorage> {
         let fill_value = data_type
             .fill_value_from_metadata(&metadata_v3.fill_value)
             .map_err(ArrayCreateError::InvalidFillValueMetadata)?;
-        let codecs = CodecChain::from_metadata(&metadata_v3.codecs)
-            .map_err(ArrayCreateError::CodecsCreateError)?;
+        let codecs = Arc::new(
+            CodecChain::from_metadata(&metadata_v3.codecs)
+                .map_err(ArrayCreateError::CodecsCreateError)?,
+        );
         let storage_transformers =
             StorageTransformerChain::from_metadata(&metadata_v3.storage_transformers)
                 .map_err(ArrayCreateError::StorageTransformersCreateError)?;
@@ -432,7 +434,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
 
     /// Get the codecs.
     #[must_use]
-    pub const fn codecs(&self) -> &CodecChain {
+    pub fn codecs(&self) -> &CodecChain {
         &self.codecs
     }
 

--- a/zarrs/src/array/array_async_readable.rs
+++ b/zarrs/src/array/array_async_readable.rs
@@ -273,10 +273,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
 
     /// Async variant of [`partial_decoder`](Array::partial_decoder).
     #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    pub async fn async_partial_decoder<'a>(
-        &'a self,
+    pub async fn async_partial_decoder(
+        &self,
         chunk_indices: &[u64],
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, ArrayError> {
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, ArrayError> {
         self.async_partial_decoder_opt(chunk_indices, &CodecOptions::default())
             .await
     }
@@ -768,7 +768,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
                 storage_transformer,
                 self.chunk_key(chunk_indices),
             ));
-            self.codecs()
+            self.codecs
+                .clone()
                 .async_partial_decoder(input_handle, &chunk_representation, options)
                 .await?
                 .partial_decode_opt(&[chunk_subset.clone()], options)
@@ -820,7 +821,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             ));
 
             Ok(self
-                .codecs()
+                .codecs
+                .clone()
                 .async_partial_decoder(input_handle, &chunk_representation, options)
                 .await?
                 .partial_decode_into(chunk_subset, output, output_shape, output_subset, options)
@@ -860,11 +862,11 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
 
     /// Async variant of [`partial_decoder_opt`](Array::partial_decoder_opt).
     #[allow(clippy::missing_errors_doc)]
-    pub async fn async_partial_decoder_opt<'a>(
-        &'a self,
+    pub async fn async_partial_decoder_opt(
+        &self,
         chunk_indices: &[u64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, ArrayError> {
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, ArrayError> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
@@ -875,7 +877,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         ));
         let chunk_representation = self.chunk_array_representation(chunk_indices)?;
         Ok(self
-            .codecs()
+            .codecs
+            .clone()
             .async_partial_decoder(input_handle, &chunk_representation, options)
             .await?)
     }

--- a/zarrs/src/array/array_builder.rs
+++ b/zarrs/src/array/array_builder.rs
@@ -335,11 +335,11 @@ impl ArrayBuilder {
             chunk_grid: self.chunk_grid.clone(),
             chunk_key_encoding: self.chunk_key_encoding.clone(),
             fill_value: self.fill_value.clone(),
-            codecs: CodecChain::new(
+            codecs: Arc::new(CodecChain::new(
                 self.array_to_array_codecs.clone(),
                 self.array_to_bytes_codec.clone(),
                 self.bytes_to_bytes_codecs.clone(),
-            ),
+            )),
             storage_transformers: self.storage_transformers.clone(),
             // attributes: self.attributes.clone(),
             dimension_names: self.dimension_names.clone(),

--- a/zarrs/src/array/array_sync_readable.rs
+++ b/zarrs/src/array/array_sync_readable.rs
@@ -407,10 +407,10 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if initialisation of the partial decoder fails.
-    pub fn partial_decoder<'a>(
-        &'a self,
+    pub fn partial_decoder(
+        &self,
         chunk_indices: &[u64],
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, ArrayError> {
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
         self.partial_decoder_opt(chunk_indices, &CodecOptions::default())
     }
 
@@ -830,7 +830,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
                 self.chunk_key(chunk_indices),
             ));
 
-            self.codecs()
+            self.codecs
+                .clone()
                 .partial_decoder(input_handle, &chunk_representation, options)?
                 .partial_decode_opt(&[chunk_subset.clone()], options)?
                 .remove(0)
@@ -873,7 +874,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
             ));
 
             Ok(self
-                .codecs()
+                .codecs
+                .clone()
                 .partial_decoder(input_handle, &chunk_representation, options)?
                 .partial_decode_into(chunk_subset, output, output_shape, output_subset, options)?)
         }
@@ -909,11 +911,11 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
 
     /// Explicit options version of [`partial_decoder`](Array::partial_decoder).
     #[allow(clippy::missing_errors_doc)]
-    pub fn partial_decoder_opt<'a>(
-        &'a self,
+    pub fn partial_decoder_opt(
+        &self,
         chunk_indices: &[u64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, ArrayError> {
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
@@ -924,7 +926,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         ));
         let chunk_representation = self.chunk_array_representation(chunk_indices)?;
         Ok(self
-            .codecs()
+            .codecs
+            .clone()
             .partial_decoder(input_handle, &chunk_representation, options)?)
     }
 }

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -68,10 +68,9 @@ pub use byte_interval_partial_decoder::ByteIntervalPartialDecoder;
 #[cfg(feature = "async")]
 pub use byte_interval_partial_decoder::AsyncByteIntervalPartialDecoder;
 
-use crate::byte_range::extract_byte_ranges_read_seek;
 use crate::{
     array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
-    byte_range::{ByteRange, InvalidByteRangeError},
+    byte_range::{extract_byte_ranges_read_seek, ByteRange, InvalidByteRangeError},
     metadata::v3::MetadataV3,
     plugin::{Plugin, PluginCreateError},
     storage::{ReadableStorage, StorageError, StoreKey},
@@ -563,24 +562,24 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    fn partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn ArrayPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, CodecError>;
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError>;
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial decoder.
     ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, CodecError>;
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError>;
 }
 
 /// Traits for array to bytes codecs.
@@ -660,24 +659,24 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    fn partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, CodecError>;
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError>;
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial decoder.
     ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        mut input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        mut input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, CodecError>;
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError>;
 }
 
 /// Traits for bytes to bytes codecs.
@@ -723,24 +722,24 @@ pub trait BytesToBytesCodecTraits: CodecTraits + core::fmt::Debug {
     ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    fn partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         decoded_representation: &BytesRepresentation,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn BytesPartialDecoderTraits + 'a>, CodecError>;
+    ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError>;
 
     #[cfg(feature = "async")]
     /// Initialises an asynchronous partial decoder.
     ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: &BytesRepresentation,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits + 'a>, CodecError>;
+    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits>, CodecError>;
 }
 
 impl BytesPartialDecoderTraits for std::io::Cursor<&[u8]> {

--- a/zarrs/src/array/codec/array_to_array/bitround.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround.rs
@@ -321,7 +321,7 @@ mod tests {
     fn codec_bitround_partial_decode() {
         const JSON: &'static str = r#"{ "keepbits": 2 }"#;
         let codec_configuration: BitroundCodecConfiguration = serde_json::from_str(JSON).unwrap();
-        let codec = BitroundCodec::new_with_configuration(&codec_configuration);
+        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration));
 
         let elements: Vec<f32> = (0..32).map(|i| i as f32).collect();
         let chunk_representation = ChunkRepresentation::new(
@@ -345,7 +345,7 @@ mod tests {
             ArraySubset::new_with_ranges(&[17..21]),
         ];
         let input_handle = Arc::new(std::io::Cursor::new(encoded.into_fixed().unwrap()));
-        let bytes_codec = BytesCodec::default();
+        let bytes_codec = Arc::new(BytesCodec::default());
         let input_handle = bytes_codec
             .partial_decoder(
                 input_handle,
@@ -380,7 +380,7 @@ mod tests {
     async fn codec_bitround_async_partial_decode() {
         const JSON: &'static str = r#"{ "keepbits": 2 }"#;
         let codec_configuration: BitroundCodecConfiguration = serde_json::from_str(JSON).unwrap();
-        let codec = BitroundCodec::new_with_configuration(&codec_configuration);
+        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration));
 
         let elements: Vec<f32> = (0..32).map(|i| i as f32).collect();
         let chunk_representation = ChunkRepresentation::new(
@@ -404,7 +404,7 @@ mod tests {
             ArraySubset::new_with_ranges(&[17..21]),
         ];
         let input_handle = Arc::new(std::io::Cursor::new(encoded.into_fixed().unwrap()));
-        let bytes_codec = BytesCodec::default();
+        let bytes_codec = Arc::new(BytesCodec::default());
         let input_handle = bytes_codec
             .async_partial_decoder(
                 input_handle,

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -111,12 +111,12 @@ impl ArrayToArrayCodecTraits for BitroundCodec {
         Ok(bytes)
     }
 
-    fn partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn ArrayPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             bitround_partial_decoder::BitroundPartialDecoder::new(
                 input_handle,
@@ -127,12 +127,12 @@ impl ArrayToArrayCodecTraits for BitroundCodec {
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             bitround_partial_decoder::AsyncBitroundPartialDecoder::new(
                 input_handle,

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_partial_decoder.rs
@@ -14,16 +14,16 @@ use crate::array::codec::AsyncArrayPartialDecoderTraits;
 use super::{round_bytes, IDENTIFIER};
 
 /// Partial decoder for the `bitround` codec.
-pub struct BitroundPartialDecoder<'a> {
-    input_handle: Arc<dyn ArrayPartialDecoderTraits + 'a>,
+pub struct BitroundPartialDecoder {
+    input_handle: Arc<dyn ArrayPartialDecoderTraits>,
     data_type: DataType,
     keepbits: u32,
 }
 
-impl<'a> BitroundPartialDecoder<'a> {
+impl BitroundPartialDecoder {
     /// Create a new partial decoder for the `bitround` codec.
     pub fn new(
-        input_handle: Arc<dyn ArrayPartialDecoderTraits + 'a>,
+        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         data_type: &DataType,
         keepbits: u32,
     ) -> Result<Self, CodecError> {
@@ -52,7 +52,7 @@ impl<'a> BitroundPartialDecoder<'a> {
     }
 }
 
-impl ArrayPartialDecoderTraits for BitroundPartialDecoder<'_> {
+impl ArrayPartialDecoderTraits for BitroundPartialDecoder {
     fn data_type(&self) -> &DataType {
         &self.data_type
     }
@@ -79,17 +79,17 @@ impl ArrayPartialDecoderTraits for BitroundPartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `bitround` codec.
-pub struct AsyncBitroundPartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncArrayPartialDecoderTraits + 'a>,
+pub struct AsyncBitroundPartialDecoder {
+    input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
     data_type: DataType,
     keepbits: u32,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncBitroundPartialDecoder<'a> {
+impl AsyncBitroundPartialDecoder {
     /// Create a new partial decoder for the `bitround` codec.
     pub fn new(
-        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits + 'a>,
+        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         data_type: &DataType,
         keepbits: u32,
     ) -> Result<Self, CodecError> {
@@ -120,7 +120,7 @@ impl<'a> AsyncBitroundPartialDecoder<'a> {
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncArrayPartialDecoderTraits for AsyncBitroundPartialDecoder<'_> {
+impl AsyncArrayPartialDecoderTraits for AsyncBitroundPartialDecoder {
     fn data_type(&self) -> &DataType {
         &self.data_type
     }

--- a/zarrs/src/array/codec/array_to_array/transpose.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose.rs
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn codec_transpose_partial_decode() {
-        let codec = TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap());
+        let codec = Arc::new(TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap()));
 
         let elements: Vec<f32> = (0..16).map(|i| i as f32).collect();
         let chunk_representation = ChunkRepresentation::new(
@@ -220,7 +220,7 @@ mod tests {
             ArraySubset::new_with_ranges(&[2..4, 0..2]),
         ];
         let input_handle = Arc::new(std::io::Cursor::new(encoded.into_fixed().unwrap()));
-        let bytes_codec = BytesCodec::default();
+        let bytes_codec = Arc::new(BytesCodec::default());
         let input_handle = bytes_codec
             .partial_decoder(
                 input_handle,
@@ -258,7 +258,7 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn codec_transpose_async_partial_decode() {
-        let codec = TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap());
+        let codec = Arc::new(TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap()));
 
         let elements: Vec<f32> = (0..16).map(|i| i as f32).collect();
         let chunk_representation = ChunkRepresentation::new(
@@ -283,7 +283,7 @@ mod tests {
             ArraySubset::new_with_ranges(&[2..4, 0..2]),
         ];
         let input_handle = Arc::new(std::io::Cursor::new(encoded.into_fixed().unwrap()));
-        let bytes_codec = BytesCodec::default();
+        let bytes_codec = Arc::new(BytesCodec::default());
         let input_handle = bytes_codec
             .async_partial_decoder(
                 input_handle,

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
@@ -161,12 +161,12 @@ impl ArrayToArrayCodecTraits for TransposeCodec {
         }
     }
 
-    fn partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn ArrayPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::transpose_partial_decoder::TransposePartialDecoder::new(
                 input_handle,
@@ -177,12 +177,12 @@ impl ArrayToArrayCodecTraits for TransposeCodec {
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::transpose_partial_decoder::AsyncTransposePartialDecoder::new(
                 input_handle,

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
@@ -10,16 +10,16 @@ use crate::array::{
 use crate::array::codec::AsyncArrayPartialDecoderTraits;
 
 /// Partial decoder for the Transpose codec.
-pub struct TransposePartialDecoder<'a> {
-    input_handle: Arc<dyn ArrayPartialDecoderTraits + 'a>,
+pub struct TransposePartialDecoder {
+    input_handle: Arc<dyn ArrayPartialDecoderTraits>,
     decoded_representation: ChunkRepresentation,
     order: TransposeOrder,
 }
 
-impl<'a> TransposePartialDecoder<'a> {
+impl TransposePartialDecoder {
     /// Create a new partial decoder for the Transpose codec.
     pub fn new(
-        input_handle: Arc<dyn ArrayPartialDecoderTraits + 'a>,
+        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         decoded_representation: ChunkRepresentation,
         order: TransposeOrder,
     ) -> Self {
@@ -102,7 +102,7 @@ fn do_transpose<'a>(
         .collect::<Result<Vec<_>, CodecError>>()
 }
 
-impl ArrayPartialDecoderTraits for TransposePartialDecoder<'_> {
+impl ArrayPartialDecoderTraits for TransposePartialDecoder {
     fn data_type(&self) -> &DataType {
         self.decoded_representation.data_type()
     }
@@ -132,17 +132,17 @@ impl ArrayPartialDecoderTraits for TransposePartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the Transpose codec.
-pub struct AsyncTransposePartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncArrayPartialDecoderTraits + 'a>,
+pub struct AsyncTransposePartialDecoder {
+    input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
     decoded_representation: ChunkRepresentation,
     order: TransposeOrder,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncTransposePartialDecoder<'a> {
+impl AsyncTransposePartialDecoder {
     /// Create a new partial decoder for the Transpose codec.
     pub fn new(
-        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits + 'a>,
+        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         decoded_representation: ChunkRepresentation,
         order: TransposeOrder,
     ) -> Self {
@@ -156,7 +156,7 @@ impl<'a> AsyncTransposePartialDecoder<'a> {
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncArrayPartialDecoderTraits for AsyncTransposePartialDecoder<'_> {
+impl AsyncArrayPartialDecoderTraits for AsyncTransposePartialDecoder {
     fn data_type(&self) -> &DataType {
         self.decoded_representation.data_type()
     }

--- a/zarrs/src/array/codec/array_to_bytes/bytes.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes.rs
@@ -270,7 +270,7 @@ mod tests {
         let elements: Vec<u8> = (0..chunk_representation.num_elements() as u8).collect();
         let bytes: ArrayBytes = elements.into();
 
-        let codec = BytesCodec::new(None);
+        let codec = Arc::new(BytesCodec::new(None));
 
         let encoded = codec
             .encode(
@@ -314,7 +314,7 @@ mod tests {
         let elements: Vec<u8> = (0..chunk_representation.num_elements() as u8).collect();
         let bytes: ArrayBytes = elements.into();
 
-        let codec = BytesCodec::new(None);
+        let codec = Arc::new(BytesCodec::new(None));
 
         let encoded = codec
             .encode(

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
@@ -167,12 +167,12 @@ impl ArrayToBytesCodecTraits for BytesCodec {
         ))
     }
 
-    fn partial_decoder<'a>(
-        &self,
-        input_handle: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(bytes_partial_decoder::BytesPartialDecoder::new(
             input_handle,
             decoded_representation.clone(),
@@ -181,12 +181,12 @@ impl ArrayToBytesCodecTraits for BytesCodec {
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             bytes_partial_decoder::AsyncBytesPartialDecoder::new(
                 input_handle,

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
@@ -107,17 +107,17 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `bytes` codec.
-pub struct AsyncBytesPartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncBytesPartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: ChunkRepresentation,
     endian: Option<Endianness>,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncBytesPartialDecoder<'a> {
+impl AsyncBytesPartialDecoder {
     /// Create a new partial decoder for the `bytes` codec.
     pub fn new(
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: ChunkRepresentation,
         endian: Option<Endianness>,
     ) -> Self {
@@ -131,7 +131,7 @@ impl<'a> AsyncBytesPartialDecoder<'a> {
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder<'_> {
+impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder {
     fn data_type(&self) -> &DataType {
         self.decoded_representation.data_type()
     }

--- a/zarrs/src/array/codec/array_to_bytes/pcodec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec.rs
@@ -242,7 +242,9 @@ mod tests {
         let bytes = transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
 
-        let codec = PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap());
+        let codec = Arc::new(PcodecCodec::new_with_configuration(
+            &serde_json::from_str(JSON_VALID).unwrap(),
+        ));
 
         let encoded = codec
             .encode(
@@ -290,7 +292,9 @@ mod tests {
         let bytes = transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
 
-        let codec = PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap());
+        let codec = Arc::new(PcodecCodec::new_with_configuration(
+            &serde_json::from_str(JSON_VALID).unwrap(),
+        ));
 
         let encoded = codec
             .encode(

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
@@ -227,12 +227,12 @@ impl ArrayToBytesCodecTraits for PcodecCodec {
         Ok(ArrayBytes::from(bytes))
     }
 
-    fn partial_decoder<'a>(
-        &self,
-        input_handle: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(pcodec_partial_decoder::PcodecPartialDecoder::new(
             input_handle,
             decoded_representation.clone(),
@@ -240,12 +240,12 @@ impl ArrayToBytesCodecTraits for PcodecCodec {
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             pcodec_partial_decoder::AsyncPCodecPartialDecoder::new(
                 input_handle,

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
@@ -118,16 +118,16 @@ impl ArrayPartialDecoderTraits for PcodecPartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `bytes` codec.
-pub struct AsyncPCodecPartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncPCodecPartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: ChunkRepresentation,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncPCodecPartialDecoder<'a> {
+impl AsyncPCodecPartialDecoder {
     /// Create a new partial decoder for the `bytes` codec.
     pub fn new(
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: ChunkRepresentation,
     ) -> Self {
         Self {
@@ -139,7 +139,7 @@ impl<'a> AsyncPCodecPartialDecoder<'a> {
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncArrayPartialDecoderTraits for AsyncPCodecPartialDecoder<'_> {
+impl AsyncArrayPartialDecoderTraits for AsyncPCodecPartialDecoder {
     fn data_type(&self) -> &DataType {
         self.decoded_representation.data_type()
     }

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec_builder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec_builder.rs
@@ -110,16 +110,16 @@ impl ShardingCodecBuilder {
     /// Build into a [`ShardingCodec`].
     #[must_use]
     pub fn build(&self) -> ShardingCodec {
-        let inner_codecs = CodecChain::new(
+        let inner_codecs = Arc::new(CodecChain::new(
             self.array_to_array_codecs.clone(),
             self.array_to_bytes_codec.clone(),
             self.bytes_to_bytes_codecs.clone(),
-        );
-        let index_codecs = CodecChain::new(
+        ));
+        let index_codecs = Arc::new(CodecChain::new(
             vec![],
             self.index_array_to_bytes_codec.clone(),
             self.index_bytes_to_bytes_codecs.clone(),
-        );
+        ));
         ShardingCodec::new(
             self.inner_chunk_shape.clone(),
             inner_codecs,

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
@@ -118,12 +118,12 @@ impl ArrayToBytesCodecTraits for VlenV2Codec {
         Ok(ArrayBytes::new_vlen(bytes, offsets))
     }
 
-    fn partial_decoder<'a>(
-        &self,
-        input_handle: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::vlen_v2_partial_decoder::VlenV2PartialDecoder::new(
                 input_handle,
@@ -133,12 +133,12 @@ impl ArrayToBytesCodecTraits for VlenV2Codec {
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::vlen_v2_partial_decoder::AsyncVlenV2PartialDecoder::new(
                 input_handle,

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_partial_decoder.rs
@@ -78,16 +78,16 @@ impl ArrayPartialDecoderTraits for VlenV2PartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `bytes` codec.
-pub struct AsyncVlenV2PartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncVlenV2PartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: ChunkRepresentation,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncVlenV2PartialDecoder<'a> {
+impl AsyncVlenV2PartialDecoder {
     /// Create a new partial decoder for the `bytes` codec.
     pub fn new(
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: ChunkRepresentation,
     ) -> Self {
         Self {
@@ -99,7 +99,7 @@ impl<'a> AsyncVlenV2PartialDecoder<'a> {
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncArrayPartialDecoderTraits for AsyncVlenV2PartialDecoder<'_> {
+impl AsyncArrayPartialDecoderTraits for AsyncVlenV2PartialDecoder {
     fn data_type(&self) -> &DataType {
         self.decoded_representation.data_type()
     }

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -523,7 +523,7 @@ mod tests {
         let bytes: ArrayBytes = bytes.into();
 
         let configuration: ZfpCodecConfiguration = serde_json::from_str(JSON_REVERSIBLE).unwrap();
-        let codec = ZfpCodec::new_with_configuration(&configuration);
+        let codec = Arc::new(ZfpCodec::new_with_configuration(&configuration));
 
         let encoded = codec
             .encode(
@@ -579,7 +579,7 @@ mod tests {
         let bytes: ArrayBytes = bytes.into();
 
         let configuration: ZfpCodecConfiguration = serde_json::from_str(JSON_REVERSIBLE).unwrap();
-        let codec = ZfpCodec::new_with_configuration(&configuration);
+        let codec = Arc::new(ZfpCodec::new_with_configuration(&configuration));
 
         let max_encoded_size = codec.compute_encoded_size(&chunk_representation).unwrap();
         let encoded = codec

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -238,12 +238,12 @@ impl ArrayToBytesCodecTraits for ZfpCodec {
         .map(ArrayBytes::from)
     }
 
-    fn partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(zfp_partial_decoder::ZfpPartialDecoder::new(
             input_handle,
             decoded_representation,
@@ -253,12 +253,12 @@ impl ArrayToBytesCodecTraits for ZfpCodec {
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(zfp_partial_decoder::AsyncZfpPartialDecoder::new(
             input_handle,
             decoded_representation,

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
@@ -111,18 +111,18 @@ impl ArrayPartialDecoderTraits for ZfpPartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `zfp` codec.
-pub struct AsyncZfpPartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncZfpPartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: ChunkRepresentation,
     mode: ZfpMode,
     write_header: bool,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncZfpPartialDecoder<'a> {
+impl AsyncZfpPartialDecoder {
     /// Create a new partial decoder for the `zfp` codec.
     pub fn new(
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         decoded_representation: &ChunkRepresentation,
         mode: ZfpMode,
         write_header: bool,
@@ -144,7 +144,7 @@ impl<'a> AsyncZfpPartialDecoder<'a> {
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder<'_> {
+impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder {
     fn data_type(&self) -> &DataType {
         self.decoded_representation.data_type()
     }

--- a/zarrs/src/array/codec/byte_interval_partial_decoder.rs
+++ b/zarrs/src/array/codec/byte_interval_partial_decoder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     array::RawBytes,
     byte_range::{ByteLength, ByteOffset, ByteRange},
@@ -11,16 +13,16 @@ use super::AsyncBytesPartialDecoderTraits;
 /// A partial decoder for a byte interval of a [`BytesPartialDecoderTraits`] partial decoder.
 ///
 /// Modifies byte range requests to a specific byte interval in an inner bytes partial decoder.
-pub struct ByteIntervalPartialDecoder<'a> {
-    inner: &'a dyn BytesPartialDecoderTraits,
+pub struct ByteIntervalPartialDecoder {
+    inner: Arc<dyn BytesPartialDecoderTraits>,
     byte_offset: ByteOffset,
     byte_length: ByteLength,
 }
 
-impl<'a> ByteIntervalPartialDecoder<'a> {
+impl ByteIntervalPartialDecoder {
     /// Create a new byte interval partial decoder.
     pub fn new(
-        inner: &'a dyn BytesPartialDecoderTraits,
+        inner: Arc<dyn BytesPartialDecoderTraits>,
         byte_offset: ByteOffset,
         byte_length: ByteLength,
     ) -> Self {
@@ -32,7 +34,7 @@ impl<'a> ByteIntervalPartialDecoder<'a> {
     }
 }
 
-impl<'a> BytesPartialDecoderTraits for ByteIntervalPartialDecoder<'a> {
+impl BytesPartialDecoderTraits for ByteIntervalPartialDecoder {
     fn partial_decode(
         &self,
         byte_ranges: &[ByteRange],
@@ -64,17 +66,17 @@ impl<'a> BytesPartialDecoderTraits for ByteIntervalPartialDecoder<'a> {
 /// A partial decoder for a byte interval of a [`AsyncBytesPartialDecoderTraits`] partial decoder.
 ///
 /// Modifies byte range requests to a specific byte interval in an inner bytes partial decoder.
-pub struct AsyncByteIntervalPartialDecoder<'a> {
-    inner: &'a dyn AsyncBytesPartialDecoderTraits,
+pub struct AsyncByteIntervalPartialDecoder {
+    inner: Arc<dyn AsyncBytesPartialDecoderTraits>,
     byte_offset: ByteOffset,
     byte_length: ByteLength,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncByteIntervalPartialDecoder<'a> {
+impl AsyncByteIntervalPartialDecoder {
     /// Create a new byte interval partial decoder.
     pub fn new(
-        inner: &'a dyn AsyncBytesPartialDecoderTraits,
+        inner: Arc<dyn AsyncBytesPartialDecoderTraits>,
         byte_offset: ByteOffset,
         byte_length: ByteLength,
     ) -> Self {
@@ -88,7 +90,7 @@ impl<'a> AsyncByteIntervalPartialDecoder<'a> {
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl<'a> AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder<'a> {
+impl AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder {
     async fn partial_decode(
         &self,
         byte_ranges: &[ByteRange],

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
@@ -356,10 +356,10 @@ mod tests {
 
         let codec_configuration: BloscCodecConfiguration =
             serde_json::from_str(JSON_VALID2).unwrap();
-        let codec = BloscCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec = Arc::new(BloscCodec::new_with_configuration(&codec_configuration).unwrap());
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
@@ -403,10 +403,10 @@ mod tests {
 
         let codec_configuration: BloscCodecConfiguration =
             serde_json::from_str(JSON_VALID2).unwrap();
-        let codec = BloscCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec = Arc::new(BloscCodec::new_with_configuration(&codec_configuration).unwrap());
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_codec.rs
@@ -196,24 +196,24 @@ impl BytesToBytesCodecTraits for BloscCodec {
         Ok(Cow::Owned(Self::do_decode(&encoded_value, n_threads)?))
     }
 
-    fn partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _parallel: &CodecOptions,
-    ) -> Result<Arc<dyn BytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(blosc_partial_decoder::BloscPartialDecoder::new(
             input_handle,
         )))
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _parallel: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             blosc_partial_decoder::AsyncBloscPartialDecoder::new(input_handle),
         ))

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
@@ -66,20 +66,20 @@ impl BytesPartialDecoderTraits for BloscPartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `blosc` codec.
-pub struct AsyncBloscPartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncBloscPartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncBloscPartialDecoder<'a> {
-    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>) -> Self {
+impl AsyncBloscPartialDecoder {
+    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>) -> Self {
         Self { input_handle }
     }
 }
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder<'_> {
+impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder {
     async fn partial_decode(
         &self,
         decoded_regions: &[ByteRange],

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
@@ -103,10 +103,10 @@ mod tests {
         let bytes = crate::array::transmute_to_bytes_vec(elements);
 
         let codec_configuration: Bz2CodecConfiguration = serde_json::from_str(JSON_VALID1).unwrap();
-        let codec = Bz2Codec::new_with_configuration(&codec_configuration);
+        let codec = Arc::new(Bz2Codec::new_with_configuration(&codec_configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
@@ -149,10 +149,10 @@ mod tests {
         let bytes = crate::array::transmute_to_bytes_vec(elements);
 
         let codec_configuration: Bz2CodecConfiguration = serde_json::from_str(JSON_VALID1).unwrap();
-        let codec = Bz2Codec::new_with_configuration(&codec_configuration);
+        let codec = Arc::new(Bz2Codec::new_with_configuration(&codec_configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2/bz2_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2/bz2_codec.rs
@@ -105,24 +105,24 @@ impl BytesToBytesCodecTraits for Bz2Codec {
         Ok(Cow::Owned(out))
     }
 
-    fn partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn BytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(bz2_partial_decoder::Bz2PartialDecoder::new(
             input_handle,
         )))
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(bz2_partial_decoder::AsyncBz2PartialDecoder::new(
             input_handle,
         )))

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2/bz2_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2/bz2_partial_decoder.rs
@@ -51,20 +51,20 @@ impl BytesPartialDecoderTraits for Bz2PartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `bz2` codec.
-pub struct AsyncBz2PartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncBz2PartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncBz2PartialDecoder<'a> {
-    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>) -> Self {
+impl AsyncBz2PartialDecoder {
+    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>) -> Self {
         Self { input_handle }
     }
 }
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncBytesPartialDecoderTraits for AsyncBz2PartialDecoder<'_> {
+impl AsyncBytesPartialDecoderTraits for AsyncBz2PartialDecoder {
     async fn partial_decode(
         &self,
         decoded_regions: &[ByteRange],

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
@@ -105,10 +105,10 @@ mod tests {
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
         let codec_configuration: Crc32cCodecConfiguration = serde_json::from_str(JSON1).unwrap();
-        let codec = Crc32cCodec::new_with_configuration(&codec_configuration);
+        let codec = Arc::new(Crc32cCodec::new_with_configuration(&codec_configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [ByteRange::FromStart(3, Some(2))];
         let input_handle = Arc::new(std::io::Cursor::new(encoded));
@@ -141,10 +141,10 @@ mod tests {
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
         let codec_configuration: Crc32cCodecConfiguration = serde_json::from_str(JSON1).unwrap();
-        let codec = Crc32cCodec::new_with_configuration(&codec_configuration);
+        let codec = Arc::new(Crc32cCodec::new_with_configuration(&codec_configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [ByteRange::FromStart(3, Some(2))];
         let input_handle = Arc::new(std::io::Cursor::new(encoded));

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_codec.rs
@@ -96,24 +96,24 @@ impl BytesToBytesCodecTraits for Crc32cCodec {
         }
     }
 
-    fn partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn BytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(crc32c_partial_decoder::Crc32cPartialDecoder::new(
             input_handle,
         )))
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             crc32c_partial_decoder::AsyncCrc32cPartialDecoder::new(input_handle),
         ))

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_partial_decoder.rs
@@ -64,21 +64,21 @@ impl BytesPartialDecoderTraits for Crc32cPartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `crc32c` (CRC32C checksum) codec.
-pub struct AsyncCrc32cPartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncCrc32cPartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncCrc32cPartialDecoder<'a> {
+impl AsyncCrc32cPartialDecoder {
     /// Create a new partial decoder for the `crc32c` codec.
-    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>) -> Self {
+    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>) -> Self {
         Self { input_handle }
     }
 }
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncBytesPartialDecoderTraits for AsyncCrc32cPartialDecoder<'_> {
+impl AsyncBytesPartialDecoderTraits for AsyncCrc32cPartialDecoder {
     async fn partial_decode(
         &self,
         decoded_regions: &[ByteRange],

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
@@ -295,10 +295,10 @@ mod tests {
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
         let configuration: GDeflateCodecConfiguration = serde_json::from_str(JSON_VALID).unwrap();
-        let codec = GDeflateCodec::new_with_configuration(&configuration);
+        let codec = Arc::new(GDeflateCodec::new_with_configuration(&configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),
@@ -335,10 +335,10 @@ mod tests {
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
         let configuration: GDeflateCodecConfiguration = serde_json::from_str(JSON_VALID).unwrap();
-        let codec = GDeflateCodec::new_with_configuration(&configuration);
+        let codec = Arc::new(GDeflateCodec::new_with_configuration(&configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate/gdeflate_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate/gdeflate_codec.rs
@@ -114,24 +114,24 @@ impl BytesToBytesCodecTraits for GDeflateCodec {
         Ok(Cow::Owned(gdeflate_decode(&encoded_value)?))
     }
 
-    fn partial_decoder<'a>(
-        &self,
-        r: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        r: Arc<dyn BytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn BytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             gdeflate_partial_decoder::GDeflatePartialDecoder::new(r),
         ))
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        r: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        r: Arc<dyn AsyncBytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             gdeflate_partial_decoder::AsyncGDeflatePartialDecoder::new(r),
         ))

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate/gdeflate_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate/gdeflate_partial_decoder.rs
@@ -50,21 +50,21 @@ impl BytesPartialDecoderTraits for GDeflatePartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `gdeflate` codec.
-pub struct AsyncGDeflatePartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncGDeflatePartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncGDeflatePartialDecoder<'a> {
+impl AsyncGDeflatePartialDecoder {
     /// Create a new partial decoder for the `gdeflate` codec.
-    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>) -> Self {
+    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>) -> Self {
         Self { input_handle }
     }
 }
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncBytesPartialDecoderTraits for AsyncGDeflatePartialDecoder<'_> {
+impl AsyncBytesPartialDecoderTraits for AsyncGDeflatePartialDecoder {
     async fn partial_decode(
         &self,
         decoded_regions: &[ByteRange],

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
@@ -104,10 +104,10 @@ mod tests {
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
         let configuration: GzipCodecConfiguration = serde_json::from_str(JSON_VALID).unwrap();
-        let codec = GzipCodec::new_with_configuration(&configuration);
+        let codec = Arc::new(GzipCodec::new_with_configuration(&configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),
@@ -144,10 +144,10 @@ mod tests {
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
         let configuration: GzipCodecConfiguration = serde_json::from_str(JSON_VALID).unwrap();
-        let codec = GzipCodec::new_with_configuration(&configuration);
+        let codec = Arc::new(GzipCodec::new_with_configuration(&configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
@@ -103,22 +103,22 @@ impl BytesToBytesCodecTraits for GzipCodec {
         Ok(Cow::Owned(out))
     }
 
-    fn partial_decoder<'a>(
-        &self,
-        r: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        r: Arc<dyn BytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn BytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(gzip_partial_decoder::GzipPartialDecoder::new(r)))
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        r: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        r: Arc<dyn AsyncBytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             gzip_partial_decoder::AsyncGzipPartialDecoder::new(r),
         ))

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_partial_decoder.rs
@@ -56,21 +56,21 @@ impl BytesPartialDecoderTraits for GzipPartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `gzip` codec.
-pub struct AsyncGzipPartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncGzipPartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncGzipPartialDecoder<'a> {
+impl AsyncGzipPartialDecoder {
     /// Create a new partial decoder for the `gzip` codec.
-    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>) -> Self {
+    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>) -> Self {
         Self { input_handle }
     }
 }
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncBytesPartialDecoderTraits for AsyncGzipPartialDecoder<'_> {
+impl AsyncBytesPartialDecoderTraits for AsyncGzipPartialDecoder {
     async fn partial_decode(
         &self,
         decoded_regions: &[ByteRange],

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
@@ -44,10 +44,10 @@ mod tests {
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
-        let codec: TestUnboundedCodec = TestUnboundedCodec::new();
+        let codec = Arc::new(TestUnboundedCodec::new());
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),
@@ -85,10 +85,10 @@ mod tests {
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
-        let codec: TestUnboundedCodec = TestUnboundedCodec::new();
+        let codec = Arc::new(TestUnboundedCodec::new());
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
@@ -71,24 +71,24 @@ impl BytesToBytesCodecTraits for TestUnboundedCodec {
         Ok(encoded_value)
     }
 
-    fn partial_decoder<'a>(
-        &self,
-        r: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        r: Arc<dyn BytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn BytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             test_unbounded_partial_decoder::TestUnboundedPartialDecoder::new(r),
         ))
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        r: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        r: Arc<dyn AsyncBytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             test_unbounded_partial_decoder::AsyncTestUnboundedPartialDecoder::new(r),
         ))

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
@@ -46,21 +46,21 @@ impl BytesPartialDecoderTraits for TestUnboundedPartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `test_unbounded` codec.
-pub struct AsyncTestUnboundedPartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncTestUnboundedPartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncTestUnboundedPartialDecoder<'a> {
+impl AsyncTestUnboundedPartialDecoder {
     /// Create a new partial decoder for the `test_unbounded` codec.
-    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>) -> Self {
+    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>) -> Self {
         Self { input_handle }
     }
 }
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder<'_> {
+impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder {
     async fn partial_decode(
         &self,
         decoded_regions: &[ByteRange],

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
@@ -85,10 +85,10 @@ mod tests {
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
         let configuration: ZstdCodecConfiguration = serde_json::from_str(JSON_VALID).unwrap();
-        let codec = ZstdCodec::new_with_configuration(&configuration);
+        let codec = Arc::new(ZstdCodec::new_with_configuration(&configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),
@@ -126,10 +126,10 @@ mod tests {
         let bytes_representation = BytesRepresentation::FixedSize(bytes.len() as u64);
 
         let configuration: ZstdCodecConfiguration = serde_json::from_str(JSON_VALID).unwrap();
-        let codec = ZstdCodec::new_with_configuration(&configuration);
+        let codec = Arc::new(ZstdCodec::new_with_configuration(&configuration));
 
         let encoded = codec
-            .encode(Cow::Borrowed(&bytes), &CodecOptions::default())
+            .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
         let decoded_regions = [
             ByteRange::FromStart(4, Some(4)),

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd/zstd_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd/zstd_codec.rs
@@ -102,22 +102,22 @@ impl BytesToBytesCodecTraits for ZstdCodec {
             .map(Cow::Owned)
     }
 
-    fn partial_decoder<'a>(
-        &self,
-        r: Arc<dyn BytesPartialDecoderTraits + 'a>,
+    fn partial_decoder(
+        self: Arc<Self>,
+        r: Arc<dyn BytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn BytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(zstd_partial_decoder::ZstdPartialDecoder::new(r)))
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder<'a>(
-        &'a self,
-        r: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        r: Arc<dyn AsyncBytesPartialDecoderTraits>,
         _decoded_representation: &BytesRepresentation,
         _options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits + 'a>, CodecError> {
+    ) -> Result<Arc<dyn AsyncBytesPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             zstd_partial_decoder::AsyncZstdPartialDecoder::new(r),
         ))

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd/zstd_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd/zstd_partial_decoder.rs
@@ -50,21 +50,21 @@ impl BytesPartialDecoderTraits for ZstdPartialDecoder<'_> {
 
 #[cfg(feature = "async")]
 /// Asynchronous partial decoder for the `zstd` codec.
-pub struct AsyncZstdPartialDecoder<'a> {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>,
+pub struct AsyncZstdPartialDecoder {
+    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
 }
 
 #[cfg(feature = "async")]
-impl<'a> AsyncZstdPartialDecoder<'a> {
+impl AsyncZstdPartialDecoder {
     /// Create a new partial decoder for the `zstd` codec.
-    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits + 'a>) -> Self {
+    pub fn new(input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>) -> Self {
         Self { input_handle }
     }
 }
 
 #[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl AsyncBytesPartialDecoderTraits for AsyncZstdPartialDecoder<'_> {
+impl AsyncBytesPartialDecoderTraits for AsyncZstdPartialDecoder {
     async fn partial_decode(
         &self,
         decoded_regions: &[ByteRange],


### PR DESCRIPTION
Remove lifetime constraints in partial decoder API. This is possible since #69 required that codecs be `Arc`'d.