### PR TITLE
zarrs_storage: Fix `data_key` on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Change `output` parameter of `decode_into` codec trait methods to `&UnsafeCellSlice<u8>`
 - **Breaking**: Add `dynamic()` to all `CodecTraits`
 - **Breaking**: Add `options` parameter to `[Async]ArrayPartialDecoderTraits::partial_decode` and remove `partial_decode_opt`
+- Bump `zarrs_storage` to 0.2.2
 
 ## [0.17.0] - 2024-10-02
 

--- a/zarrs/src/node/key.rs
+++ b/zarrs/src/node/key.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use crate::storage::StoreKey;
 
 use super::NodePath;
@@ -54,7 +52,10 @@ pub fn meta_key_v2_attributes(path: &NodePath) -> StoreKey {
 pub fn data_key(path: &NodePath, chunk_key: &StoreKey) -> StoreKey {
     let path = path.as_str();
     let path = path.strip_prefix('/').unwrap_or(path);
-    let mut key_path = PathBuf::from(path);
-    key_path.push(chunk_key.as_str());
-    unsafe { StoreKey::new_unchecked(key_path.to_string_lossy().to_string()) }
+    let key_path = if path.is_empty() {
+        chunk_key.as_str().to_string()
+    } else {
+        format!("{}/{}", path, chunk_key.as_str())
+    };
+    unsafe { StoreKey::new_unchecked(key_path) }
 }

--- a/zarrs_storage/CHANGELOG.md
+++ b/zarrs_storage/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - Bump `unsafe_cell_slice` to 0.2.0
+ - Validate that chunk keys do not contain '//'
 
 ### Fixed
  - Fix new clippy warnings
+ - Fix `data_key` encoding on windows (it contained '//')
 
 ## [0.2.1] - 2024-09-22
 

--- a/zarrs_storage/src/store_key.rs
+++ b/zarrs_storage/src/store_key.rs
@@ -53,11 +53,13 @@ impl StoreKey {
     /// Validates a key according to the following rule from the specification:
     /// - a key is a Unicode string, where the final character is not a `/` character.
     ///
-    /// Additionally, a key which starts with '/' is invalid even though this is not explicit in the specification.
-    /// A key cannot be an empty string.
+    /// Additional checks (not in the specification):
+    /// - a key which starts with '/' is invalid, and
+    /// - a key that contains '//' is invalid, and
+    /// - a key cannot be an empty string.
     #[must_use]
     pub fn validate(key: &str) -> bool {
-        !key.starts_with('/') && !key.ends_with('/') && !key.is_empty()
+        !key.starts_with('/') && !key.ends_with('/') && !key.is_empty() && !key.contains("//")
     }
 
     /// Returns true if the key has prefix `prefix`.


### PR DESCRIPTION
Also validate that chunk keys do not contain '//'.