### PR TITLE
Change performance metrics and usage log storage transformers to storage adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Change `Contiguous[Linearised]Indices` iterators to return indices only
 - **Breaking**: Remove lifetime constraints in partial decoder API by utilising `Arc`'d codecs
 - **Breaking**: `ShardingCodec::new` `CodecChain` parameters now must be in an `Arc`
+- **Breaking**: Change `UsageLogStorageTransformer` to `UsageLogStorageAdapter` and move to `zarrs_storage`
+- **Breaking**: Change `PerformanceMetricsStorageTransformer` to `PerformanceMetricsStorageAdapter` and move to `zarrs_storage`
 
 ### Fixed
 - Fixed an unnecessary copy in `Array::[async_]retrieve_chunk_if_exists_opt`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.1.0"
 path = "zarrs_metadata"
 
 [workspace.dependencies.zarrs_storage]
-version = "0.2.0"
+version = "0.2.1"
 path = "zarrs_storage"
 
 [workspace.dependencies.zarrs_filesystem]

--- a/examples/array_write_read.rs
+++ b/examples/array_write_read.rs
@@ -1,7 +1,6 @@
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use zarrs::{
-    array::storage_transformer::{StorageTransformerExtension, UsageLogStorageTransformer},
-    storage::ReadableWritableListableStorage,
+use zarrs::storage::{
+    storage_adapter::usage_log::UsageLogStorageAdapter, ReadableWritableListableStorage,
 };
 
 fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
@@ -28,12 +27,9 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
                 std::io::stdout(),
                 //    )
             ));
-            let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
+            store = Arc::new(UsageLogStorageAdapter::new(store, log_writer, || {
                 chrono::Utc::now().format("[%T%.3f] ").to_string()
             }));
-            store = usage_log
-                .clone()
-                .create_readable_writable_listable_transformer(store);
         }
     }
 

--- a/examples/array_write_read_ndarray.rs
+++ b/examples/array_write_read_ndarray.rs
@@ -1,8 +1,7 @@
 use ndarray::{array, Array2, ArrayD};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use zarrs::{
-    array::storage_transformer::{StorageTransformerExtension, UsageLogStorageTransformer},
-    storage::ReadableWritableListableStorage,
+use zarrs::storage::{
+    storage_adapter::usage_log::UsageLogStorageAdapter, ReadableWritableListableStorage,
 };
 
 fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
@@ -29,12 +28,9 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
                 std::io::stdout(),
                 //    )
             ));
-            let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
+            store = Arc::new(UsageLogStorageAdapter::new(store, log_writer, || {
                 chrono::Utc::now().format("[%T%.3f] ").to_string()
             }));
-            store = usage_log
-                .clone()
-                .create_readable_writable_listable_transformer(store);
         }
     }
 

--- a/examples/array_write_read_string.rs
+++ b/examples/array_write_read_string.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use ndarray::{array, Array2, ArrayD};
 use zarrs::{
-    array::storage_transformer::{StorageTransformerExtension, UsageLogStorageTransformer},
+    storage::storage_adapter::usage_log::UsageLogStorageAdapter,
     storage::ReadableWritableListableStorage,
 };
 
@@ -28,12 +28,9 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
                 std::io::stdout(),
                 //    )
             ));
-            let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
+            store = Arc::new(UsageLogStorageAdapter::new(store, log_writer, || {
                 chrono::Utc::now().format("[%T%.3f] ").to_string()
             }));
-            store = usage_log
-                .clone()
-                .create_readable_writable_listable_transformer(store);
         }
     }
 

--- a/examples/async_array_write_read.rs
+++ b/examples/async_array_write_read.rs
@@ -1,7 +1,6 @@
 use futures::TryStreamExt;
-use zarrs::{
-    array::storage_transformer::{StorageTransformerExtension, UsageLogStorageTransformer},
-    storage::AsyncReadableWritableListableStorage,
+use zarrs::storage::{
+    storage_adapter::usage_log::UsageLogStorageAdapter, AsyncReadableWritableListableStorage,
 };
 
 async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
@@ -24,12 +23,9 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
                 std::io::stdout(),
                 //    )
             ));
-            let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
+            store = Arc::new(UsageLogStorageAdapter::new(store, log_writer, || {
                 chrono::Utc::now().format("[%T%.3f] ").to_string()
             }));
-            store = usage_log
-                .clone()
-                .create_async_readable_writable_listable_transformer(store);
         }
     }
 

