### PR TITLE
Change `ByteRange::FromEnd` to `ByteRange::Suffix`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.2.0"
 path = "zarrs_metadata"
 
 [workspace.dependencies.zarrs_storage]
-version = "0.2.2"
+version = "0.3.0-dev"
 path = "zarrs_storage"
 
 [workspace.dependencies.zarrs_filesystem]

--- a/zarrs/Cargo.toml
+++ b/zarrs/Cargo.toml
@@ -66,7 +66,8 @@ unsafe_cell_slice = "0.2.0"
 zarrs_filesystem = { workspace = true, optional = true }
 zarrs_metadata = { workspace = true }
 zarrs_storage = { workspace = true }
-zfp-sys = {version = "0.1.15", features = ["static"], optional = true }
+# zfp-sys is pinned to 0.1.15 to mainain 1.76 MSRV
+zfp-sys = {version = "=0.1.15", features = ["static"], optional = true }
 zstd = { version = "0.13.1", features = ["zstdmt"], optional = true }
 
 [dependencies.num-complex]

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -145,7 +145,7 @@ fn get_index_byte_range(
         .map_err(|e| CodecError::Other(e.to_string()))?;
     Ok(match index_location {
         ShardingIndexLocation::Start => ByteRange::FromStart(0, Some(index_encoded_size)),
-        ShardingIndexLocation::End => ByteRange::FromEnd(0, Some(index_encoded_size)),
+        ShardingIndexLocation::End => ByteRange::Suffix(index_encoded_size),
     })
 }
 

--- a/zarrs/src/array/codec/byte_interval_partial_decoder.rs
+++ b/zarrs/src/array/codec/byte_interval_partial_decoder.rs
@@ -49,11 +49,8 @@ impl BytesPartialDecoderTraits for ByteIntervalPartialDecoder {
                 ByteRange::FromStart(offset, Some(length)) => {
                     ByteRange::FromStart(self.byte_offset + offset, Some(*length))
                 }
-                ByteRange::FromEnd(offset, None) => {
-                    ByteRange::FromStart(self.byte_offset, Some(self.byte_length - *offset))
-                }
-                ByteRange::FromEnd(offset, Some(length)) => ByteRange::FromEnd(
-                    self.byte_offset + self.byte_length - offset - *length,
+                ByteRange::Suffix(length) => ByteRange::FromStart(
+                    self.byte_offset + self.byte_length - *length,
                     Some(*length),
                 ),
             })
@@ -105,11 +102,8 @@ impl AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder {
                 ByteRange::FromStart(offset, Some(length)) => {
                     ByteRange::FromStart(self.byte_offset + offset, Some(*length))
                 }
-                ByteRange::FromEnd(offset, None) => {
-                    ByteRange::FromStart(self.byte_offset, Some(self.byte_length - *offset))
-                }
-                ByteRange::FromEnd(offset, Some(length)) => ByteRange::FromEnd(
-                    self.byte_offset + self.byte_length - offset - *length,
+                ByteRange::Suffix(length) => ByteRange::FromStart(
+                    self.byte_offset + self.byte_length - *length,
                     Some(*length),
                 ),
             })

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_partial_decoder.rs
@@ -45,14 +45,10 @@ impl BytesPartialDecoderTraits for Crc32cPartialDecoder<'_> {
                     let length = bytes.len() - CHECKSUM_SIZE;
                     Cow::Owned(bytes[..length].to_vec())
                 }
-                ByteRange::FromEnd(offset, _) => {
-                    if *offset < CHECKSUM_SIZE as u64 {
-                        let length = bytes.len() as u64 - (CHECKSUM_SIZE as u64 - offset);
-                        let length = usize::try_from(length).unwrap();
-                        Cow::Owned(bytes[..length].to_vec())
-                    } else {
-                        bytes
-                    }
+                ByteRange::Suffix(_) => {
+                    let length = bytes.len() as u64 - (CHECKSUM_SIZE as u64);
+                    let length = usize::try_from(length).unwrap();
+                    Cow::Owned(bytes[..length].to_vec())
                 }
             };
             output.push(bytes);
@@ -101,14 +97,10 @@ impl AsyncBytesPartialDecoderTraits for AsyncCrc32cPartialDecoder {
                     let length = bytes.len() - CHECKSUM_SIZE;
                     Cow::Owned(bytes[..length].to_vec())
                 }
