### PR TITLE
fix: permit (and ignore) `typesize` in `blosc` codec in Zarr V2 arrays [zarrs_metadata 0.3.x]

### DIFF
--- a/zarrs_metadata/CHANGELOG.md
+++ b/zarrs_metadata/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Permit (and ignore) `typesize` in `blosc` codec in Zarr V2 arrays
+
 ## [0.3.6] - 2025-03-02
 
 ### Added

--- a/zarrs_metadata/src/v2/array/codec/blosc.rs
+++ b/zarrs_metadata/src/v2/array/codec/blosc.rs
@@ -12,7 +12,7 @@ use crate::v3::array::{
 
 /// Configuration parameters for the `blosc` codec (numcodecs).
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug, Display)]
-#[serde(deny_unknown_fields)]
+// #[serde(deny_unknown_fields)]
 #[display("{}", serde_json::to_string(self).unwrap_or_default())]
 pub struct BloscCodecConfigurationNumcodecs {
     /// The compressor.


### PR DESCRIPTION
Changed in `numcodecs` 0.16
https://github.com/zarr-developers/numcodecs/pull/713