### PR TITLE
fix: make `pcodec` compatible with `numcodecs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Vlen{Array,Bytes,Utf8}Codec`, replacing `VlenV2Codec`
 - Add `ZstdCodecConfigurationNumCodecs`
   - Adds support for Zarr V2 `zstd` encoded data created with `numcodecs` < 0.13
+- Add support for pcodec `Auto`, `None`, and `TryLookback` delta specs
 
 ### Changed
 - **Breaking**: Seal `Array` extension traits: `ArraySharded[Readable]Ext` and `ArrayChunkCacheExt`
@@ -25,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Make `array::codec::array_to_bytes::bytes::reverse_endianness` private
 - **Breaking**: Make `VlenV2Codec` private
 - Bump `itertools` to 0.14
+
+### Removed
+- Remove support for pcodec `Try{FloatMult,FloatQuant,IntMult}` mode specs
+  - These may be reimplemented when supported by `zarr-python`/`numcodecs`
 
 ### Fixed
 - Cleanup unnecessary lifetime constraints in partial decoders

--- a/zarrs_metadata/CHANGELOG.md
+++ b/zarrs_metadata/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Breaking**: Rename `DataTypeMetadataV3::Binary` to `Bytes` for compatibility with `zarr-python`
+- **Breaking**: Revise `PcodecCodecConfiguration` to match `numcodecs`:
+  - Adds `delta_spec: PcodecDeltaSpecConfiguration` and `paging_spec: PcodecPagingSpecConfiguration`
+  - Removes `PcodecModeSpecConfiguration::{TryFloatMult,TryFloatQuant,TryIntMult}`
 
 ### Removed
 - **Breaking**: Remove the `v3::array::codec::vlen_v2` module and all associated types

