### PR TITLE
chore(zfp): rename from `zarrs.zfp` to `zfp`

### DIFF
--- a/zarrs/doc/status/codecs.md
+++ b/zarrs/doc/status/codecs.md
@@ -11,7 +11,7 @@
 |                | [`numcodecs.zfpy`]       | Experimental | zfp           |
 |                | [`zarrs.vlen`]           | Experimental |               |
 |                | [`zarrs.vlen_v2`]        | Experimental |               |
-|                | [`zarrs.zfp`]            | Experimental | zfp           |
+|                | [`zfp`]                  | Experimental | zfp           |
 | Bytes to Bytes | [`blosc`]                | Core         | **blosc**     |
 |                | [`crc32c`]               | Core         | **crc32c**    |
 |                | [`gzip`]                 | Core         | **gzip**      |
@@ -41,7 +41,7 @@
 [`numcodecs.zfpy`]: crate::array::codec::array_to_bytes::zfpy
 [`zarrs.vlen`]: crate::array::codec::array_to_bytes::vlen
 [`zarrs.vlen_v2`]: crate::array::codec::array_to_bytes::vlen_v2
-[`zarrs.zfp`]: crate::array::codec::array_to_bytes::zfp
+[`zfp`]: crate::array::codec::array_to_bytes::zfp
 
 [`blosc`]: crate::array::codec::bytes_to_bytes::blosc
 [`crc32c`]: crate::array::codec::bytes_to_bytes::crc32c

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -21,6 +21,7 @@
 //! - a zfp header is **not** written, as it is redundant with the codec metadata
 //!
 //! ### Codec `name` Aliases (Zarr V3)
+//! - `zfp`
 //! - `zarrs.zfp`
 //! - `https://codec.zarrs.dev/array_to_bytes/zfp`
 //!

--- a/zarrs_metadata/src/extension/extension_aliases_codec.rs
+++ b/zarrs_metadata/src/extension/extension_aliases_codec.rs
@@ -25,7 +25,7 @@ impl Default for ExtensionAliasesCodecV3 {
                 (codec::ZFPY, "numcodecs.zfpy".into()),
                 (codec::VLEN, "zarrs.vlen".into()),
                 (codec::VLEN_V2, "zarrs.vlen_v2".into()),
-                (codec::ZFP, "zarrs.zfp".into()),
+                (codec::ZFP, "zfp".into()),
                 // bytes to bytes
                 (codec::BZ2, "numcodecs.bz2".into()),
                 (codec::GDEFLATE, "zarrs.gdeflate".into()),
@@ -40,7 +40,8 @@ impl Default for ExtensionAliasesCodecV3 {
                 // zarrs 0.20
                 ("zarrs.vlen".into(), codec::VLEN),
                 ("zarrs.vlen_v2".into(), codec::VLEN_V2),
-                ("zarrs.zfp".into(), codec::ZFP),
+                ("zfp".into(), codec::ZFP),
+                ("zarrs.zfp".into(), codec::ZFP), // 0.20.0-dev
                 ("zarrs.gdeflate".into(), codec::GDEFLATE),
                 // zarrs 0.20 / zarr-python 3.0
                 ("numcodecs.bitround".into(), codec::BITROUND),
@@ -77,7 +78,7 @@ impl Default for ExtensionAliasesCodecV2 {
                 // array to bytes
                 (codec::VLEN, "zarrs.vlen".into()),
                 (codec::VLEN_V2, "zarrs.vlen_v2".into()),
-                (codec::ZFP, "zarrs.zfp".into()),
+                (codec::ZFP, "zfp".into()),
                 // bytes to bytes
                 (codec::GDEFLATE, "zarrs.gdeflate".into()),
             ]),
@@ -86,7 +87,8 @@ impl Default for ExtensionAliasesCodecV2 {
                 // zarrs 0.20
                 ("zarrs.vlen".into(), codec::VLEN),
                 ("zarrs.vlen_v2".into(), codec::VLEN_V2),
-                ("zarrs.zfp".into(), codec::ZFP),
+                ("zfp".into(), codec::ZFP),
+                ("zarrs.zfp".into(), codec::ZFP), // 0.20.0-dev
                 ("zarrs.gdeflate".into(), codec::GDEFLATE),
                 // zarrs < 0.20
                 ("https://codec.zarrs.dev/array_to_bytes/bitround".into(), codec::BITROUND),


### PR DESCRIPTION
Pending merge of https://github.com/zarr-developers/zarr-extensions/pull/8