### PR TITLE
refactor(data_types)!: remove data type enum from `zarrs_data_types`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `array:codec::{InvalidBytesLengthError,InvalidArrayShapeError,InvalidNumberOfElementsError,SubsetOutOfBoundsError}`
 - Add `ArraySubset::inbounds_shape()` (matches the old `ArraySubset::inbounds` behaviour)
 - Add `ArrayBytesFixedDisjointView[CreateError]`
-- Add support for data type extensions with `zarrs_data_type` 0.2.0
+- Add support for data type extensions
+  - The data type extension API is defined in the `zarrs_data_type` crate
+  - Add `Extension` variant to `DataType`
+  - **Breaking**: `DataType::metadata_fill_value()` is now fallible
+  - **Breaking**: `DataType::from_metadata()` now returns a `PluginCreateError` on error instead of `UnsupportedDataTypeError`
+  - **Breaking**: `DataType::from_metadata()` has an additional `ExtensionAliasesDataTypeV3` parameter
+  - **Breaking**: `DataType::[fixed_]size()` are no longer `const`
+  - **Breaking**: Remove `TryFrom<DataTypeMetadataV3>` for `DataType`
+  - **Breaking**: Remove `DataType::identifier()`
+  - **Breaking**: move the `zarrs::array::{data_type,fill_value}` modules into the `zarrs_data_type` crate
 - Add `custom_data_type_{fixed_size,variable_size,uint4,uint12,float8_e3m4}` examples
 - Add `[Async]ArrayDlPackExt` traits that add methods to `Array` for `DLPack` tensor interop
   - Gated by the `dlpack` feature
@@ -40,7 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: change `RawBytesOffsets` into a validated newtype
 - **Breaking**: `ArrayBytes::new_vlen()` not returns a `Result` and validates bytes/offsets compatibility
 - Reenable broken compatibility tests since fixed in `zarr-python`/`numcodecs`
-- **Breaking**: move the `zarrs::array::{data_type,fill_value}` modules into the `zarrs_data_type` crate
 - Bump `lru` to 0.13
 - Use codec identifiers in the example for `experimental_codec_names` remapping
 - Allow `{Array,Group}::new_with_metadata()` and `{Array,Group}Builder` to create arrays with `"must_understand": true` additional fields

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ println!("{array_ndarray:4}");
 
 ### Core
 - [`zarrs`]: The core library for manipulating Zarr hierarchies.
-- [`zarrs_data_type`]: Zarr data types (re-exported as `zarrs::data_type`).
+- [`zarrs_data_type`]: Zarr data type extension support (re-exported in `zarrs::array::data_type`).
 - [`zarrs_metadata`]: Zarr metadata support (re-exported as `zarrs::metadata`).
 - [`zarrs_plugin`]: The plugin API for `zarrs` (re-exported as `zarrs::plugin`).
 - [`zarrs_storage`]: The storage API for `zarrs` (re-exported as `zarrs::storage`).

--- a/zarrs/doc/ecosystem.md
+++ b/zarrs/doc/ecosystem.md
@@ -1,6 +1,6 @@
 #### Core
 - [`zarrs`]: The core library for manipulating Zarr hierarchies.
-- [`zarrs_data_type`]: Zarr data types (re-exported as `zarrs::data_type`).
+- [`zarrs_data_type`]: Zarr data type extension support (re-exported in `zarrs::array::data_type`).
 - [`zarrs_metadata`]: Zarr metadata support (re-exported as `zarrs::metadata`).
 - [`zarrs_plugin`]: The plugin API for `zarrs` (re-exported as `zarrs::plugin`).
 - [`zarrs_storage`]: The storage API for `zarrs` (re-exported as `zarrs::storage`).