--- a/examples/rectangular_array_write_read.rs
+++ b/examples/rectangular_array_write_read.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
-
-use zarrs::{
-    array::storage_transformer::{StorageTransformerExtension, UsageLogStorageTransformer},
-    storage::ReadableWritableListableStorage,
+use zarrs::storage::{
+    storage_adapter::usage_log::UsageLogStorageAdapter, ReadableWritableListableStorage,
 };
 
 fn rectangular_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
@@ -30,12 +28,9 @@ fn rectangular_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
                 std::io::stdout(),
                 //    )
             ));
-            let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
+            store = Arc::new(UsageLogStorageAdapter::new(store, log_writer, || {
                 chrono::Utc::now().format("[%T%.3f] ").to_string()
             }));
-            store = usage_log
-                .clone()
-                .create_readable_writable_listable_transformer(store);
         }
     }
 

--- a/examples/sharded_array_write_read.rs
+++ b/examples/sharded_array_write_read.rs
@@ -1,8 +1,9 @@
 use itertools::Itertools;
 use zarrs::{
     array::bytes_to_ndarray,
-    array::storage_transformer::{StorageTransformerExtension, UsageLogStorageTransformer},
-    storage::ReadableWritableListableStorage,
+    storage::{
+        storage_adapter::usage_log::UsageLogStorageAdapter, ReadableWritableListableStorage,
+    },
 };
 
 fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
@@ -34,12 +35,9 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
                 std::io::stdout(),
                 //    )
             ));
-            let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
+            store = Arc::new(UsageLogStorageAdapter::new(store, log_writer, || {
                 chrono::Utc::now().format("[%T%.3f] ").to_string()
             }));
-            store = usage_log
-                .clone()
-                .create_readable_writable_listable_transformer(store);
         }
     }
 

--- a/examples/zip_array_write_read.rs
+++ b/examples/zip_array_write_read.rs
@@ -6,9 +6,9 @@ use std::{
 };
 
 use zarrs::{
-    array::storage_transformer::{StorageTransformerExtension, UsageLogStorageTransformer},
     array::{Array, ZARR_NAN_F32},
     array_subset::ArraySubset,
+    storage::storage_adapter::usage_log::UsageLogStorageAdapter,
     storage::{
         ReadableStorageTraits, ReadableWritableListableStorage, ReadableWritableStorageTraits,
         StoreKey,
@@ -161,12 +161,9 @@ fn zip_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
                 std::io::stdout(),
                 //    )
             ));
