### PR TITLE
fix: use `typesize` if present in `numcodecs` `blosc` V2 arrays

### DIFF
--- a/zarrs/tests/data/v2/array_blosc_C.zarr/.zarray
+++ b/zarrs/tests/data/v2/array_blosc_C.zarr/.zarray
@@ -16,7 +16,8 @@
     "cname": "zstd",
     "clevel": 1,
     "shuffle": 2,
-    "blocksize": 0
+    "blocksize": 0,
+    "typesize": null
   },
   "zarr_format": 2,
   "dtype": "<f4"

--- a/zarrs/tests/data/v2/array_blosc_F.zarr/.zarray
+++ b/zarrs/tests/data/v2/array_blosc_F.zarr/.zarray
@@ -16,7 +16,8 @@
     "cname": "zstd",
     "clevel": 1,
     "shuffle": 2,
-    "blocksize": 0
+    "blocksize": 0,
+    "typesize": null
   },
   "zarr_format": 2,
   "dtype": "<f4"

--- a/zarrs/tests/data/v2_generate.py
+++ b/zarrs/tests/data/v2_generate.py
@@ -2,8 +2,8 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "zarr==3.0.1",
-#     "numcodecs==0.15.0",
+#     "zarr==3.0.6",
+#     "numcodecs==0.16.0",
 #     "zfpy==1.0.1",
 #     "pcodec==0.3.2",
 # ]

--- a/zarrs/tests/data/v3_generate.py
+++ b/zarrs/tests/data/v3_generate.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "zarr==3.0.2,<3.0.3", # 3.0.4+ is broken with some numcodecs.zarr3 codecs
-#     "numcodecs==0.15.1",
+#     "numcodecs==0.16.0",
 #     "zfpy==1.0.1",
 #     "pcodec==0.3.2",
 # ]

--- a/zarrs_metadata/CHANGELOG.md
+++ b/zarrs_metadata/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Move `v3::array::data_type::DataTypeSize` to the crate root
 - **Breaking**: Rename `v2_to_v3::array_metadata_fill_value_v2_to_v3` to `fill_value_metadata_v2_to_v3`
 - **Breaking**: Rename `v2_to_v3::data_type_metadata_v2_to_v3_data_type` to `data_type_metadata_v2_to_v3`
+- **Breaking**: Add `typesize` to `BloscCodecConfigurationNumcodecs` and use it (if present) in `codec_blosc_v2_numcodecs_to_v3`
 
 ### Removed
 - **Breaking**: Remove `fill_value::{HexString,FillValueFloat,FillValueFloatStringNonFinite}`

--- a/zarrs_metadata/src/v3/array/codec/core/blosc.rs
+++ b/zarrs_metadata/src/v3/array/codec/core/blosc.rs
@@ -123,6 +123,8 @@ pub struct BloscCodecConfigurationNumcodecs {
     /// The compression block size. Automatically determined if 0.
     #[serde(default)]
     pub blocksize: usize,
+    /// The typesize.
+    pub typesize: Option<usize>,
 }
 
 /// Blosc shuffle modes (numcodecs).
@@ -145,6 +147,10 @@ pub fn codec_blosc_v2_numcodecs_to_v3(
     blosc: &BloscCodecConfigurationNumcodecs,
     data_type_size: Option<DataTypeSize>,
 ) -> BloscCodecConfiguration {
+    let data_type_size = blosc
+        .typesize
+        .map(|size| DataTypeSize::Fixed(size))
+        .or_else(|| data_type_size);
     let (shuffle, typesize) = match (&blosc.shuffle, data_type_size) {
         (BloscShuffleModeNumcodecs::NoShuffle, _) | (_, None) => {
             (BloscShuffleMode::NoShuffle, None)

--- a/zarrs_metadata/src/v3/array/codec/core/blosc.rs
+++ b/zarrs_metadata/src/v3/array/codec/core/blosc.rs
@@ -147,10 +147,7 @@ pub fn codec_blosc_v2_numcodecs_to_v3(
     blosc: &BloscCodecConfigurationNumcodecs,
     data_type_size: Option<DataTypeSize>,
 ) -> BloscCodecConfiguration {
-    let data_type_size = blosc
-        .typesize
-        .map(|size| DataTypeSize::Fixed(size))
-        .or_else(|| data_type_size);
+    let data_type_size = blosc.typesize.map(DataTypeSize::Fixed).or(data_type_size);
     let (shuffle, typesize) = match (&blosc.shuffle, data_type_size) {
         (BloscShuffleModeNumcodecs::NoShuffle, _) | (_, None) => {
             (BloscShuffleMode::NoShuffle, None)


### PR DESCRIPTION
Changed in `numcodecs` 0.16
https://github.com/zarr-developers/numcodecs/pull/713