### PR TITLE
Child NodePath's

### DIFF
--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -286,6 +286,51 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
             })
             .collect()
     }
+
+    /// Return the paths of the groups children
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] if there is an underlying error with the store.
+    pub fn child_paths(&self, recursive: bool) -> Result<Vec<NodePath>, StorageError> {
+        let paths = self
+            .children(recursive)?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        Ok(paths)
+    }
+
+    /// Return the paths of the groups children if the child is a group
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] if there is an underlying error with the store.
+    pub fn child_group_paths(&self, recursive: bool) -> Result<Vec<NodePath>, StorageError> {
+        let paths = self
+            .children(recursive)?
+            .into_iter()
+            .filter_map(|node| match node.metadata() {
+                NodeMetadata::Group(_) => Some(node.into()),
+                NodeMetadata::Array(_) => None,
+            })
+            .collect();
+        Ok(paths)
+    }
+
+    /// Return the paths of the groups children if the child is an array
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] if there is an underlying error with the store.
+    pub fn child_array_paths(&self, recursive: bool) -> Result<Vec<NodePath>, StorageError> {
+        let paths = self
+            .children(recursive)?
+            .into_iter()
+            .filter_map(|node| match node.metadata() {
+                NodeMetadata::Array(_) => Some(node.into()),
+                NodeMetadata::Group(_) => None,
+            })
+            .collect();
+        Ok(paths)
+    }
 }
 
 #[cfg(feature = "async")]

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -67,6 +67,12 @@ impl From<Node> for NodeMetadata {
     }
 }
 
+impl From<Node> for NodePath {
+    fn from(value: Node) -> Self {
+        value.path
+    }
+}
+
 /// A node creation error.
 #[derive(Debug, Error)]
 pub enum NodeCreateError {


### PR DESCRIPTION
Add functions to get the `NodePath`s for the children of a `Group`.

Originally, the idea was to get the `NodeName`s. However, with the recursive option the name is ambiguous because the prefix is unknown. One consideration would be to get the relative path starting at the current `Group`, but currently there is no data structure for that and it may not be worth creating one for that use case. It would also be possible to just use a normal `String` for the relative path.

Thoughts?