### PR TITLE
functions to get children of Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add `Node::[async_]get_direct_child_nodes`
 - Impl `From<Node>` for `NodeMetadata`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `Node::[async_]get_direct_child_nodes`
+- Impl `From<Node>` for `NodeMetadata`
 
 ### Changed
 - Reduce metadata code duplication in the `Node` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#104](https://github.com/LDeakin/zarrs/pull/104) functions to get children of Group by [@niklasmueboe]
 - Impl `From<Node>` for `NodeMetadata`
 
 ### Changed
@@ -1213,3 +1214,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [@lorenzocerrone]: https://github.com/lorenzocerrone
 [@dustinlagoy]: https://github.com/dustinlagoy
 [@sk1p]: https://github.com/sk1p
+[@niklasmueboe]: https://github.com/niklasmueboe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [#104](https://github.com/LDeakin/zarrs/pull/104) functions to get children of Group by [@niklasmueboe]
+  - adds `Group::[async_]children`, `Group::[async_]child_groups`, `Group::[async_]child_arrays`
 - Impl `From<Node>` for `NodeMetadata`
 
 ### Changed

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -245,8 +245,14 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
     pub fn child_groups(&self) -> Result<Vec<Self>, GroupCreateError> {
         self.children()?
             .into_iter()
-            .filter(|node| matches!(node.metadata(), NodeMetadata::Group(_)))
-            .map(|node| Group::open(self.storage.clone(), node.name().as_str()))
+            .filter_map(|node| match node.metadata() {
+                NodeMetadata::Group(metadata) => Some(Group::new_with_metadata(
+                    self.storage.clone(),
+                    node.name().as_str(),
+                    metadata.clone(),
+                )),
+                _ => None,
+            })
             .collect()
     }
 }
@@ -259,8 +265,14 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits + 'static>
     pub fn child_arrays(&self) -> Result<Vec<Array<TStorage>>, ArrayCreateError> {
         self.children()?
             .into_iter()
-            .filter(|node| matches!(node.metadata(), NodeMetadata::Array(_)))
-            .map(|node| Array::open(self.storage.clone(), node.name().as_str()))
+            .filter_map(|node| match node.metadata() {
+                NodeMetadata::Array(metadata) => Some(Array::new_with_metadata(
+                    self.storage.clone(),
+                    node.name().as_str(),
+                    metadata.clone(),
+                )),
+                _ => None,
+            })
             .collect()
     }
 }

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -44,14 +44,16 @@ use crate::{
         v3::{AdditionalFields, UnsupportedAdditionalFieldError},
     },
     node::{
-        get_child_nodes, get_direct_child_nodes, meta_key_v2_attributes, meta_key_v2_group,
-        meta_key_v3, Node, NodePath, NodePathError,
+        _get_child_nodes, meta_key_v2_attributes, meta_key_v2_group, meta_key_v3, Node, NodePath,
+        NodePathError,
     },
     storage::{ReadableStorageTraits, StorageError, StorageHandle, WritableStorageTraits},
 };
 
 #[cfg(feature = "async")]
 use crate::storage::{AsyncReadableStorageTraits, AsyncWritableStorageTraits};
+// #[cfg(feature = "async")]
+// use crate::node::_async_get_child_nodes;
 
 pub use self::group_builder::GroupBuilder;
 pub use crate::metadata::{v3::GroupMetadataV3, GroupMetadata};