-                ByteRange::FromEnd(offset, _) => {
-                    if *offset < CHECKSUM_SIZE as u64 {
-                        let length = bytes.len() as u64 - (CHECKSUM_SIZE as u64 - offset);
-                        let length = usize::try_from(length).unwrap();
-                        Cow::Owned(bytes[..length].to_vec())
-                    } else {
-                        bytes
-                    }
+                ByteRange::Suffix(_) => {
+                    let length = bytes.len() as u64 - (CHECKSUM_SIZE as u64);
+                    let length = usize::try_from(length).unwrap();
+                    Cow::Owned(bytes[..length].to_vec())
                 }
             };
             output.push(bytes);

--- a/zarrs_filesystem/CHANGELOG.md
+++ b/zarrs_filesystem/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Bump `zarrs_storage` to 0.3.0-dev
+
 ## [0.1.0] - 2024-09-15
 
 ### Added

--- a/zarrs_filesystem/src/lib.rs
+++ b/zarrs_filesystem/src/lib.rs
@@ -279,20 +279,19 @@ impl ReadableStorageTraits for FilesystemStore {
                 // Seek
                 match byte_range {
                     ByteRange::FromStart(offset, _) => file.seek(SeekFrom::Start(*offset)),
-                    ByteRange::FromEnd(_, None) => file.seek(SeekFrom::Start(0u64)),
-                    ByteRange::FromEnd(offset, Some(length)) => {
-                        file.seek(SeekFrom::End(-(i64::try_from(*offset + *length).unwrap())))
+                    ByteRange::Suffix(length) => {
+                        file.seek(SeekFrom::End(-(i64::try_from(*length).unwrap())))
                     }
                 }?;
 
                 // Read
                 match byte_range {
-                    ByteRange::FromStart(_, None) | ByteRange::FromEnd(_, None) => {
+                    ByteRange::FromStart(_, None) => {
                         let mut buffer = Vec::new();
                         file.read_to_end(&mut buffer)?;
                         buffer
                     }
-                    ByteRange::FromStart(_, Some(length)) | ByteRange::FromEnd(_, Some(length)) => {
+                    ByteRange::FromStart(_, Some(length)) | ByteRange::Suffix(length) => {
                         let length = usize::try_from(*length).unwrap();
                         let mut buffer = vec![0; length];
                         file.read_exact(&mut buffer)?;

--- a/zarrs_http/CHANGELOG.md
+++ b/zarrs_http/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Bump `zarrs_storage` to 0.3.0-dev
+
 ## [0.1.0] - 2024-09-15
 
 ### Added

--- a/zarrs_object_store/CHANGELOG.md
+++ b/zarrs_object_store/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Bump `zarrs_storage` to 0.3.0-dev
+
 ## [0.2.1] - 2024-09-23
 
 ### Added

--- a/zarrs_opendal/CHANGELOG.md
+++ b/zarrs_opendal/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Bump `zarrs_storage` to 0.3.0-dev
+
 ## [0.3.1] - 2024-09-23
 
 ### Added

--- a/zarrs_storage/CHANGELOG.md
+++ b/zarrs_storage/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - Bump `unsafe_cell_slice` to 0.2.0
+ - **Breaking**: Change `ByteRange::FromEnd` to `ByteRange::Suffix`
+
+### Removed
+ - **Breaking**: Remove `ByteRange::offset()`
 
 ## [0.2.2] - 2024-10-17
 

--- a/zarrs_storage/CHANGELOG.md
+++ b/zarrs_storage/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - Add `ByteRange::new` and `From` for `RangeBounds<u64>`
+
 ### Changed
  - Bump `unsafe_cell_slice` to 0.2.0
  - **Breaking**: Change `ByteRange::FromEnd` to `ByteRange::Suffix`

--- a/zarrs_storage/Cargo.toml
+++ b/zarrs_storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs_storage"
-version = "0.2.2"
+version = "0.3.0-dev"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.76"

--- a/zarrs_storage/src/byte_range.rs
+++ b/zarrs_storage/src/byte_range.rs
@@ -28,10 +28,8 @@ pub enum ByteRange {
     ///
     /// If the byte length is [`None`], reads to the end of the value.
     FromStart(ByteOffset, Option<ByteLength>),
-    /// A byte range from the end.
-    ///
-    /// If the byte length is [`None`], reads to the start of the value.
-    FromEnd(ByteOffset, Option<ByteLength>),
+    /// A suffix byte range.
+    Suffix(ByteLength),
 }
 
 impl ByteRange {
@@ -40,9 +38,7 @@ impl ByteRange {
     pub fn start(&self, size: u64) -> u64 {
         match self {
             Self::FromStart(offset, _) => *offset,
-            Self::FromEnd(offset, length) => {
-                length.as_ref().map_or(0, |length| size - *offset - *length)
-            }
+            Self::Suffix(length) => size - *length,
         }
     }
 
@@ -53,23 +49,16 @@ impl ByteRange {
             Self::FromStart(offset, length) => {
                 length.as_ref().map_or(size, |length| offset + length)
             }
-            Self::FromEnd(offset, _) => size - offset,
+            Self::Suffix(_) => size,
         }
-    }
-
-    /// Return the internal offset of the byte range (which can be at its start or end).
-    #[must_use]
-    pub const fn offset(&self) -> u64 {
-        let (Self::FromStart(offset, _) | Self::FromEnd(offset, _)) = self;
-        *offset
     }
 
     /// Return the length of a byte range. `size` is the size of the entire bytes.
     #[must_use]
     pub fn length(&self, size: u64) -> u64 {
         match self {
-            Self::FromStart(offset, None) | Self::FromEnd(offset, None) => size - offset,
-            Self::FromStart(_, Some(length)) | Self::FromEnd(_, Some(length)) => *length,
+            Self::FromStart(offset, None) => size - offset,
+            Self::FromStart(_, Some(length)) | Self::Suffix(length) => *length,
         }
     }
 
@@ -103,16 +92,7 @@ impl std::fmt::Display for ByteRange {
                 },
                 length.map_or(String::new(), |length| (offset + length).to_string())
             ),
-            Self::FromEnd(offset, length) => write!(
-                f,
-                "{}..{}",
-                length.map_or(String::new(), |length| format!("-{}", offset + length)),
-                if offset == &0 {
-                    String::new()
-                } else {
-                    format!("-{offset}")
-                }
-            ),
+            Self::Suffix(length) => write!(f, "{}..", format!("-{}", length),),
         }
     }
 }
@@ -136,8 +116,11 @@ fn validate_byte_ranges(
 ) -> Result<(), InvalidByteRangeError> {
     for byte_range in byte_ranges {
         let valid = match byte_range {
-            ByteRange::FromStart(offset, length) | ByteRange::FromEnd(offset, length) => {
+            ByteRange::FromStart(offset, length) => {
                 offset + length.unwrap_or(0) <= bytes_len
+            }
+            ByteRange::Suffix(length) => {
+                *length <= bytes_len
             }
         };
         if !valid {
@@ -260,15 +243,8 @@ pub fn extract_byte_ranges_read_seek<T: Read + Seek>(
                 bytes.read_exact(&mut data)?;
                 data
             }
-            ByteRange::FromEnd(offset, None) => {
-                bytes.seek(SeekFrom::Start(0))?;
-                let length = usize::try_from(len - offset).unwrap();
-                let mut data = vec![0; length];
-                bytes.read_exact(&mut data)?;
-                data
-            }
-            ByteRange::FromEnd(offset, Some(length)) => {
-                bytes.seek(SeekFrom::End(-i64::try_from(*offset + *length).unwrap()))?;
+            ByteRange::Suffix(length) => {
+                bytes.seek(SeekFrom::End(-i64::try_from(*length).unwrap()))?;
                 let length = usize::try_from(*length).unwrap();
                 let mut data = vec![0; length];
                 bytes.read_exact(&mut data)?;
@@ -367,12 +343,10 @@ mod tests {
         let byte_range = ByteRange::FromStart(1, None);
         assert_eq!(byte_range.to_range(10), 1..10);
         assert_eq!(byte_range.length(10), 9);
-        assert_eq!(byte_range.offset(), 1);
 
-        let byte_range = ByteRange::FromEnd(1, None);
-        assert_eq!(byte_range.to_range(10), 0..9);
-        assert_eq!(byte_range.length(10), 9);
-        assert_eq!(byte_range.offset(), 1);
+        let byte_range = ByteRange::Suffix(1);
+        assert_eq!(byte_range.to_range(10), 9..10);
+        assert_eq!(byte_range.length(10), 1);
 
         let byte_range = ByteRange::FromStart(1, Some(5));
         assert_eq!(byte_range.to_range(10), 1..6);
@@ -382,8 +356,8 @@ mod tests {
         assert!(validate_byte_ranges(&[ByteRange::FromStart(1, Some(5))], 6).is_ok());
         assert!(validate_byte_ranges(&[ByteRange::FromStart(1, Some(5))], 2).is_err());
 
-        assert!(validate_byte_ranges(&[ByteRange::FromEnd(1, Some(5))], 6).is_ok());
-        assert!(validate_byte_ranges(&[ByteRange::FromEnd(1, Some(5))], 2).is_err());
+        assert!(validate_byte_ranges(&[ByteRange::Suffix(5)], 6).is_ok());
+        assert!(validate_byte_ranges(&[ByteRange::Suffix(5)], 2).is_err());
 
         assert!(extract_byte_ranges(&[1, 2, 3], &[ByteRange::FromStart(1, Some(2))]).is_ok());
         let bytes = extract_byte_ranges(&[1, 2, 3], &[ByteRange::FromStart(1, Some(4))]);
@@ -399,9 +373,7 @@ mod tests {
         assert_eq!(format!("{}", ByteRange::FromStart(0, None)), "..");
         assert_eq!(format!("{}", ByteRange::FromStart(5, None)), "5..");
         assert_eq!(format!("{}", ByteRange::FromStart(5, Some(2))), "5..7");
-        assert_eq!(format!("{}", ByteRange::FromEnd(5, None)), "..-5");
-        assert_eq!(format!("{}", ByteRange::FromEnd(0, Some(2))), "-2..");
-        assert_eq!(format!("{}", ByteRange::FromEnd(5, Some(2))), "-7..-5");
+        assert_eq!(format!("{}", ByteRange::Suffix(2)), "-2..");
     }
 
     #[test]
@@ -413,12 +385,12 @@ mod tests {
             ByteRange::FromStart(3, Some(3)),
             ByteRange::FromStart(4, Some(1)),
             ByteRange::FromStart(1, Some(1)),
-            ByteRange::FromEnd(1, Some(5)),
+            ByteRange::Suffix(5),
         ];
         let out = extract_byte_ranges_read(&mut read, size, &byte_ranges).unwrap();
         assert_eq!(
             out,
-            vec![vec![3, 4, 5], vec![4], vec![1], vec![4, 5, 6, 7, 8]]
+            vec![vec![3, 4, 5], vec![4], vec![1], vec![5, 6, 7, 8, 9]]
         );
     }
 }

--- a/zarrs_storage/src/store_test.rs
+++ b/zarrs_storage/src/store_test.rs
@@ -62,22 +62,19 @@ pub fn store_read<T: ReadableStorageTraits>(store: &T) -> Result<(), Box<dyn Err
     assert_eq!(
         store.get_partial_values_key(
             &"a/b".try_into()?,
-            &[
-                ByteRange::FromStart(1, Some(1)),
-                ByteRange::FromEnd(0, Some(1))
-            ]
+            &[ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)]
         )?,
         Some(vec![vec![1].into(), vec![3].into()])
     );
     assert_eq!(
         store.get_partial_values(&[
             StoreKeyRange::new("a/b".try_into()?, ByteRange::FromStart(1, None)),
-            StoreKeyRange::new("a/b".try_into()?, ByteRange::FromEnd(1, Some(2))),
+            StoreKeyRange::new("a/b".try_into()?, ByteRange::Suffix(2)),
             StoreKeyRange::new("i/j/k".try_into()?, ByteRange::FromStart(1, Some(1))),
         ])?,
         vec![
             Some(vec![1, 2, 3].into()),
-            Some(vec![1, 2].into()),
+            Some(vec![2, 3].into()),
             Some(vec![1].into())
         ]
     );
@@ -225,10 +222,7 @@ pub async fn async_store_read<T: AsyncReadableStorageTraits>(
         store
             .get_partial_values_key(
                 &"a/b".try_into()?,
-                &[
-                    ByteRange::FromStart(1, Some(1)),
-                    ByteRange::FromEnd(0, Some(1))
-                ]
+                &[ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)]
             )
             .await?,
         Some(vec![vec![1].into(), vec![3].into()])
@@ -237,13 +231,13 @@ pub async fn async_store_read<T: AsyncReadableStorageTraits>(
         store
             .get_partial_values(&[
                 StoreKeyRange::new("a/b".try_into()?, ByteRange::FromStart(1, None)),
-                StoreKeyRange::new("a/b".try_into()?, ByteRange::FromEnd(1, Some(2))),
+                StoreKeyRange::new("a/b".try_into()?, ByteRange::Suffix(2)),
                 StoreKeyRange::new("i/j/k".try_into()?, ByteRange::FromStart(1, Some(1))),
             ])
             .await?,
         vec![
             Some(vec![1, 2, 3].into()),
-            Some(vec![1, 2].into()),
+            Some(vec![2, 3].into()),
             Some(vec![1].into())
         ]
     );

--- a/zarrs_zip/CHANGELOG.md
+++ b/zarrs_zip/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Bump `zarrs_storage` to 0.3.0-dev
+
 ## [0.1.0] - 2024-09-15
 
 ### Added


### PR DESCRIPTION
No codecs would request a footer with an offset, and most stores could not support such an operation without a size request.

- Add `ByteRange::new` and `From` for various `RangeBounds<u64>` implementors.
- Remove `ByteRange::offset()`
- Add `ByteRange::new` and `From` for `RangeBounds<u64>`