-            let usage_log = Arc::new(UsageLogStorageTransformer::new(log_writer, || {
+            store = Arc::new(UsageLogStorageAdapter::new(store, log_writer, || {
                 chrono::Utc::now().format("[%T%.3f] ").to_string()
             }));
-            store = usage_log
-                .clone()
-                .create_readable_writable_listable_transformer(store);
         }
     }
 

--- a/zarrs/doc/status/storage_transformers.md
+++ b/zarrs/doc/status/storage_transformers.md
@@ -1,6 +1,1 @@
 Zarr V3 does not currently define any storage transformers.
-
-`zarrs` supports two internal storage transformers for debugging: [usage log] and [performance metrics].
-
-[usage log]: crate::array::storage_transformer::UsageLogStorageTransformer
-[performance metrics]: crate::array::storage_transformer::PerformanceMetricsStorageTransformer

--- a/zarrs/doc/status/stores.md
+++ b/zarrs/doc/status/stores.md
@@ -1,18 +1,21 @@
-| Store/Storage Adapter       | ZEP       | Read     | Write    | List     | Sync    | Async   | Crate                |
-| --------------------------- | --------  | -------- | -------- | -------- | ------- | ------- | -------------------- |
-| [MemoryStore]               |           | &check;  | &check;  | &check;  | &check; |         | [zarrs_storage]      |
-| [FilesystemStore]           | [ZEP0001] | &check;  | &check;  | &check;  | &check; |         | [zarrs_filesystem]   |
-| [OpendalStore]              |           | &check;* | &check;* | &check;* | &check; |         | [zarrs_opendal]      |
-| [AsyncOpendalStore]         |           | &check;* | &check;* | &check;* |         | &check; | [zarrs_opendal]      |
-| [AsyncObjectStore]          |           | &check;* | &check;* | &check;* |         | &check; | [zarrs_object_store] |
-| [HTTPStore]                 |           | &check;  |          |          | &check; |         | [zarrs_http]         |
-| [ZipStorageAdapter]         |           | &check;  |          | &check;  | &check; |         | [zarrs_zip]          |
+| Store/Storage Adapter              | ZEP    | Read     | Write    | List     | Sync    | Async   | Crate                       |
+| ---------------------------------- | ------ | -------- | -------- | -------- | ------- | ------- | --------------------------- |
+| [MemoryStore]                      |        | &check;  | &check;  | &check;  | &check; |         | [zarrs_storage]<sup>†</sup> |
+| [FilesystemStore]                  | [0001] | &check;  | &check;  | &check;  | &check; |         | [zarrs_filesystem]          |
+| [OpendalStore]                     |        | &check;* | &check;* | &check;* | &check; |         | [zarrs_opendal]             |
+| [AsyncOpendalStore]                |        | &check;* | &check;* | &check;* |         | &check; | [zarrs_opendal]             |
+| [AsyncObjectStore]                 |        | &check;* | &check;* | &check;* |         | &check; | [zarrs_object_store]        |
+| [HTTPStore]                        |        | &check;  |          |          | &check; |         | [zarrs_http]                |
+| [AsyncToSyncStorageAdapter]        |        | &check;  | &check;  | &check;  | &check; | &check; | [zarrs_storage]<sup>†</sup> |
+| [UsageLogStorageAdapter]           |        | &check;  | &check;  | &check;  | &check; | &check; | [zarrs_storage]<sup>†</sup> |
+| [PerformanceMetricsStorageAdapter] |        | &check;  | &check;  | &check;  | &check; | &check; | [zarrs_storage]<sup>†</sup> |
+| [ZipStorageAdapter]                |        | &check;  |          | &check;  | &check; |         | [zarrs_zip]                 |
 
+<sup>† Re-exported in the `zarrs::storage` module</sup>
+<br>
 <sup>\* Support depends on the [`opendal`](https://docs.rs/opendal/latest/opendal/) [`BlockingOperator`](https://docs.rs/opendal/latest/opendal/struct.BlockingOperator.html)/[`Operator`](https://docs.rs/opendal/latest/opendal/struct.Operator.html) or [`object_store`](https://docs.rs/object_store/latest/object_store/) [store](https://docs.rs/object_store/latest/object_store/index.html#modules).</sup>
 
-[ZEP0001]: https://zarr.dev/zeps/accepted/ZEP0001.html
-
-[AsyncToSyncStorageAdapter]: crate::storage::storage_adapter::async_to_sync::AsyncToSyncStorageAdapter
+[0001]: https://zarr.dev/zeps/accepted/ZEP0001.html
 
 [zarrs_storage]: https://docs.rs/zarrs_storage/latest/zarrs_storage/
 [zarrs_filesystem]: https://docs.rs/zarrs_filesystem/latest/zarrs_filesystem/
@@ -27,4 +30,8 @@
 [AsyncOpendalStore]: https://docs.rs/zarrs_opendal/latest/zarrs_opendal/struct.AsyncOpendalStore.html
 [AsyncObjectStore]: https://docs.rs/zarrs_object_store/latest/zarrs_object_store/struct.AsyncObjectStore.html
 [HTTPStore]: https://docs.rs/zarrs_http/latest/zarrs_http/struct.HTTPStore.html
+
+[AsyncToSyncStorageAdapter]: crate::storage::storage_adapter::async_to_sync::AsyncToSyncStorageAdapter
+[UsageLogStorageAdapter]: crate::storage::storage_adapter::usage_log::UsageLogStorageAdapter
+[PerformanceMetricsStorageAdapter]: crate::storage::storage_adapter::performance_metrics::PerformanceMetricsStorageAdapter
 [ZipStorageAdapter]: https://docs.rs/zarrs_zip/latest/zarrs_zip/struct.ZipStorageAdapter.html

--- a/zarrs/src/array/storage_transformer.rs
+++ b/zarrs/src/array/storage_transformer.rs
@@ -1,20 +1,13 @@
 //! Zarr storage transformers.
 //!
-//! Includes [performance metrics](performance_metrics::PerformanceMetricsStorageTransformer) and [usage log](usage_log::UsageLogStorageTransformer) implementations for internal use.
-//!
 //! A Zarr storage transformer modifies a request to read or write data before passing that request to a following storage transformer or store.
 //! A [`StorageTransformerChain`] represents a sequence of storage transformers.
 //! A storage transformer chain and individual storage transformers all have the same interface as a [store](crate::storage::store).
 //!
 //! See <https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#id23>.
 
-mod performance_metrics;
 mod storage_transformer_chain;
-mod usage_log;
-
-pub use performance_metrics::PerformanceMetricsStorageTransformer;
 pub use storage_transformer_chain::StorageTransformerChain;
-pub use usage_log::UsageLogStorageTransformer;
 
 use std::sync::Arc;
 
@@ -125,62 +118,4 @@ pub trait StorageTransformerExtension: core::fmt::Debug + Send + Sync {
         self: Arc<Self>,
         storage: AsyncReadableWritableListableStorage,
     ) -> AsyncReadableWritableListableStorage;
-}
-
-#[cfg(test)]
-mod tests {
-    use std::io::Write;
-
-    use crate::storage::{store::MemoryStore, StoreKey};
-
-    use super::*;
-
-    #[test]
-    fn transformers_multithreaded() {
-        use rayon::prelude::*;
-
-        let store = Arc::new(MemoryStore::default());
-
-        let log_writer = Arc::new(std::sync::Mutex::new(std::io::BufWriter::new(
-            std::io::stdout(),
-        )));
-
-        // let storage_transformer_usage_log = Arc::new(self::storage_transformer::UsageLogStorageTransformer::new(
-        //     || "mt_log: ".to_string(),
-        //     log_writer.clone(),
-        // ));
-        let storage_transformer_performance_metrics =
-            Arc::new(PerformanceMetricsStorageTransformer::new());
-        let storage_transformer_chain = StorageTransformerChain::new(vec![
-            // storage_transformer_usage_log.clone(),
-            storage_transformer_performance_metrics.clone(),
-        ]);
-        let transformer =
-            storage_transformer_chain.create_readable_writable_transformer(store.clone());
-        let transformer_listable = storage_transformer_chain.create_listable_transformer(store);
-
-        (0..10).into_par_iter().for_each(|_| {
-            transformer_listable.list().unwrap();
-        });
-
-        (0..10).into_par_iter().for_each(|i| {
-            transformer
-                .set(&StoreKey::new(&i.to_string()).unwrap(), vec![i; 5].into())
-                .unwrap();
-        });
-
-        for i in 0..10 {
-            let _ = transformer.get(&StoreKey::new(&i.to_string()).unwrap());
-        }
-
-        log_writer.lock().unwrap().flush().unwrap();
-
-        println!(
-            "stats\n\t{}\n\t{}\n\t{}\n\t{}",
-            storage_transformer_performance_metrics.bytes_written(),
-            storage_transformer_performance_metrics.bytes_read(),
-            storage_transformer_performance_metrics.writes(),
-            storage_transformer_performance_metrics.reads()
-        );
-    }
 }

--- a/zarrs/tests/zarr_python_compat.rs
+++ b/zarrs/tests/zarr_python_compat.rs
@@ -1,8 +1,7 @@
 use std::{error::Error, path::PathBuf, sync::Arc};
 
-use zarrs::{array::Array, array_subset::ArraySubset};
+use zarrs::{array::Array, array_subset::ArraySubset, storage::StoreKey};
 use zarrs_filesystem::FilesystemStore;
-use zarrs_storage::StoreKey;
 use zarrs_zip::ZipStorageAdapter;
 
 #[test]

--- a/zarrs_storage/CHANGELOG.md
+++ b/zarrs_storage/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - Add `storage_adapter::usage_log::UsageLogStorageAdapter`
+ - Add `storage_adapter::performance_metrics::PerformanceMetricsStorageAdapter`
+
 ## [0.2.0] - 2024-09-15
 
 ### Changed 

--- a/zarrs_storage/Cargo.toml
+++ b/zarrs_storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs_storage"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.76"
@@ -29,4 +29,5 @@ thiserror = "1.0.61"
 unsafe_cell_slice = "0.1.0"
 
 [dev-dependencies]
+chrono = "0.4"
 tempfile = "3"

--- a/zarrs_storage/src/storage_adapter.rs
+++ b/zarrs_storage/src/storage_adapter.rs
@@ -4,3 +4,6 @@
 
 #[cfg(feature = "async")]
 pub mod async_to_sync;
+
+pub mod performance_metrics;
+pub mod usage_log;

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -265,12 +265,13 @@ pub trait AsyncWritableStorageTraits: Send + Sync {
 pub trait AsyncReadableWritableStorageTraits:
     AsyncReadableStorageTraits + AsyncWritableStorageTraits
 {
-    // /// Returns the mutex for the store value at `key`.
-    // ///
-    // /// # Errors
-    // /// Returns a [`StorageError`] if the mutex cannot be retrieved.
-    // async fn mutex(&self, key: &StoreKey) -> Result<AsyncStoreKeyMutex, StorageError>;
 }
+
+// FIXME: Enable this in the next major release
+// impl<T> AsyncReadableWritableStorageTraits for T where
+//     T: AsyncReadableStorageTraits + AsyncWritableStorageTraits
+// {
+// }
 
 /// A supertrait of [`AsyncReadableStorageTraits`] and [`AsyncListableStorageTraits`].
 pub trait AsyncReadableListableStorageTraits:


### PR DESCRIPTION
These were shoehorned in as storage transformers before storage adapters were introduced.