### PR TITLE
fix: Zarr V2 empty filter serialisation

### DIFF
--- a/doc/correctness_issues.md
+++ b/doc/correctness_issues.md
@@ -1,4 +1,8 @@
 ## Correctness Issues with Past Versions
+- Prior to `zarrs_metadata` [v0.3.5](https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata-v0.3.5) (`zarrs` <= 0.19), it was possible for a user to create non-conformant Zarr V2 metadata with `filters: []`
+  - Empty filters now always correctly serialise to `null`
+  - `zarrs` will indefinitely support reading Zarr V2 data with `filters: []`
+  - `zarr-python` shared this bug (see https://github.com/zarr-developers/zarr-python/issues/2842)
 - Prior to zarrs [v0.11.5](https://github.com/LDeakin/zarrs/releases/tag/v0.11.5), arrays that used the `crc32c` codec have invalid chunk checksums
   - These arrays will fail to be read by Zarr implementations if they validate checksums
   - These arrays can be read by zarrs if the [validate checksums](crate::config::Config#validate-checksums) global configuration option is disabled or the relevant codec option is set explicitly

--- a/zarrs_metadata/CHANGELOG.md
+++ b/zarrs_metadata/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Ensure that Zarr V2 array metadata with empty `filters` is serialised as `null` instead of `[]`
+
 ## [0.3.4] - 2025-02-13
 
 ### Added


### PR DESCRIPTION
It is no longer possible to create non-conformant Zarr V2 filter metadata by setting filters to `Some(Vec![])`. Zarr V2 arrays with `filters: []` can still be read. `zarr-python` also shared this bug.