@@ -235,11 +237,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
     /// # Errors
     /// Returns [`StorageError`] if there is an underlying error with the store.
     pub fn children(&self, recursive: bool) -> Result<Vec<Node>, StorageError> {
-        if recursive {
-            get_child_nodes(&self.storage, &self.path)
-        } else {
-            get_direct_child_nodes(&self.storage, &self.path)
-        }
+        #[allow(clippy::used_underscore_items)]
+        _get_child_nodes(&self.storage, &self.path, recursive)
     }
 
     /// Return the children of the group that are [`Group`]s

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -231,11 +231,17 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Group<TStorage> {
 
 impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TStorage> {
     /// Return the children of the group
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] if there is an underlying error with the store.
     pub fn children(&self) -> Result<Vec<Node>, StorageError> {
         get_child_nodes(&self.storage, &self.path)
     }
 
     /// Return the children of the group that are [`Group`]s
+    ///
+    /// # Errors
+    /// Returns [`GroupCreateError`] if there is a storage error or any metadata is invalid.
     pub fn child_groups(&self) -> Result<Vec<Self>, GroupCreateError> {
         self.children()?
             .into_iter()
@@ -247,6 +253,9 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
 
 impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits + 'static> Group<TStorage> {
     /// Return the children of the group that are [`Array`]s
+    ///
+    /// # Errors
+    /// Returns [`ArrayCreateError`] if there is a storage error or any metadata is invalid.
     pub fn child_arrays(&self) -> Result<Vec<Array<TStorage>>, ArrayCreateError> {
         self.children()?
             .into_iter()

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -249,19 +249,21 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
     pub fn child_groups(&self, recursive: bool) -> Result<Vec<Self>, GroupCreateError> {
         self.children(recursive)?
             .into_iter()
-            .filter_map(|node| match node.metadata() {
-                NodeMetadata::Group(metadata) => Some(Group::new_with_metadata(
-                    self.storage.clone(),
-                    node.name().as_str(),
-                    metadata.clone(),
-                )),
-                _ => None,
+            .filter_map(|node| {
+                let name = node.name();
+                let metadata: NodeMetadata = node.into();
+                match metadata {
+                    NodeMetadata::Group(metadata) => Some(Group::new_with_metadata(
+                        self.storage.clone(),
+                        name.as_str(),
+                        metadata,
+                    )),
+                    NodeMetadata::Array(_) => None,
+                }
             })
             .collect()
     }
-}
 
-impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits + 'static> Group<TStorage> {
     /// Return the children of the group that are [`Array`]s
     ///
     /// # Errors
@@ -269,13 +271,17 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits + 'static>
     pub fn child_arrays(&self, recursive: bool) -> Result<Vec<Array<TStorage>>, ArrayCreateError> {
         self.children(recursive)?
             .into_iter()
-            .filter_map(|node| match node.metadata() {
-                NodeMetadata::Array(metadata) => Some(Array::new_with_metadata(
-                    self.storage.clone(),
-                    node.name().as_str(),
-                    metadata.clone(),
-                )),
-                _ => None,
+            .filter_map(|node| {
+                let name = node.name();
+                let metadata: NodeMetadata = node.into();
+                match metadata {
+                    NodeMetadata::Array(metadata) => Some(Array::new_with_metadata(
+                        self.storage.clone(),
+                        name.as_str(),
+                        metadata.clone(),
+                    )),
+                    NodeMetadata::Group(_) => None,
+                }
             })
             .collect()
     }

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -23,8 +23,8 @@ pub use key::{
 
 #[cfg(feature = "async")]
 mod node_async;
-// #[cfg(feature = "async")]
-// pub(crate) use node_async::_async_get_child_nodes;
+#[cfg(feature = "async")]
+pub(crate) use node_async::_async_get_child_nodes;
 #[cfg(feature = "async")]
 pub use node_async::{async_get_child_nodes, async_node_exists, async_node_exists_listable};
 

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -13,7 +13,8 @@ mod node_path;
 pub use node_path::{NodePath, NodePathError};
 
 mod node_sync;
-pub use node_sync::{get_child_nodes, get_direct_child_nodes, node_exists, node_exists_listable};
+pub(crate) use node_sync::_get_child_nodes;
+pub use node_sync::{get_child_nodes, node_exists, node_exists_listable};
 
 mod key;
 pub use key::{
@@ -22,11 +23,10 @@ pub use key::{
 
 #[cfg(feature = "async")]
 mod node_async;
+// #[cfg(feature = "async")]
+// pub(crate) use node_async::_async_get_child_nodes;
 #[cfg(feature = "async")]
-pub use node_async::{
-    async_get_child_nodes, async_get_direct_child_nodes, async_node_exists,
-    async_node_exists_listable,
-};
+pub use node_async::{async_get_child_nodes, async_node_exists, async_node_exists_listable};
 
 use std::sync::Arc;
 

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -61,6 +61,12 @@ pub struct Node {
     children: Vec<Node>,
 }
 
+impl From<Node> for NodeMetadata {
+    fn from(value: Node) -> Self {
+        value.metadata
+    }
+}
+
 /// A node creation error.
 #[derive(Debug, Error)]
 pub enum NodeCreateError {

--- a/zarrs/src/node/node_async.rs
+++ b/zarrs/src/node/node_async.rs
@@ -12,6 +12,40 @@ use super::{
     meta_key_v2_array, meta_key_v2_group, meta_key_v3, Node, NodeMetadata, NodePath, NodePathError,
 };
 
+// TODO: Replace async_get_child_nodes with this method in the next breaking release
+// TODO: Change to NodeCreateError in the next breaking release
+pub(crate) async fn _async_get_child_nodes<TStorage>(
+    storage: &Arc<TStorage>,
+    path: &NodePath,
+    recursive: bool,
+) -> Result<Vec<Node>, StorageError>
+where
+    TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits,
+{
+    let prefix: StorePrefix = path.try_into()?;
+    let prefixes = async_discover_children(storage, &prefix).await?;
+    let mut nodes: Vec<Node> = Vec::new();
+    // TODO: Asynchronously get metadata of all prefixes
+    for prefix in &prefixes {
+        let path: NodePath = prefix
+            .try_into()
+            .map_err(|err: NodePathError| StorageError::Other(err.to_string()))?;
+        let child_metadata =
+            Node::async_get_metadata(storage, &path, &MetadataRetrieveVersion::Default).await?;
+
+        let children = if recursive {
+            match child_metadata {
+                NodeMetadata::Array(_) => Vec::default(),
+                NodeMetadata::Group(_) => Box::pin(async_get_child_nodes(storage, &path)).await?,
+            }
+        } else {
+            vec![]
+        };
+        nodes.push(Node::new_with_metadata(path, child_metadata, children));
+    }
+    Ok(nodes)
+}
+
 /// Asynchronously get the child nodes.
 ///
 /// # Errors
@@ -24,54 +58,8 @@ pub async fn async_get_child_nodes<TStorage>(
 where
     TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits,
 {
-    let prefix: StorePrefix = path.try_into()?;
-    let prefixes = async_discover_children(storage, &prefix).await?;
-    let mut nodes: Vec<Node> = Vec::new();
-    // TODO: Asynchronously get metadata of all prefixes
-    for prefix in &prefixes {
-        let path: NodePath = prefix
-            .try_into()
-            .map_err(|err: NodePathError| StorageError::Other(err.to_string()))?;
-        let child_metadata =
-            Node::async_get_metadata(storage, &path, &MetadataRetrieveVersion::Default).await?;
-
-        let children = match child_metadata {
-            NodeMetadata::Array(_) => Vec::default(),
-            NodeMetadata::Group(_) => Box::pin(async_get_child_nodes(storage, &path)).await?,
-        };
-        nodes.push(Node::new_with_metadata(path, child_metadata, children));
-    }
-    Ok(nodes)
-}
-
-/// Get the direct child nodes.
-///
-/// Unlike [`async_get_child_nodes`], this does not fully resolve the node hierarchy and the nodes returned will not have any children.
-///
-/// # Errors
-/// Returns a [`StorageError`] if there is an underlying error with the store.
-// FIXME: Change to NodeCreateError in the next breaking release
-pub async fn async_get_direct_child_nodes<TStorage>(
-    storage: &Arc<TStorage>,
-    path: &NodePath,
-) -> Result<Vec<Node>, StorageError>
-where
-    TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits,
-{
-    let prefix: StorePrefix = path.try_into()?;
-    let prefixes = async_discover_children(storage, &prefix).await?;
-    let mut nodes: Vec<Node> = Vec::new();
-    // TODO: Asynchronously get metadata of all prefixes
-    for prefix in &prefixes {
-        let path: NodePath = prefix
-            .try_into()
-            .map_err(|err: NodePathError| StorageError::Other(err.to_string()))?;
-        let child_metadata =
-            Node::async_get_metadata(storage, &path, &MetadataRetrieveVersion::Default).await?;
-
-        nodes.push(Node::new_with_metadata(path, child_metadata, vec![]));
-    }
-    Ok(nodes)
+    #[allow(clippy::used_underscore_items)]
+    _async_get_child_nodes(storage, path, true).await
 }
 
 /// Asynchronously check if a node exists.


### PR DESCRIPTION
First draft of functions to directly get the children of a `Group`.

Not sure what the API should look like. One could also consider returning a list of `Node`s which correspond to only `Array`s/`Group`s instead of returning a list of `Array`s/`Group`s directly for the function `child_arrays`/`child_groups`, respectively.

Async function could also be added if needed.

Functions that only return a list of child names (i.e. `Vec<String>`) instead of `Array`s/`Group`s could also be useful. Something akin to  https://zarr.readthedocs.io/en/stable/api/hierarchy.html#zarr.hierarchy.Group.group_keys

Would be good to get some feedback, then I can make some further adjustments.

Disclaimer; I am still quite new to Rust.