### PR TITLE
feat: Implement `From<T: IntoIterator<Item = Range<u64>>>` for `ArraySubset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Async{Array,Bytes}PartialEncoderTraits` and `*CodecTraits::async_partial_encoder()`
 - Add `array_subset::ArraySubsetError` [#156] by [@ilan-gold]
 - Add `array_subset::IncompatibleOffsetError`
+- Implement `From<T: IntoIterator<Item = Range<u64>>>` for `ArraySubset`
 
 ### Changed
 - **Breaking**: change `ArraySubset::inbounds` to take another subset rather than a shape

--- a/zarrs/src/array/chunk_grid.rs
+++ b/zarrs/src/array/chunk_grid.rs
@@ -473,9 +473,8 @@ pub trait ChunkGridTraits: core::fmt::Debug + Send + Sync {
             let ranges = chunk_origin
                 .iter()
                 .zip(&chunk_shape)
-                .map(|(&o, &s)| o..(o + s))
-                .collect::<Vec<_>>();
-            Some(ArraySubset::new_with_ranges(&ranges))
+                .map(|(&o, &s)| o..(o + s));
+            Some(ArraySubset::from(ranges))
         } else {
             None
         }

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_partial_decoder.rs
@@ -48,10 +48,9 @@ fn get_decoded_regions_squeezed(
             shape.iter()
         )
         .filter(|(_, _, &shape)| shape.get() > 1)
-        .map(|(rstart, rshape, _)| (*rstart..rstart + rshape))
-        .collect::<Vec<_>>();
+        .map(|(rstart, rshape, _)| (*rstart..rstart + rshape));
 
-        let decoded_region_squeeze = ArraySubset::new_with_ranges(&ranges);
+        let decoded_region_squeeze = ArraySubset::from(ranges);
         decoded_regions_squeezed.push(decoded_region_squeeze);
     }
     Ok(decoded_regions_squeezed)

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
@@ -54,12 +54,8 @@ fn get_decoded_regions_transposed(
     for decoded_region in decoded_regions {
         let start = permute(decoded_region.start(), &order.0);
         let size = permute(decoded_region.shape(), &order.0);
-        let ranges = start
-            .iter()
-            .zip(size)
-            .map(|(&st, si)| (st..(st + si)))
-            .collect::<Vec<_>>();
-        let decoded_region_transpose = ArraySubset::new_with_ranges(&ranges);
+        let ranges = start.iter().zip(size).map(|(&st, si)| (st..(st + si)));
+        let decoded_region_transpose = ArraySubset::from(ranges);
         decoded_regions_transposed.push(decoded_region_transpose);
     }
     decoded_regions_transposed

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -531,9 +531,8 @@ impl ShardingCodec {
         let ranges = shape
             .iter()
             .zip(&chunk_start)
-            .map(|(&sh, &st)| st..(st + sh.get()))
-            .collect::<Vec<_>>();
-        ArraySubset::new_with_ranges(&ranges)
+            .map(|(&sh, &st)| st..(st + sh.get()));
+        ArraySubset::from(ranges)
     }
 
     /// Computed the bounded size of an encoded shard from

--- a/zarrs/src/array_subset/iterators/chunks_iterator.rs
+++ b/zarrs/src/array_subset/iterators/chunks_iterator.rs
@@ -1,6 +1,6 @@
 use std::{iter::FusedIterator, num::NonZeroU64};
 
-use itertools::{izip, Itertools};
+use itertools::izip;
 use rayon::iter::{
     plumbing::{bridge, Consumer, Producer, ProducerCallback, UnindexedConsumer},
     IndexedParallelIterator, IntoParallelIterator, ParallelIterator,
@@ -135,10 +135,9 @@ pub struct ChunksIterator<'a> {
 
 impl ChunksIterator<'_> {
     fn chunk_indices_with_subset(&self, chunk_indices: Vec<u64>) -> (Vec<u64>, ArraySubset) {
-        let ranges = std::iter::zip(&chunk_indices, self.chunk_shape)
-            .map(|(i, c)| ((i * c)..(i * c) + c))
-            .collect_vec();
-        let chunk_subset = ArraySubset::new_with_ranges(&ranges);
+        let ranges =
+            std::iter::zip(&chunk_indices, self.chunk_shape).map(|(i, c)| ((i * c)..(i * c) + c));
+        let chunk_subset = ArraySubset::from(ranges);
         (chunk_indices, chunk_subset)
     }
 }

--- a/zarrs/src/array_subset/iterators/contiguous_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/contiguous_indices_iterator.rs
@@ -74,9 +74,8 @@ impl ContiguousIndices {
             .start()
             .iter()
             .zip(shape_out)
-            .map(|(&st, sh)| st..(st + sh))
-            .collect::<Vec<_>>();
-        let subset_contiguous_start = ArraySubset::new_with_ranges(&ranges);
+            .map(|(&st, sh)| st..(st + sh));
+        let subset_contiguous_start = ArraySubset::from(ranges);
         // let inner = subset_contiguous_start.iter_indices();
         Ok(Self {
             subset_contiguous_start,


### PR DESCRIPTION
Reduces internal allocations when creating an `ArraySubset` from ranges

Follow up to #156.