--- a/zarrs_metadata/src/v3/array/codec/pcodec.rs
+++ b/zarrs_metadata/src/v3/array/codec/pcodec.rs
@@ -21,7 +21,7 @@ impl Default for PcodecCodecConfiguration {
 
 /// Configuration parameters for the `pcodec` codec (version 1.0 draft).
 ///
-/// Based upon [`pco::ChunkConfig`](https://docs.rs/pco/latest/pco/struct.ChunkConfig.html).
+/// This configuration matches the implementation in `numcodecs`.
 ///
 /// ### Example: encode with a compression level of 12 and otherwise default parameters
 /// ```rust
@@ -33,21 +33,23 @@ impl Default for PcodecCodecConfiguration {
 /// # use zarrs_metadata::v3::array::codec::pcodec::PcodecCodecConfigurationV1;
 /// # let configuration: PcodecCodecConfigurationV1 = serde_json::from_str(JSON).unwrap();
 // TODO: Examples for more advanced configurations
-// TODO: Docs about valid usage with base/k
-#[derive(Clone, PartialEq, Debug, Display)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Display)]
 #[display("{}", serde_json::to_string(self).unwrap_or_default())]
+#[serde(default)] // for compatibility with zarrs < 0.19
 pub struct PcodecCodecConfigurationV1 {
     /// A compression level from 0-12, where 12 takes the longest and compresses the most.
-    ///
-    /// The default is 8.
     pub level: PcodecCompressionLevel,
+    /// The pcodec mode spec.
+    pub mode_spec: PcodecModeSpecConfiguration,
+    /// The delta encoding strategy.
+    pub delta_spec: PcodecDeltaSpecConfiguration,
+    /// The paging spec.
+    pub paging_spec: PcodecPagingSpecConfiguration,
     /// Either a delta encoding level from 0-7 or None.
     ///
     /// If set to None, pcodec will try to infer the optimal delta encoding order.
     /// The default is None.
     pub delta_encoding_order: Option<PcodecDeltaEncodingOrder>,
-    /// The pcodec mode spec.
-    pub mode_spec: PcodecModeSpecConfiguration,
     /// The maximum number of values to encode per pcodec page.
     ///
     /// If set too high or too low, pcodec's compression ratio may drop.
@@ -57,161 +59,63 @@ pub struct PcodecCodecConfigurationV1 {
     pub equal_pages_up_to: usize,
 }
 
-/// Specifies how Pco should choose a [`mode`](https://docs.rs/pco/latest/pco/enum.Mode.html) to compress this
-/// chunk of data.
-///
-/// see [`pco::ModeSpec`](https://docs.rs/pco/latest/pco/enum.ModeSpec.html).
-#[derive(Deserialize, Clone, Copy, PartialEq, Debug, Display)]
-pub enum PcodecModeSpecConfiguration {
-    /// Automatically detect a good mode.
-    ///
-    /// This works well most of the time, but costs some compression time and can
-    /// select a bad mode in adversarial cases.
-    Auto,
-    /// Only use `Classic` mode.
-    Classic,
-    /// Try using `FloatMult` mode with a given `base`.
-    ///
-    /// Only applies to floating-point types.
-    TryFloatMult(f64),
-    /// Try using `FloatQuant` mode with `k` bits of quantization.
-    ///
-    /// Only applies to floating-point types.
-    TryFloatQuant(u32),
-    /// Try using `IntMult` mode with a given `base`.
-    ///
-    /// Only applies to integer types.
-    TryIntMult(u64),
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-// #[serde(untagged)]
-#[serde(rename_all = "snake_case")]
-enum PcodecModeSpecConfigurationIntermediate {
-    Auto,
-    Classic,
-    TryFloatMult,
-    TryFloatQuant,
-    TryIntMult,
-}
-
-impl Default for PcodecModeSpecConfigurationIntermediate {
-    fn default() -> Self {
-        Self::Auto
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
-enum UIntOrFloat {
-    UInt(u64),
-    Float(f64),
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
-struct PcodecCodecConfigurationIntermediate {
-    #[serde(default)]
-    level: PcodecCompressionLevel,
-    #[serde(default)]
-    delta_encoding_order: Option<PcodecDeltaEncodingOrder>,
-    #[serde(default)]
-    mode_spec: PcodecModeSpecConfigurationIntermediate,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    base: Option<UIntOrFloat>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    k: Option<u32>,
-    #[serde(default = "default_equal_pages_up_to")]
-    equal_pages_up_to: usize,
-}
-
-impl serde::Serialize for PcodecCodecConfigurationV1 {
-    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        let (mode_spec, base, k) = match self.mode_spec {
-            PcodecModeSpecConfiguration::Auto => {
-                (PcodecModeSpecConfigurationIntermediate::Auto, None, None)
-            }
-            PcodecModeSpecConfiguration::Classic => {
-                (PcodecModeSpecConfigurationIntermediate::Classic, None, None)
-            }
-            PcodecModeSpecConfiguration::TryFloatMult(base) => (
-                PcodecModeSpecConfigurationIntermediate::TryFloatMult,
-                Some(UIntOrFloat::Float(base)),
-                None,
-            ),
-            PcodecModeSpecConfiguration::TryFloatQuant(k) => (
-                PcodecModeSpecConfigurationIntermediate::TryFloatQuant,
-                None,
-                Some(k),
-            ),
-            PcodecModeSpecConfiguration::TryIntMult(base) => (
-                PcodecModeSpecConfigurationIntermediate::TryIntMult,
-                Some(UIntOrFloat::UInt(base)),
-                None,
-            ),
-        };
-
-        let config = PcodecCodecConfigurationIntermediate {
-            level: self.level,
-            delta_encoding_order: self.delta_encoding_order,
-            mode_spec,
-            base,
-            k,
-            equal_pages_up_to: self.equal_pages_up_to,
-        };
-        config.serialize(s)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for PcodecCodecConfigurationV1 {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let config = PcodecCodecConfigurationIntermediate::deserialize(d)?;
-        let mode_spec = match (config.mode_spec, config.base, config.k) {
-            (PcodecModeSpecConfigurationIntermediate::Auto, None, None) => {
-                Ok(PcodecModeSpecConfiguration::Auto)
-            }
-            (PcodecModeSpecConfigurationIntermediate::Classic, None, None) => {
-                Ok(PcodecModeSpecConfiguration::Classic)
-            }
-            (
-                PcodecModeSpecConfigurationIntermediate::TryFloatMult,
-                Some(UIntOrFloat::Float(base)),
-                None,
-            ) => Ok(PcodecModeSpecConfiguration::TryFloatMult(base)),
-            (PcodecModeSpecConfigurationIntermediate::TryFloatQuant, None, Some(k)) => {
-                Ok(PcodecModeSpecConfiguration::TryFloatQuant(k))
-            }
-            (
-                PcodecModeSpecConfigurationIntermediate::TryIntMult,
-                Some(UIntOrFloat::UInt(base)),
-                None,
-            ) => Ok(PcodecModeSpecConfiguration::TryIntMult(base)),
-            _ => Err(serde::de::Error::custom(
-                "For requested mode_spec, base or k incompatible/missing",
-            )),
-        }?;
-        let config = Self {
-            level: config.level,
-            delta_encoding_order: config.delta_encoding_order,
-            mode_spec,
-            equal_pages_up_to: config.equal_pages_up_to,
-        };
-        Ok(config)
-    }
-}
-
 impl Default for PcodecCodecConfigurationV1 {
     fn default() -> Self {
         Self {
             level: PcodecCompressionLevel::default(),
+            mode_spec: PcodecModeSpecConfiguration::default(),
+            delta_spec: PcodecDeltaSpecConfiguration::default(),
+            paging_spec: PcodecPagingSpecConfiguration::default(),
             delta_encoding_order: None,
-            mode_spec: PcodecModeSpecConfiguration::Auto,
             equal_pages_up_to: default_equal_pages_up_to(),
         }
     }
 }
 
+/// The [`pco::ModeSpec`](https://docs.rs/pco/latest/pco/enum.ModeSpec.html).
+///
+/// `TryFloatMult`, `TryFloatQuant`, and `TryIntMult` are not currently supported.
+#[derive(Serialize, Deserialize, Default, Clone, Copy, PartialEq, Debug, Display)]
+#[serde(rename_all = "snake_case")]
+pub enum PcodecModeSpecConfiguration {
+    /// See <https://docs.rs/pco/latest/pco/enum.ModeSpec.html#variant.Auto>.
+    #[default]
+    Auto,
+    /// See <https://docs.rs/pco/latest/pco/enum.ModeSpec.html#variant.Classic>.
+    Classic,
+}
+
+/// The [`pco::DeltaSpec`](https://docs.rs/pco/latest/pco/enum.DeltaSpec.html).
+///
+/// The delta encoding order for `TryConsecutive` is serialised in a separate field.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Copy, PartialEq, Display)]
+#[serde(rename_all = "snake_case")]
+pub enum PcodecDeltaSpecConfiguration {
+    /// See <https://docs.rs/pco/latest/pco/enum.DeltaSpec.html#variant.Auto>.
+    #[default]
+    Auto,
+    /// See <https://docs.rs/pco/latest/pco/enum.DeltaSpec.html#variant.None>.
+    None,
+    /// See <https://docs.rs/pco/latest/pco/enum.DeltaSpec.html#variant.TryConsecutive>.
+    TryConsecutive,
+    /// See <https://docs.rs/pco/latest/pco/enum.DeltaSpec.html#variant.TryLookback>.
+    TryLookback,
+}
+
+/// The [`pco::PagingSpec`](https://docs.rs/pco/latest/pco/enum.PagingSpec.html).
+///
+/// The `Exact` paging spec is not supported.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Copy, PartialEq, Display)]
+#[serde(rename_all = "snake_case")]
+pub enum PcodecPagingSpecConfiguration {
+    /// See <https://docs.rs/pco/latest/pco/enum.PagingSpec.html#variant.EqualPagesUpTo>.
+    #[default]
+    EqualPagesUpTo,
+}
+
 /// An integer from 0 to 12 controlling the compression level.
+///
+/// The default is 8.
 ///
 /// See <https://docs.rs/pco/latest/pco/struct.ChunkConfig.html#structfield.compression_level>.
 ///
@@ -397,48 +301,6 @@ mod tests {
             "level": 8,
             "delta_encoding_order": 2,
             "mode_spec": "classic",
-            "equal_pages_up_to": 262144
-        }"#,
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn codec_pcodec_valid_try_float_mult() {
-        serde_json::from_str::<PcodecCodecConfiguration>(
-            r#"{
-            "level": 8,
-            "delta_encoding_order": 2,
-            "mode_spec": "try_float_mult",
-            "base": 0.1,
-            "equal_pages_up_to": 262144
-        }"#,
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn codec_pcodec_valid_try_float_quant() {
-        serde_json::from_str::<PcodecCodecConfiguration>(
-            r#"{
-            "level": 8,
-            "delta_encoding_order": 2,
-            "mode_spec": "try_float_quant",
-            "k": 1,
-            "equal_pages_up_to": 262144
-        }"#,
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn codec_pcodec_valid_try_int_mult() {
-        serde_json::from_str::<PcodecCodecConfiguration>(
-            r#"{
-            "level": 8,
-            "delta_encoding_order": 2,
-            "mode_spec": "try_int_mult",
-            "base": 1,
             "equal_pages_up_to": 262144
         }"#,
         )


### PR DESCRIPTION
This should be compatible with the next numcodecs release.

Fixes #111