--- a/zarrs/doc/status/data_types.md
+++ b/zarrs/doc/status/data_types.md
@@ -4,27 +4,27 @@
 [r* (raw bits)] | [ZEP0001] | &check; | | |
 | [bfloat16] | [zarr-specs #130] | &check; | | |
 | [string] | [zarr-extensions/data-types/string] | &check; | | |
-| [bytes](crate::data_type::DataType::Bytes) | [zarr-extensions/data-types/bytes] | &check; | | |
+| [bytes](crate::array::DataType::Bytes) | [zarr-extensions/data-types/bytes] | &check; | | |
 
 <sup>† Experimental data types are recommended for evaluation only.</sup>
 
-[bool]: crate::data_type::DataType::Bool
-[int8]: crate::data_type::DataType::Int8
-[int16]: crate::data_type::DataType::Int16
-[int32]: crate::data_type::DataType::Int32
-[int64]: crate::data_type::DataType::Int64
-[uint8]: crate::data_type::DataType::UInt8
-[uint16]: crate::data_type::DataType::UInt16
-[uint32]: crate::data_type::DataType::UInt32
-[uint64]: crate::data_type::DataType::UInt64
-[float16]: crate::data_type::DataType::Float16
-[float32]: crate::data_type::DataType::Float32
-[float64]: crate::data_type::DataType::Float64
-[complex64]: crate::data_type::DataType::Complex64
-[complex128]: crate::data_type::DataType::Complex128
-[bfloat16]: crate::data_type::DataType::BFloat16
-[r* (raw bits)]: crate::data_type::DataType::RawBits
-[string]: crate::data_type::DataType::String
+[bool]: crate::array::DataType::Bool
+[int8]: crate::array::DataType::Int8
+[int16]: crate::array::DataType::Int16
+[int32]: crate::array::DataType::Int32
+[int64]: crate::array::DataType::Int64
+[uint8]: crate::array::DataType::UInt8
+[uint16]: crate::array::DataType::UInt16
+[uint32]: crate::array::DataType::UInt32
+[uint64]: crate::array::DataType::UInt64
+[float16]: crate::array::DataType::Float16
+[float32]: crate::array::DataType::Float32
+[float64]: crate::array::DataType::Float64
+[complex64]: crate::array::DataType::Complex64
+[complex128]: crate::array::DataType::Complex128
+[bfloat16]: crate::array::DataType::BFloat16
+[r* (raw bits)]: crate::array::DataType::RawBits
+[string]: crate::array::DataType::String
 
 [ZEP0001]: https://zarr.dev/zeps/accepted/ZEP0001.html
 [zarr-specs #130]: https://github.com/zarr-developers/zarr-specs/issues/130

--- a/zarrs/examples/custom_data_type_fixed_size.rs
+++ b/zarrs/examples/custom_data_type_fixed_size.rs
@@ -17,10 +17,11 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 use num::traits::{FromBytes, ToBytes};
 use serde::Deserialize;
 use zarrs::array::{
-    ArrayBuilder, ArrayBytes, ArrayError, DataTypeSize, Element, ElementOwned, FillValueMetadataV3,
+    ArrayBuilder, ArrayBytes, ArrayError, DataType, DataTypeSize, Element, ElementOwned,
+    FillValueMetadataV3,
 };
 use zarrs_data_type::{
-    DataType, DataTypeExtension, DataTypeExtensionBytesCodec, DataTypeExtensionBytesCodecError,
+    DataTypeExtension, DataTypeExtensionBytesCodec, DataTypeExtensionBytesCodecError,
     DataTypeExtensionError, DataTypePlugin, FillValue, IncompatibleFillValueError,
     IncompatibleFillValueMetadataError,
 };
@@ -152,9 +153,11 @@ fn is_custom_dtype(name: &str) -> bool {
     name == CUSTOM_NAME
 }
 
-fn create_custom_dtype(metadata: &MetadataV3) -> Result<DataType, PluginCreateError> {
+fn create_custom_dtype(
+    metadata: &MetadataV3,
+) -> Result<Arc<dyn DataTypeExtension>, PluginCreateError> {
     if metadata.configuration_is_none_or_empty() {
-        Ok(DataType::Extension(Arc::new(CustomDataTypeFixedSize)))
+        Ok(Arc::new(CustomDataTypeFixedSize))
     } else {
         Err(PluginMetadataInvalidError::new(CUSTOM_NAME, "codec", metadata.to_string()).into())
     }

--- a/zarrs/examples/custom_data_type_float8_e3m4.rs
+++ b/zarrs/examples/custom_data_type_float8_e3m4.rs
@@ -7,10 +7,11 @@ use std::{borrow::Cow, sync::Arc};
 
 use serde::Deserialize;
 use zarrs::array::{
-    ArrayBuilder, ArrayBytes, ArrayError, DataTypeSize, Element, ElementOwned, FillValueMetadataV3,
+    ArrayBuilder, ArrayBytes, ArrayError, DataType, DataTypeSize, Element, ElementOwned,
+    FillValueMetadataV3,
 };
 use zarrs_data_type::{
-    DataType, DataTypeExtension, DataTypeExtensionBytesCodec, DataTypeExtensionBytesCodecError,
+    DataTypeExtension, DataTypeExtensionBytesCodec, DataTypeExtensionBytesCodecError,
     DataTypeExtensionError, DataTypePlugin, FillValue, IncompatibleFillValueError,
     IncompatibleFillValueMetadataError,
 };
@@ -38,9 +39,11 @@ fn is_custom_dtype(name: &str) -> bool {
     name == FLOAT8_E3M4
 }
 
-fn create_custom_dtype(metadata: &MetadataV3) -> Result<DataType, PluginCreateError> {
+fn create_custom_dtype(
+    metadata: &MetadataV3,
+) -> Result<Arc<dyn DataTypeExtension>, PluginCreateError> {
     if metadata.configuration_is_none_or_empty() {
-        Ok(DataType::Extension(Arc::new(CustomDataTypeFloat8e3m4)))
+        Ok(Arc::new(CustomDataTypeFloat8e3m4))
     } else {
         Err(PluginMetadataInvalidError::new(FLOAT8_E3M4, "codec", metadata.to_string()).into())
     }

--- a/zarrs/examples/custom_data_type_uint12.rs
+++ b/zarrs/examples/custom_data_type_uint12.rs
@@ -7,13 +7,13 @@ use std::{borrow::Cow, sync::Arc};
 use serde::Deserialize;
 use zarrs::{
     array::{
-        ArrayBuilder, ArrayBytes, ArrayError, DataTypeSize, Element, ElementOwned,
+        ArrayBuilder, ArrayBytes, ArrayError, DataType, DataTypeSize, Element, ElementOwned,
         FillValueMetadataV3,
     },
     array_subset::ArraySubset,
 };
 use zarrs_data_type::{
-    DataType, DataTypeExtension, DataTypeExtensionBytesCodec, DataTypeExtensionBytesCodecError,
+    DataTypeExtension, DataTypeExtensionBytesCodec, DataTypeExtensionBytesCodecError,
     DataTypeExtensionError, DataTypeExtensionPackBitsCodec, DataTypePlugin, FillValue,
     IncompatibleFillValueError, IncompatibleFillValueMetadataError,
 };
@@ -41,9 +41,11 @@ fn is_custom_dtype(name: &str) -> bool {
     name == UINT12
 }
 
-fn create_custom_dtype(metadata: &MetadataV3) -> Result<DataType, PluginCreateError> {
+fn create_custom_dtype(
+    metadata: &MetadataV3,
+) -> Result<Arc<dyn DataTypeExtension>, PluginCreateError> {
     if metadata.configuration_is_none_or_empty() {
-        Ok(DataType::Extension(Arc::new(CustomDataTypeUInt12)))
+        Ok(Arc::new(CustomDataTypeUInt12))
     } else {
         Err(PluginMetadataInvalidError::new(UINT12, "codec", metadata.to_string()).into())
     }

--- a/zarrs/examples/custom_data_type_uint4.rs
+++ b/zarrs/examples/custom_data_type_uint4.rs
@@ -7,13 +7,13 @@ use std::{borrow::Cow, sync::Arc};
 use serde::Deserialize;
 use zarrs::{
     array::{
-        ArrayBuilder, ArrayBytes, ArrayError, DataTypeSize, Element, ElementOwned,
+        ArrayBuilder, ArrayBytes, ArrayError, DataType, DataTypeSize, Element, ElementOwned,
         FillValueMetadataV3,
     },
     array_subset::ArraySubset,
 };
 use zarrs_data_type::{
-    DataType, DataTypeExtension, DataTypeExtensionBytesCodec, DataTypeExtensionBytesCodecError,
+    DataTypeExtension, DataTypeExtensionBytesCodec, DataTypeExtensionBytesCodecError,
     DataTypeExtensionError, DataTypeExtensionPackBitsCodec, DataTypePlugin, FillValue,
     IncompatibleFillValueError, IncompatibleFillValueMetadataError,
 };
@@ -41,9 +41,11 @@ fn is_custom_dtype(name: &str) -> bool {
     name == UINT4
 }
 
-fn create_custom_dtype(metadata: &MetadataV3) -> Result<DataType, PluginCreateError> {
+fn create_custom_dtype(
+    metadata: &MetadataV3,
+) -> Result<Arc<dyn DataTypeExtension>, PluginCreateError> {
     if metadata.configuration_is_none_or_empty() {
-        Ok(DataType::Extension(Arc::new(CustomDataTypeUInt4)))
+        Ok(Arc::new(CustomDataTypeUInt4))
     } else {
         Err(PluginMetadataInvalidError::new(UINT4, "codec", metadata.to_string()).into())
     }

--- a/zarrs/examples/custom_data_type_variable_size.rs
+++ b/zarrs/examples/custom_data_type_variable_size.rs
@@ -6,11 +6,11 @@ use derive_more::Deref;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use zarrs::array::{
-    ArrayBuilder, ArrayBytes, ArrayError, DataTypeSize, Element, ElementOwned, FillValueMetadataV3,
-    RawBytesOffsets,
+    ArrayBuilder, ArrayBytes, ArrayError, DataType, DataTypeSize, Element, ElementOwned,
+    FillValueMetadataV3, RawBytesOffsets,
 };
 use zarrs_data_type::{
-    DataType, DataTypeExtension, DataTypePlugin, FillValue, IncompatibleFillValueError,
+    DataTypeExtension, DataTypePlugin, FillValue, IncompatibleFillValueError,
     IncompatibleFillValueMetadataError,
 };
 use zarrs_metadata::v3::{MetadataConfiguration, MetadataV3};
@@ -91,9 +91,11 @@ fn is_custom_dtype(name: &str) -> bool {
     name == CUSTOM_NAME
 }
 
-fn create_custom_dtype(metadata: &MetadataV3) -> Result<DataType, PluginCreateError> {
+fn create_custom_dtype(
+    metadata: &MetadataV3,
+) -> Result<Arc<dyn DataTypeExtension>, PluginCreateError> {
     if metadata.configuration_is_none_or_empty() {
-        Ok(DataType::Extension(Arc::new(CustomDataTypeVariableSize)))
+        Ok(Arc::new(CustomDataTypeVariableSize))
     } else {
         Err(PluginMetadataInvalidError::new(CUSTOM_NAME, "codec", metadata.to_string()).into())
     }

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -29,13 +29,14 @@ mod array_metadata_options;
 mod array_representation;
 mod bytes_representation;
 mod chunk_cache;
+mod element;
+
 pub mod chunk_grid;
 pub mod chunk_key_encoding;
 pub mod codec;
 pub mod concurrency;
-mod element;
+pub mod data_type;
 pub mod storage_transformer;
-pub use crate::data_type; // re-export for zarrs < 0.20 compat
 
 #[cfg(feature = "dlpack")]
 mod array_dlpack_ext;
@@ -69,7 +70,7 @@ pub use self::{
     element::{Element, ElementFixedLength, ElementOwned},
     storage_transformer::StorageTransformerChain,
 };
-pub use crate::data_type::{DataType, FillValue}; // re-export for zarrs < 0.20 compat
+pub use data_type::{DataType, FillValue}; // re-export for zarrs < 0.20 compat
 
 pub use crate::metadata::v2::ArrayMetadataV2;
 pub use crate::metadata::v3::{

--- a/zarrs/src/array/array_dlpack_ext.rs
+++ b/zarrs/src/array/array_dlpack_ext.rs
@@ -1,9 +1,9 @@
 use std::{ffi::c_void, sync::Arc};
 
+use crate::array::DataType;
 use derive_more::Display;
 use dlpark::{ffi::Device, ShapeAndStrides, ToTensor};
 use thiserror::Error;
-use zarrs_data_type::DataType;
 
 use super::{ChunkRepresentation, RawBytes};
 
@@ -95,11 +95,10 @@ impl ToTensor for RawBytesDlPack {
 #[cfg(test)]
 mod tests {
     use dlpark::{IntoDLPack, ManagedTensor};
-    use zarrs_data_type::{DataType, FillValue};
     use zarrs_storage::store::MemoryStore;
 
     use crate::{
-        array::{codec::CodecOptions, ArrayBuilder, ArrayDlPackExt},
+        array::{codec::CodecOptions, ArrayBuilder, ArrayDlPackExt, DataType, FillValue},
         array_subset::ArraySubset,
     };
 

--- a/zarrs/src/array/array_errors.rs
+++ b/zarrs/src/array/array_errors.rs
@@ -1,11 +1,11 @@
 use thiserror::Error;
 
 use crate::{
+    array::data_type::{IncompatibleFillValueError, IncompatibleFillValueMetadataError},
     array_subset::{
         ArraySubset, IncompatibleDimensionalityError, IncompatibleOffsetError,
         IncompatibleStartEndIndicesError,
     },
-    data_type::{IncompatibleFillValueError, IncompatibleFillValueMetadataError},
     metadata::v3::UnsupportedAdditionalFieldError,
     node::NodePathError,
     plugin::PluginCreateError,

--- a/zarrs/src/array/array_representation.rs
+++ b/zarrs/src/array/array_representation.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
 
 use super::{ArrayShape, DataType, DataTypeSize, FillValue};
-use crate::data_type::IncompatibleFillValueError;
+use crate::array::data_type::IncompatibleFillValueError;
 use derive_more::Display;
 
 /// The shape, data type, and fill value of an `array`.

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
@@ -74,7 +74,6 @@ pub(crate) fn create_codec_fixedscaleoffset(
 mod tests {
     use std::num::NonZeroU64;
 
-    use zarrs_data_type::DataType;
     use zarrs_metadata::codec::fixedscaleoffset::FixedScaleOffsetCodecConfiguration;
 
     use crate::array::{
@@ -82,7 +81,7 @@ mod tests {
             array_to_array::fixedscaleoffset::FixedScaleOffsetCodec, ArrayToArrayCodecTraits,
             CodecOptions,
         },
-        ArrayBytes, ChunkRepresentation,
+        ArrayBytes, ChunkRepresentation, DataType,
     };
 
     #[test]

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZeroU64, sync::Arc};
 
-use zarrs_data_type::{DataType, FillValue};
+use crate::array::{DataType, FillValue};
 use zarrs_metadata::{codec::SQUEEZE, v3::MetadataConfiguration};
 
 use crate::{

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZeroU64, sync::Arc};
 
-use zarrs_data_type::{DataType, FillValue};
+use crate::array::{DataType, FillValue};
 use zarrs_metadata::{codec::TRANSPOSE, v3::MetadataConfiguration};
 
 use crate::{

--- a/zarrs/src/array/codec/array_to_bytes/bytes.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes.rs
@@ -10,7 +10,7 @@
 //! - <https://github.com/zarr-developers/zarr-extensions/tree/main/codecs/bytes>
 //!
 //! ### Specification Deviations
-//! The `bytes` specification defines a fixed set of supported data types, whereas the `bytes` codec in `zarrs` supports any fixed size data type that implements the [`DataTypeExtensionBytesCodec`](crate::data_type::DataTypeExtensionBytesCodec) trait.
+//! The `bytes` specification defines a fixed set of supported data types, whereas the `bytes` codec in `zarrs` supports any fixed size data type that implements the [`DataTypeExtensionBytesCodec`](zarrs_data_type::DataTypeExtensionBytesCodec) trait.
 //!
 //! ### Codec `name` Aliases (Zarr V3)
 //! - `bytes`

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
@@ -2,7 +2,8 @@
 
 use std::sync::Arc;
 
-use zarrs_data_type::{DataType, DataTypeExtensionError};
+use crate::array::DataType;
+use zarrs_data_type::DataTypeExtensionError;
 use zarrs_metadata::{codec::BYTES, v3::MetadataConfiguration};
 use zarrs_plugin::PluginCreateError;
 

--- a/zarrs/src/array/codec/array_to_bytes/packbits.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits.rs
@@ -34,9 +34,9 @@ pub use crate::metadata::codec::packbits::{
 };
 use crate::{array::codec::CodecError, metadata::codec::PACKBITS};
 
+use crate::array::DataType;
 use num::Integer;
 pub use packbits_codec::PackBitsCodec;
-use zarrs_data_type::DataType;
 
 use crate::{
     array::codec::{Codec, CodecPlugin},
@@ -156,14 +156,13 @@ mod tests {
     use std::{num::NonZeroU64, sync::Arc};
 
     use num::Integer;
-    use zarrs_data_type::{DataType, FillValue};
     use zarrs_metadata::codec::packbits::PackBitsPaddingEncoding;
 
     use crate::{
         array::{
             codec::{ArrayToBytesCodecTraits, BytesCodec, CodecOptions},
             element::{Element, ElementOwned},
-            ChunkRepresentation,
+            ChunkRepresentation, DataType, FillValue,
         },
         array_subset::ArraySubset,
     };

--- a/zarrs/src/lib.rs
+++ b/zarrs/src/lib.rs
@@ -200,7 +200,6 @@ pub mod group;
 pub mod node;
 pub mod version;
 
-pub use zarrs_data_type as data_type;
 pub use zarrs_metadata as metadata;
 pub use zarrs_plugin as plugin;
 pub use zarrs_storage as storage;

--- a/zarrs_data_type/CHANGELOG.md
+++ b/zarrs_data_type/CHANGELOG.md
@@ -10,23 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for data type extensions
   - Add `DataTypePlugin` and `DataTypeExtension`
-  - Add `Extension` variant to `DataType`
   - Add `DataTypeExtensionBytesCodec`, `DataTypeExtensionBytesCodecError`
   - Add `DataTypeExtensionPackBitsCodec`
+  - This crate no longer defines explicit data types
 
 ### Changed
-- **Breaking**: `DataType::metadata_fill_value()` is now fallible
-- **Breaking**: `DataType::from_metadata()` now returns a `PluginCreateError` on error instead of `UnsupportedDataTypeError`
-- **Breaking**: `DataType::from_metadata()` has an additional `ExtensionAliasesDataTypeV3` parameter
-- **Breaking**: `DataType::[fixed_]size()` are no longer `const`
 - Bump `derive_more` to 2.0.0
 - Bump `half` to 2.3.1
 - Bump `thiserror` to 2.0.12
 
 ### Removed
+- **Breaking**: Remove `DataType` (moved to `zarrs::array[::data_type]::DataType`)
 - **Breaking**: Remove `UnsupportedDataTypeError`
-- **Breaking**: Remove `DataType::identifier()`
-- **Breaking**: Remove `TryFrom<DataTypeMetadataV3>` for `DataType`
 
 ## [0.1.0] - 2025-01-24
 

--- a/zarrs_data_type/src/fill_value.rs
+++ b/zarrs_data_type/src/fill_value.rs
@@ -2,7 +2,36 @@
 //!
 //! See <https://zarr-specs.readthedocs.io/en/latest/v3/core/index.html#fill-value>.
 
-/// The fill value of the Zarr array.
+use thiserror::Error;
+use zarrs_metadata::v3::array::fill_value::FillValueMetadataV3;
+
+/// A fill value metadata incompatibility error.
+#[derive(Debug, Error)]
+#[error("incompatible fill value {} for data type {}", _1.to_string(), _0.to_string())]
+pub struct IncompatibleFillValueMetadataError(String, FillValueMetadataV3);
+
+impl IncompatibleFillValueMetadataError {
+    /// Create a new [`IncompatibleFillValueMetadataError`].
+    #[must_use]
+    pub fn new(data_type: String, fill_value_metadata: FillValueMetadataV3) -> Self {
+        Self(data_type, fill_value_metadata)
+    }
+}
+
+/// A fill value incompatibility error.
+#[derive(Debug, Error)]
+#[error("incompatible fill value {1} for data type {0}")]
+pub struct IncompatibleFillValueError(String, FillValue);
+
+impl IncompatibleFillValueError {
+    /// Create a new incompatible fill value error.
+    #[must_use]
+    pub const fn new(data_type_name: String, fill_value: FillValue) -> Self {
+        Self(data_type_name, fill_value)
+    }
+}
+
+/// A fill value.
 ///
 /// Provides an element value to use for uninitialised portions of the Zarr array.
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/zarrs_data_type/src/lib.rs
+++ b/zarrs_data_type/src/lib.rs
@@ -1,17 +1,15 @@
 //! [Zarr](https://zarr-specs.readthedocs.io/) data types for the [`zarrs`](https://docs.rs/zarrs/latest/zarrs/index.html) crate.
 
-mod data_type;
 mod data_type_extension;
 mod data_type_extension_bytes_codec;
 mod data_type_extension_packbits_codec;
 mod data_type_plugin;
 mod fill_value;
 
-pub use data_type::{DataType, IncompatibleFillValueError, IncompatibleFillValueMetadataError};
 pub use data_type_extension::{DataTypeExtension, DataTypeExtensionError};
 pub use data_type_extension_bytes_codec::{
     DataTypeExtensionBytesCodec, DataTypeExtensionBytesCodecError,
 };
 pub use data_type_extension_packbits_codec::DataTypeExtensionPackBitsCodec;
 pub use data_type_plugin::DataTypePlugin;
-pub use fill_value::FillValue;
+pub use fill_value::{FillValue, IncompatibleFillValueError, IncompatibleFillValueMetadataError};


### PR DESCRIPTION
`zarrs_data_types` no longer defines data types explicitly, just the data type extension API.
This makes it more amenable to stabilisation.

`zarrs` itself can continue to evolve the `DataType` enum as new data types are created.