### PR TITLE
Storage transformer refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: `ShardingCodec::new` `CodecChain` parameters now must be in an `Arc`
 - **Breaking**: Change `UsageLogStorageTransformer` to `UsageLogStorageAdapter` and move to `zarrs_storage`
 - **Breaking**: Change `PerformanceMetricsStorageTransformer` to `PerformanceMetricsStorageAdapter` and move to `zarrs_storage`
+- **Breaking**: Storage transformer refactor:
+  - Add `StorageTransformerPlugin` for storage transformer registration instead of generic `Plugin`
+  - Remove several `StorageTransformerExtension` trait methods no longer needed
+  - Change `StorageTransformerExtension::create_metadata` to return `MetadataV3` instead of an `Option`
+  - `StorageTransformerExtension::[async_]create_*_transformer` methods are now fallible
+  - `StorageTransformerExtension::async_create_*_transformer` methods are now async
+  - `StorageTransformerChain::from_metadata` and `try_create_storage_transformer` now has a `path: &NodePath` parameter
 
 ### Fixed
 - Fixed an unnecessary copy in `Array::[async_]retrieve_chunk_if_exists_opt`

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -357,7 +357,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
                 .map_err(ArrayCreateError::CodecsCreateError)?,
         );
         let storage_transformers =
-            StorageTransformerChain::from_metadata(&metadata_v3.storage_transformers)
+            StorageTransformerChain::from_metadata(&metadata_v3.storage_transformers, &path)
                 .map_err(ArrayCreateError::StorageTransformersCreateError)?;
         let chunk_key_encoding = ChunkKeyEncoding::from_metadata(&metadata_v3.chunk_key_encoding)
             .map_err(ArrayCreateError::ChunkKeyEncodingCreateError)?;

--- a/zarrs/src/array/array_async_readable.rs
+++ b/zarrs/src/array/array_async_readable.rs
@@ -129,7 +129,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_async_readable_transformer(storage_handle);
+            .create_async_readable_transformer(storage_handle)
+            .await?;
 
         storage_transformer
             .get(&self.chunk_key(chunk_indices))
@@ -300,7 +301,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_async_readable_transformer(storage_handle);
+            .create_async_readable_transformer(storage_handle)
+            .await?;
         let chunk_encoded = storage_transformer
             .get(&self.chunk_key(chunk_indices))
             .await
@@ -359,7 +361,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_async_readable_transformer(storage_handle);
+            .create_async_readable_transformer(storage_handle)
+            .await?;
         let chunk_encoded = storage_transformer
             .get(&self.chunk_key(chunk_indices))
             .await
@@ -487,7 +490,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_async_readable_transformer(storage_handle);
+            .create_async_readable_transformer(storage_handle)
+            .await?;
 
         let retrieve_encoded_chunk = |chunk_indices: Vec<u64>| {
             let storage_transformer = storage_transformer.clone();
@@ -763,7 +767,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
             let storage_transformer = self
                 .storage_transformers()
-                .create_async_readable_transformer(storage_handle);
+                .create_async_readable_transformer(storage_handle)
+                .await?;
             let input_handle = Arc::new(AsyncStoragePartialDecoder::new(
                 storage_transformer,
                 self.chunk_key(chunk_indices),
@@ -814,7 +819,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
             let storage_transformer = self
                 .storage_transformers()
-                .create_async_readable_transformer(storage_handle);
+                .create_async_readable_transformer(storage_handle)
+                .await?;
             let input_handle = Arc::new(AsyncStoragePartialDecoder::new(
                 storage_transformer,
                 self.chunk_key(chunk_indices),
@@ -870,7 +876,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_async_readable_transformer(storage_handle);
+            .create_async_readable_transformer(storage_handle)
+            .await?;
         let input_handle = Arc::new(AsyncStoragePartialDecoder::new(
             storage_transformer,
             self.chunk_key(chunk_indices),

--- a/zarrs/src/array/array_async_writable.rs
+++ b/zarrs/src/array/array_async_writable.rs
@@ -33,7 +33,8 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_async_writable_transformer(storage_handle);
+            .create_async_writable_transformer(storage_handle)
+            .await?;
 
         // Get the metadata with options applied and store
         let metadata = self.metadata_opt(options);
@@ -194,7 +195,8 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_async_writable_transformer(storage_handle);
+            .create_async_writable_transformer(storage_handle)
+            .await?;
         storage_transformer
             .erase(&self.chunk_key(chunk_indices))
             .await
@@ -206,7 +208,8 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_async_writable_transformer(storage_handle);
+            .create_async_writable_transformer(storage_handle)
+            .await?;
         let erase_chunk = |chunk_indices: Vec<u64>| {
             let storage_transformer = storage_transformer.clone();
             async move {
@@ -267,7 +270,8 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_async_writable_transformer(storage_handle);
+            .create_async_writable_transformer(storage_handle)
+            .await?;
         storage_transformer
             .set(&self.chunk_key(chunk_indices), encoded_chunk_bytes)
             .await?;

--- a/zarrs/src/array/array_sync_readable.rs
+++ b/zarrs/src/array/array_sync_readable.rs
@@ -155,7 +155,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_readable_transformer(storage_handle);
+            .create_readable_transformer(storage_handle)?;
 
         storage_transformer
             .get(&self.chunk_key(chunk_indices))
@@ -226,7 +226,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_readable_transformer(storage_handle);
+            .create_readable_transformer(storage_handle)?;
 
         let retrieve_encoded_chunk = |chunk_indices: Vec<u64>| {
             storage_transformer
@@ -433,7 +433,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_readable_transformer(storage_handle);
+            .create_readable_transformer(storage_handle)?;
         let chunk_encoded = storage_transformer
             .get(&self.chunk_key(chunk_indices))
             .map_err(ArrayError::StorageError)?;
@@ -484,7 +484,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_readable_transformer(storage_handle);
+            .create_readable_transformer(storage_handle)?;
         let chunk_encoded = storage_transformer
             .get(&self.chunk_key(chunk_indices))
             .map_err(ArrayError::StorageError)?;
@@ -824,7 +824,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
             let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
             let storage_transformer = self
                 .storage_transformers()
-                .create_readable_transformer(storage_handle);
+                .create_readable_transformer(storage_handle)?;
             let input_handle = Arc::new(StoragePartialDecoder::new(
                 storage_transformer,
                 self.chunk_key(chunk_indices),
@@ -867,7 +867,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
             let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
             let storage_transformer = self
                 .storage_transformers()
-                .create_readable_transformer(storage_handle);
+                .create_readable_transformer(storage_handle)?;
             let input_handle = Arc::new(StoragePartialDecoder::new(
                 storage_transformer,
                 self.chunk_key(chunk_indices),
@@ -919,7 +919,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_readable_transformer(storage_handle);
+            .create_readable_transformer(storage_handle)?;
         let input_handle = Arc::new(StoragePartialDecoder::new(
             storage_transformer,
             self.chunk_key(chunk_indices),

--- a/zarrs/src/array/array_sync_writable.rs
+++ b/zarrs/src/array/array_sync_writable.rs
@@ -38,7 +38,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_writable_transformer(storage_handle);
+            .create_writable_transformer(storage_handle)?;
 
         // Get the metadata with options applied and store
         let metadata = self.metadata_opt(options);
@@ -231,7 +231,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_writable_transformer(storage_handle);
+            .create_writable_transformer(storage_handle)?;
         storage_transformer.erase(&self.chunk_key(chunk_indices))
     }
 
@@ -243,7 +243,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_writable_transformer(storage_handle);
+            .create_writable_transformer(storage_handle)?;
         let erase_chunk =
             |chunk_indices: Vec<u64>| storage_transformer.erase(&self.chunk_key(&chunk_indices));
 
@@ -301,7 +301,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> Array<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
-            .create_writable_transformer(storage_handle);
+            .create_writable_transformer(storage_handle)?;
         storage_transformer.set(&self.chunk_key(chunk_indices), encoded_chunk_bytes)?;
 
         Ok(())

--- a/zarrs/src/array/storage_transformer/storage_transformer_plugin.rs
+++ b/zarrs/src/array/storage_transformer/storage_transformer_plugin.rs
@@ -1,0 +1,60 @@
+use crate::{metadata::v3::MetadataV3, node::NodePath, plugin::PluginCreateError};
+
+use super::StorageTransformer;
+
+/// A storage transformer plugin.
+pub struct StorageTransformerPlugin {
+    /// the identifier of the plugin.
+    identifier: &'static str,
+    /// Tests if the name is a match for this plugin.
+    match_name_fn: fn(name: &str) -> bool,
+    /// Create an implementation of this plugin from metadata.
+    create_fn:
+        fn(metadata: &MetadataV3, path: &NodePath) -> Result<StorageTransformer, PluginCreateError>,
+}
+inventory::collect!(StorageTransformerPlugin);
+
+impl StorageTransformerPlugin {
+    /// Create a new plugin for registration.
+    pub const fn new(
+        identifier: &'static str,
+        match_name_fn: fn(name: &str) -> bool,
+        create_fn: fn(
+            metadata: &MetadataV3,
+            path: &NodePath,
+        ) -> Result<StorageTransformer, PluginCreateError>,
+    ) -> Self {
+        Self {
+            identifier,
+            match_name_fn,
+            create_fn,
+        }
+    }
+
+    /// Create a storage transformer plugin from `metadata` relative to `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`PluginCreateError`] if plugin creation fails due to either:
+    ///  - metadata name being unregistered,
+    ///  - or the configuration is invalid.
+    pub fn create(
+        &self,
+        metadata: &MetadataV3,
+        path: &NodePath,
+    ) -> Result<StorageTransformer, PluginCreateError> {
+        (self.create_fn)(metadata, path)
+    }
+
+    /// Returns true if this plugin is associated with `name`.
+    #[must_use]
+    pub fn match_name(&self, name: &str) -> bool {
+        (self.match_name_fn)(name)
+    }
+
+    /// Returns the identifier of the plugin.
+    #[must_use]
+    pub const fn identifier(&self) -> &'static str {
+        self.identifier
+    }
+}


### PR DESCRIPTION
  - Add `StorageTransformerPlugin` for storage transformer registration
  - Remove several `StorageTransformerExtension` trait methods no longer needed
  - Change `StorageTransformerExtension::create_metadata` to return `MetadataV3` instead of an `Option`
  - `StorageTransformerExtension::[async_]create_*_transformer` methods are now fallible
  - `StorageTransformerExtension::async_create_*_transformer` methods are now async
  - `StorageTransformerChain::from_metadata` and `try_create_storage_transformer` now has a `path: &NodePath` parameter