### PR TITLE
refactor: `self: Arc<Self>` for async `Array` methods

### DIFF
--- a/zarrs/examples/async_array_write_read.rs
+++ b/zarrs/examples/async_array_write_read.rs
@@ -64,7 +64,7 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     .build_arc(store.clone(), array_path)?;
 
     // Write array metadata to store
-    array.async_store_metadata().await?;
+    array.clone().async_store_metadata().await?;
 
     println!(
         "The array metadata is:\n{}\n",
@@ -97,12 +97,14 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
 
     let subset_all = array.subset_all();
     let data_all = array
+        .clone()
         .async_retrieve_array_subset_ndarray::<f32>(&subset_all)
         .await?;
     println!("async_store_chunk [0, 0] and [0, 1]:\n{data_all:+4.1}\n");
 
     // Store multiple chunks
     array
+        .clone()
         .async_store_chunks_elements::<f32>(
             &ArraySubset::new_with_ranges(&[1..2, 0..2]),
             &[
@@ -114,36 +116,42 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     let data_all = array
+        .clone()
         .async_retrieve_array_subset_ndarray::<f32>(&subset_all)
         .await?;
     println!("async_store_chunks [1..2, 0..2]:\n{data_all:+4.1}\n");
 
     // Write a subset spanning multiple chunks, including updating chunks already written
     array
+        .clone()
         .async_store_array_subset_elements::<f32>(
             &ArraySubset::new_with_ranges(&[3..6, 3..6]),
             &[-3.3, -3.4, -3.5, -4.3, -4.4, -4.5, -5.3, -5.4, -5.5],
         )
         .await?;
     let data_all = array
+        .clone()
         .async_retrieve_array_subset_ndarray::<f32>(&subset_all)
         .await?;
     println!("async_store_array_subset [3..6, 3..6]:\n{data_all:+4.1}\n");
 
     // Store array subset
     array
+        .clone()
         .async_store_array_subset_elements::<f32>(
             &ArraySubset::new_with_ranges(&[0..8, 6..7]),
             &[-0.6, -1.6, -2.6, -3.6, -4.6, -5.6, -6.6, -7.6],
         )
         .await?;
     let data_all = array
+        .clone()
         .async_retrieve_array_subset_ndarray::<f32>(&subset_all)
         .await?;
     println!("async_store_array_subset [0..8, 6..7]:\n{data_all:+4.1}\n");
 
     // Store chunk subset
     array
+        .clone()
         .async_store_chunk_subset_elements::<f32>(
             // chunk indices
             &[1, 1],
@@ -153,13 +161,15 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     let data_all = array
+        .clone()
         .async_retrieve_array_subset_ndarray::<f32>(&subset_all)
         .await?;
     println!("async_store_chunk_subset [3..4, 0..4] of chunk [1, 1]:\n{data_all:+4.1}\n");
 
     // Erase a chunk
-    array.async_erase_chunk(&[0, 0]).await?;
+    array.clone().async_erase_chunk(&[0, 0]).await?;
     let data_all = array
+        .clone()
         .async_retrieve_array_subset_ndarray::<f32>(&subset_all)
         .await?;
     println!("async_erase_chunk [0, 0]:\n{data_all:+4.1}\n");
@@ -167,18 +177,23 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     // Read a chunk
     let chunk_indices = vec![0, 1];
     let data_chunk = array
+        .clone()
         .async_retrieve_chunk_ndarray::<f32>(&chunk_indices)
         .await?;
     println!("async_retrieve_chunk [0, 1]:\n{data_chunk:+4.1}\n");
 
     // Read chunks
     let chunks = ArraySubset::new_with_ranges(&[0..2, 1..2]);
-    let data_chunks = array.async_retrieve_chunks_ndarray::<f32>(&chunks).await?;
+    let data_chunks = array
+        .clone()
+        .async_retrieve_chunks_ndarray::<f32>(&chunks)
+        .await?;
     println!("async_retrieve_chunks [0..2, 1..2]:\n{data_chunks:+4.1}\n");
 
     // Retrieve an array subset
     let subset = ArraySubset::new_with_ranges(&[2..6, 3..5]); // the center 4x2 region
     let data_subset = array
+        .clone()
         .async_retrieve_array_subset_ndarray::<f32>(&subset)
         .await?;
     println!("async_retrieve_array_subset [2..6, 3..5]:\n{data_subset:+4.1}\n");

--- a/zarrs/examples/async_http_array_read.rs
+++ b/zarrs/examples/async_http_array_read.rs
@@ -56,6 +56,7 @@ async fn http_array_read(backend: Backend) -> Result<(), Box<dyn std::error::Err
 
     // Read the whole array
     let data_all = array
+        .clone()
         .async_retrieve_array_subset_ndarray::<f32>(&array.subset_all())
         .await?;
     println!("The whole array is:\n{data_all}\n");
@@ -63,6 +64,7 @@ async fn http_array_read(backend: Backend) -> Result<(), Box<dyn std::error::Err
     // Read a chunk back from the store
     let chunk_indices = vec![1, 0];
     let data_chunk = array
+        .clone()
         .async_retrieve_chunk_ndarray::<f32>(&chunk_indices)
         .await?;
     println!("Chunk [1,0] is:\n{data_chunk}\n");

--- a/zarrs/examples/async_http_array_read.rs
+++ b/zarrs/examples/async_http_array_read.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+#![feature(ergonomic_clones)]
 
 use std::sync::Arc;
 use zarrs::{
@@ -56,7 +57,7 @@ async fn http_array_read(backend: Backend) -> Result<(), Box<dyn std::error::Err
 
     // Read the whole array
     let data_all = array
-        .clone()
+        .use
         .async_retrieve_array_subset_ndarray::<f32>(&array.subset_all())
         .await?;
     println!("The whole array is:\n{data_all}\n");
@@ -64,7 +65,7 @@ async fn http_array_read(backend: Backend) -> Result<(), Box<dyn std::error::Err
     // Read a chunk back from the store
     let chunk_indices = vec![1, 0];
     let data_chunk = array
-        .clone()
+        .use
         .async_retrieve_chunk_ndarray::<f32>(&chunk_indices)
         .await?;
     println!("Chunk [1,0] is:\n{data_chunk}\n");

--- a/zarrs/src/array/array_dlpack_ext/array_dlpack_ext_async.rs
+++ b/zarrs/src/array/array_dlpack_ext/array_dlpack_ext_async.rs
@@ -24,7 +24,7 @@ pub trait AsyncArrayDlPackExt<TStorage: ?Sized + AsyncReadableStorageTraits + 's
     /// Returns a [`super::ArrayDlPackExtError`] if the chunk cannot be represented as a `DLPack` tensor.
     /// Otherwise returns standard [`Array::retrieve_array_subset_opt`] errors.
     async fn retrieve_array_subset_dlpack(
-        &self,
+        self: Arc<Self>,
         array_subset: &ArraySubset,
         options: &CodecOptions,
     ) -> Result<ManagerCtx<RawBytesDlPack>, ArrayError>;
@@ -37,7 +37,7 @@ pub trait AsyncArrayDlPackExt<TStorage: ?Sized + AsyncReadableStorageTraits + 's
     /// Returns a [`ArrayDlPackExtError`] if the chunk cannot be represented as a `DLPack` tensor.
     /// Otherwise returns standard [`Array::retrieve_chunk_if_exists_opt`] errors.
     async fn retrieve_chunk_if_exists_dlpack(
-        &self,
+        self: Arc<Self>,
         chunk_indices: &[u64],
         options: &CodecOptions,
     ) -> Result<Option<ManagerCtx<RawBytesDlPack>>, ArrayError>;
@@ -50,7 +50,7 @@ pub trait AsyncArrayDlPackExt<TStorage: ?Sized + AsyncReadableStorageTraits + 's
     /// Returns a [`ArrayDlPackExtError`] if the chunk cannot be represented as a `DLPack` tensor.
     /// Otherwise returns standard [`Array::retrieve_chunk_opt`] errors.
     async fn retrieve_chunk_dlpack(
-        &self,
+        self: Arc<Self>,
         chunk_indices: &[u64],
         options: &CodecOptions,
     ) -> Result<ManagerCtx<RawBytesDlPack>, ArrayError>;
@@ -63,7 +63,7 @@ pub trait AsyncArrayDlPackExt<TStorage: ?Sized + AsyncReadableStorageTraits + 's
     /// Returns a [`ArrayDlPackExtError`] if the chunk cannot be represented as a `DLPack` tensor.
     /// Otherwise returns standard [`Array::retrieve_chunks_opt`] errors.
     async fn retrieve_chunks_dlpack(
-        &self,
+        self: Arc<Self>,
         chunks: &ArraySubset,
         options: &CodecOptions,
     ) -> Result<ManagerCtx<RawBytesDlPack>, ArrayError>;
@@ -74,11 +74,12 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayDlPackEx
     for Array<TStorage>
 {
     async fn retrieve_array_subset_dlpack(
-        &self,
+        self: Arc<Self>,
         array_subset: &ArraySubset,
         options: &CodecOptions,
     ) -> Result<ManagerCtx<RawBytesDlPack>, ArrayError> {
         let bytes = self
+            .clone()
             .async_retrieve_array_subset_opt(array_subset, options)
             .await?
             .into_owned();
@@ -107,11 +108,12 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayDlPackEx
     }
 
     async fn retrieve_chunk_if_exists_dlpack(
-        &self,
+        self: Arc<Self>,
         chunk_indices: &[u64],
         options: &CodecOptions,
     ) -> Result<Option<ManagerCtx<RawBytesDlPack>>, ArrayError> {
         let Some(bytes) = self
+            .clone()
             .async_retrieve_chunk_if_exists_opt(chunk_indices, options)
             .await?
         else {
@@ -126,11 +128,12 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayDlPackEx
     }
 
     async fn retrieve_chunk_dlpack(
-        &self,
+        self: Arc<Self>,
         chunk_indices: &[u64],
         options: &CodecOptions,
     ) -> Result<ManagerCtx<RawBytesDlPack>, ArrayError> {
         let bytes = self
+            .clone()
             .async_retrieve_chunk_opt(chunk_indices, options)
             .await?
             .into_owned();
@@ -142,7 +145,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayDlPackEx
     }
 
     async fn retrieve_chunks_dlpack(
-        &self,
+        self: Arc<Self>,
         chunks: &ArraySubset,
         options: &CodecOptions,
     ) -> Result<ManagerCtx<RawBytesDlPack>, ArrayError> {

--- a/zarrs/tests/array_async.rs
+++ b/zarrs/tests/array_async.rs
@@ -35,7 +35,7 @@ async fn array_async_read(shard: bool) -> Result<(), Box<dyn std::error::Error>>
                 .build(),
         ));
     }
-    let array = builder.build(store, array_path).unwrap();
+    let array = builder.build_arc(store, array_path).unwrap();
 
     assert_eq!(array.data_type(), &DataType::UInt8);
     assert_eq!(array.fill_value().as_ne_bytes(), &[0u8]);
@@ -50,79 +50,79 @@ async fn array_async_read(shard: bool) -> Result<(), Box<dyn std::error::Error>>
     // -----|-----
     // 9 10 | 0  0
     // 0  0 | 0  0
-    array.async_store_chunk(&[0, 0], &[1, 2, 0, 0]).await?;
-    array.async_store_chunk(&[0, 1], &[3, 4, 7, 8]).await?;
-    array.async_store_array_subset(&ArraySubset::new_with_ranges(&[1..3, 0..2]), &[5, 6, 9, 10]).await?;
+    array.clone().async_store_chunk(&[0, 0], &[1, 2, 0, 0]).await?;
+    array.clone().async_store_chunk(&[0, 1], &[3, 4, 7, 8]).await?;
+    array.clone().async_store_array_subset(&ArraySubset::new_with_ranges(&[1..3, 0..2]), &[5, 6, 9, 10]).await?;
 
-    assert!(array.async_retrieve_chunk(&[0, 0, 0]).await.is_err());
-    assert_eq!(array.async_retrieve_chunk(&[0, 0]).await?, vec![1, 2, 5, 6].into());
-    assert_eq!(array.async_retrieve_chunk(&[0, 1]).await?, vec![3, 4, 7, 8].into());
-    assert_eq!(array.async_retrieve_chunk(&[1, 0]).await?, vec![9, 10, 0, 0].into());
-    assert_eq!(array.async_retrieve_chunk(&[1, 1]).await?, vec![0, 0, 0, 0].into());
+    assert!(array.clone().async_retrieve_chunk(&[0, 0, 0]).await.is_err());
+    assert_eq!(array.clone().async_retrieve_chunk(&[0, 0]).await?, vec![1, 2, 5, 6].into());
+    assert_eq!(array.clone().async_retrieve_chunk(&[0, 1]).await?, vec![3, 4, 7, 8].into());
+    assert_eq!(array.clone().async_retrieve_chunk(&[1, 0]).await?, vec![9, 10, 0, 0].into());
+    assert_eq!(array.clone().async_retrieve_chunk(&[1, 1]).await?, vec![0, 0, 0, 0].into());
 
-    assert!(array.async_retrieve_chunk_if_exists(&[0, 0, 0]).await.is_err());
-    assert_eq!(array.async_retrieve_chunk_if_exists(&[0, 0]).await?, Some(vec![1, 2, 5, 6].into()));
-    assert_eq!(array.async_retrieve_chunk_if_exists(&[0, 1]).await?, Some(vec![3, 4, 7, 8].into()));
-    assert_eq!(array.async_retrieve_chunk_if_exists(&[1, 0]).await?, Some(vec![9, 10, 0, 0].into()));
-    assert_eq!(array.async_retrieve_chunk_if_exists(&[1, 1]).await?, None);
+    assert!(array.clone().async_retrieve_chunk_if_exists(&[0, 0, 0]).await.is_err());
+    assert_eq!(array.clone().async_retrieve_chunk_if_exists(&[0, 0]).await?, Some(vec![1, 2, 5, 6].into()));
+    assert_eq!(array.clone().async_retrieve_chunk_if_exists(&[0, 1]).await?, Some(vec![3, 4, 7, 8].into()));
+    assert_eq!(array.clone().async_retrieve_chunk_if_exists(&[1, 0]).await?, Some(vec![9, 10, 0, 0].into()));
+    assert_eq!(array.clone().async_retrieve_chunk_if_exists(&[1, 1]).await?, None);
 
-    assert!(array.async_retrieve_chunk_ndarray::<u16>(&[0, 0]).await.is_err());
-    assert_eq!(array.async_retrieve_chunk_ndarray::<u8>(&[0, 0]).await?, ndarray::array![[1, 2], [5, 6]].into_dyn());
-    assert_eq!(array.async_retrieve_chunk_ndarray::<u8>(&[0, 1]).await?, ndarray::array![[3, 4], [7, 8]].into_dyn());
-    assert_eq!(array.async_retrieve_chunk_ndarray::<u8>(&[1, 0]).await?, ndarray::array![[9, 10], [0, 0]].into_dyn());
-    assert_eq!(array.async_retrieve_chunk_ndarray::<u8>(&[1, 1]).await?, ndarray::array![[0, 0], [0, 0]].into_dyn());
+    assert!(array.clone().async_retrieve_chunk_ndarray::<u16>(&[0, 0]).await.is_err());
+    assert_eq!(array.clone().async_retrieve_chunk_ndarray::<u8>(&[0, 0]).await?, ndarray::array![[1, 2], [5, 6]].into_dyn());
+    assert_eq!(array.clone().async_retrieve_chunk_ndarray::<u8>(&[0, 1]).await?, ndarray::array![[3, 4], [7, 8]].into_dyn());
+    assert_eq!(array.clone().async_retrieve_chunk_ndarray::<u8>(&[1, 0]).await?, ndarray::array![[9, 10], [0, 0]].into_dyn());
+    assert_eq!(array.clone().async_retrieve_chunk_ndarray::<u8>(&[1, 1]).await?, ndarray::array![[0, 0], [0, 0]].into_dyn());
 
-    assert_eq!(array.async_retrieve_chunk_ndarray_if_exists::<u8>(&[0, 0]).await?, Some(ndarray::array![[1, 2], [5, 6]].into_dyn()));
-    assert_eq!(array.async_retrieve_chunk_ndarray_if_exists::<u8>(&[0, 1]).await?, Some(ndarray::array![[3, 4], [7, 8]].into_dyn()));
-    assert_eq!(array.async_retrieve_chunk_ndarray_if_exists::<u8>(&[1, 0]).await?, Some(ndarray::array![[9, 10], [0, 0]].into_dyn()));
-    assert_eq!(array.async_retrieve_chunk_ndarray_if_exists::<u8>(&[1, 1]).await?, None);
+    assert_eq!(array.clone().async_retrieve_chunk_ndarray_if_exists::<u8>(&[0, 0]).await?, Some(ndarray::array![[1, 2], [5, 6]].into_dyn()));
+    assert_eq!(array.clone().async_retrieve_chunk_ndarray_if_exists::<u8>(&[0, 1]).await?, Some(ndarray::array![[3, 4], [7, 8]].into_dyn()));
+    assert_eq!(array.clone().async_retrieve_chunk_ndarray_if_exists::<u8>(&[1, 0]).await?, Some(ndarray::array![[9, 10], [0, 0]].into_dyn()));
+    assert_eq!(array.clone().async_retrieve_chunk_ndarray_if_exists::<u8>(&[1, 1]).await?, None);
 
-    assert!(array.async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..2])).await.is_err());
-    assert!(array.async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..3, 0..3])).await.is_err());
-    assert_eq!(array.async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, vec![1, 2, 5, 6].into());
-    assert_eq!(array.async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..1, 0..2])).await?, vec![1, 2].into());
-    assert_eq!(array.async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 1..2])).await?, vec![2, 6].into());
+    assert!(array.clone().async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..2])).await.is_err());
+    assert!(array.clone().async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..3, 0..3])).await.is_err());
+    assert_eq!(array.clone().async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, vec![1, 2, 5, 6].into());
+    assert_eq!(array.clone().async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..1, 0..2])).await?, vec![1, 2].into());
+    assert_eq!(array.clone().async_retrieve_chunk_subset(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 1..2])).await?, vec![2, 6].into());
 
-    assert!(array.async_retrieve_chunk_subset_ndarray::<u8>(&[0, 0], &ArraySubset::new_with_ranges(&[0..3, 0..3])).await.is_err());
-    assert!(array.async_retrieve_chunk_subset_ndarray::<u16>(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 0..2])).await.is_err());
-    assert_eq!(array.async_retrieve_chunk_subset_ndarray::<u8>(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, ndarray::array![[1, 2], [5, 6]].into_dyn());
-    assert_eq!(array.async_retrieve_chunk_subset_ndarray::<u8>(&[0, 0], &ArraySubset::new_with_ranges(&[0..1, 0..2])).await?, ndarray::array![[1, 2]].into_dyn());
-    assert_eq!(array.async_retrieve_chunk_subset_ndarray::<u8>(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 1..2])).await?, ndarray::array![[2], [6]].into_dyn());
+    assert!(array.clone().async_retrieve_chunk_subset_ndarray::<u8>(&[0, 0], &ArraySubset::new_with_ranges(&[0..3, 0..3])).await.is_err());
+    assert!(array.clone().async_retrieve_chunk_subset_ndarray::<u16>(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 0..2])).await.is_err());
+    assert_eq!(array.clone().async_retrieve_chunk_subset_ndarray::<u8>(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, ndarray::array![[1, 2], [5, 6]].into_dyn());
+    assert_eq!(array.clone().async_retrieve_chunk_subset_ndarray::<u8>(&[0, 0], &ArraySubset::new_with_ranges(&[0..1, 0..2])).await?, ndarray::array![[1, 2]].into_dyn());
+    assert_eq!(array.clone().async_retrieve_chunk_subset_ndarray::<u8>(&[0, 0], &ArraySubset::new_with_ranges(&[0..2, 1..2])).await?, ndarray::array![[2], [6]].into_dyn());
 
-    assert!(array.async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..2])).await.is_err());
-    assert_eq!(array.async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..0, 0..0])).await?, vec![].into());
-    assert_eq!(array.async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..1, 0..1])).await?, vec![1, 2, 5, 6].into());
-    assert_eq!(array.async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0, 0, 0, 0, 0].into());
-    assert_eq!(array.async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..2, 1..2])).await?, vec![3, 4, 7, 8, 0, 0, 0, 0].into());
-    assert_eq!(array.async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..1, 1..3])).await?, vec![3, 4, 0, 0, 7, 8, 0, 0].into());
+    assert!(array.clone().async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..2])).await.is_err());
+    assert_eq!(array.clone().async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..0, 0..0])).await?, vec![].into());
+    assert_eq!(array.clone().async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..1, 0..1])).await?, vec![1, 2, 5, 6].into());
+    assert_eq!(array.clone().async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0, 0, 0, 0, 0].into());
+    assert_eq!(array.clone().async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..2, 1..2])).await?, vec![3, 4, 7, 8, 0, 0, 0, 0].into());
+    assert_eq!(array.clone().async_retrieve_chunks(&ArraySubset::new_with_ranges(&[0..1, 1..3])).await?, vec![3, 4, 0, 0, 7, 8, 0, 0].into());
 
-    assert!(array.async_retrieve_chunks_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..2])).await.is_err());
-    assert!(array.async_retrieve_chunks_ndarray::<u16>(&ArraySubset::new_with_ranges(&[0..2, 0..2])).await.is_err());
-    assert_eq!(array.async_retrieve_chunks_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, ndarray::array![[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 0, 0], [0, 0, 0, 0]].into_dyn());
-    assert_eq!(array.async_retrieve_chunks_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..2, 1..2])).await?, ndarray::array![[3, 4], [7, 8], [0, 0], [0, 0]].into_dyn());
-    assert_eq!(array.async_retrieve_chunks_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..1, 1..3])).await?, ndarray::array![[3, 4, 0, 0], [7, 8, 0, 0]].into_dyn());
+    assert!(array.clone().async_retrieve_chunks_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..2])).await.is_err());
+    assert!(array.clone().async_retrieve_chunks_ndarray::<u16>(&ArraySubset::new_with_ranges(&[0..2, 0..2])).await.is_err());
+    assert_eq!(array.clone().async_retrieve_chunks_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, ndarray::array![[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 0, 0], [0, 0, 0, 0]].into_dyn());
+    assert_eq!(array.clone().async_retrieve_chunks_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..2, 1..2])).await?, ndarray::array![[3, 4], [7, 8], [0, 0], [0, 0]].into_dyn());
+    assert_eq!(array.clone().async_retrieve_chunks_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..1, 1..3])).await?, ndarray::array![[3, 4, 0, 0], [7, 8, 0, 0]].into_dyn());
 
-    assert!(array.async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..4])).await.is_err());
-    assert_eq!(array.async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..0, 0..0])).await?, vec![].into());
-    assert_eq!(array.async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, vec![1, 2, 5, 6].into());
-    assert_eq!(array.async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..4, 0..4])).await?, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0, 0, 0, 0, 0].into());
-    assert_eq!(array.async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[1..3, 1..3])).await?, vec![6, 7, 10 ,0].into());
-    assert_eq!(array.async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[5..7, 5..6])).await?, vec![0, 0].into()); // OOB -> fill value
-    assert_eq!(array.async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..5, 0..5])).await?, vec![1, 2, 3, 4, 0, 5, 6, 7, 8, 0, 9, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0].into()); // OOB -> fill value
+    assert!(array.clone().async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..4])).await.is_err());
+    assert_eq!(array.clone().async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..0, 0..0])).await?, vec![].into());
+    assert_eq!(array.clone().async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..2, 0..2])).await?, vec![1, 2, 5, 6].into());
+    assert_eq!(array.clone().async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..4, 0..4])).await?, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0, 0, 0, 0, 0].into());
+    assert_eq!(array.clone().async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[1..3, 1..3])).await?, vec![6, 7, 10 ,0].into());
+    assert_eq!(array.clone().async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[5..7, 5..6])).await?, vec![0, 0].into()); // OOB -> fill value
+    assert_eq!(array.clone().async_retrieve_array_subset(&ArraySubset::new_with_ranges(&[0..5, 0..5])).await?, vec![1, 2, 3, 4, 0, 5, 6, 7, 8, 0, 9, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0].into()); // OOB -> fill value
 
-    assert!(array.async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..4])).await.is_err());
-    assert!(array.async_retrieve_array_subset_ndarray::<u16>(&ArraySubset::new_with_ranges(&[0..4, 0..4])).await.is_err());
-    assert_eq!(array.async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..0, 0..0])).await?, ndarray::Array2::<u8>::zeros((0, 0)).into_dyn());
-    assert_eq!(array.async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..4, 0..4])).await?, ndarray::array![[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 0, 0], [0, 0, 0, 0]].into_dyn());
-    assert_eq!(array.async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[1..3, 1..3])).await?, ndarray::array![[6, 7], [10 ,0]].into_dyn());
-    assert_eq!(array.async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[5..7, 5..6])).await?, ndarray::array![[0], [0]].into_dyn()); // OOB -> fill value
-    assert_eq!(array.async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..5, 0..5])).await?, ndarray::array![[1, 2, 3, 4, 0], [5, 6, 7, 8, 0], [9, 10, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]].into_dyn()); // OOB -> fill value
+    assert!(array.clone().async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..4])).await.is_err());
+    assert!(array.clone().async_retrieve_array_subset_ndarray::<u16>(&ArraySubset::new_with_ranges(&[0..4, 0..4])).await.is_err());
+    assert_eq!(array.clone().async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..0, 0..0])).await?, ndarray::Array2::<u8>::zeros((0, 0)).into_dyn());
+    assert_eq!(array.clone().async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..4, 0..4])).await?, ndarray::array![[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 0, 0], [0, 0, 0, 0]].into_dyn());
+    assert_eq!(array.clone().async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[1..3, 1..3])).await?, ndarray::array![[6, 7], [10 ,0]].into_dyn());
+    assert_eq!(array.clone().async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[5..7, 5..6])).await?, ndarray::array![[0], [0]].into_dyn()); // OOB -> fill value
+    assert_eq!(array.clone().async_retrieve_array_subset_ndarray::<u8>(&ArraySubset::new_with_ranges(&[0..5, 0..5])).await?, ndarray::array![[1, 2, 3, 4, 0], [5, 6, 7, 8, 0], [9, 10, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]].into_dyn()); // OOB -> fill value
 
-    assert!(array.async_partial_decoder(&[0]).await.is_err());
-    assert!(array.async_partial_decoder(&[0, 0]).await?.partial_decode(&[ArraySubset::new_with_ranges(&[0..1])], &options).await.is_err());
-    assert_eq!(array.async_partial_decoder(&[0, 0]).await?.partial_decode(&[], &options).await?, []);
-    assert_eq!(array.async_partial_decoder(&[5, 0]).await?.partial_decode(&[ArraySubset::new_with_ranges(&[0..1, 0..2])], &options).await?, [vec![0, 0].into()]); // OOB -> fill value
-    assert_eq!(array.async_partial_decoder(&[0, 0]).await?.partial_decode(&[ArraySubset::new_with_ranges(&[0..1, 0..2]), ArraySubset::new_with_ranges(&[0..2, 1..2])], &options).await?, [vec![1, 2].into(), vec![2, 6].into()]);
+    assert!(array.clone().async_partial_decoder(&[0]).await.is_err());
+    assert!(array.clone().async_partial_decoder(&[0, 0]).await?.partial_decode(&[ArraySubset::new_with_ranges(&[0..1])], &options).await.is_err());
+    assert_eq!(array.clone().async_partial_decoder(&[0, 0]).await?.partial_decode(&[], &options).await?, []);
+    assert_eq!(array.clone().async_partial_decoder(&[5, 0]).await?.partial_decode(&[ArraySubset::new_with_ranges(&[0..1, 0..2])], &options).await?, [vec![0, 0].into()]); // OOB -> fill value
+    assert_eq!(array.clone().async_partial_decoder(&[0, 0]).await?.partial_decode(&[ArraySubset::new_with_ranges(&[0..1, 0..2]), ArraySubset::new_with_ranges(&[0..2, 1..2])], &options).await?, [vec![1, 2].into(), vec![2, 6].into()]);
 
     Ok(())
 }
@@ -140,14 +140,16 @@ async fn array_async_read_shard_compress() -> Result<(), Box<dyn std::error::Err
 }
 
 async fn array_str_impl(
-    array: Array<zarrs_object_store::AsyncObjectStore<InMemory>>,
+    array: Arc<Array<zarrs_object_store::AsyncObjectStore<InMemory>>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Store a single chunk
     array
+        .clone()
         .async_store_chunk_elements(&[0, 0], &["a", "bb", "ccc", "dddd"])
         .await?;
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunk_elements::<String>(&[0, 0])
             .await?,
         &["a", "bb", "ccc", "dddd"]
@@ -155,6 +157,7 @@ async fn array_str_impl(
 
     // Write array subset with full chunks
     array
+        .clone()
         .async_store_array_subset_elements(
             &ArraySubset::new_with_ranges(&[2..4, 0..4]),
             &[
@@ -164,12 +167,14 @@ async fn array_str_impl(
         .await?;
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunk_elements::<String>(&[1, 0])
             .await?,
         &["1", "22", "55555", "666666"]
     );
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunk_elements::<String>(&[1, 1])
             .await?,
         &["333", "4444", "7777777", "88888888"]
@@ -177,6 +182,7 @@ async fn array_str_impl(
 
     // Write array subset with partial chunks
     array
+        .clone()
         .async_store_array_subset_elements(
             &ArraySubset::new_with_ranges(&[1..3, 1..3]),
             &["S1", "S22", "S333", "S4444"],
@@ -184,24 +190,28 @@ async fn array_str_impl(
         .await?;
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunk_elements::<String>(&[0, 0])
             .await?,
         &["a", "bb", "ccc", "S1"]
     );
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunk_elements::<String>(&[0, 1])
             .await?,
         &["", "", "S22", ""]
     );
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunk_elements::<String>(&[1, 0])
             .await?,
         &["1", "S333", "55555", "666666"]
     );
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunk_elements::<String>(&[1, 1])
             .await?,
         &["S4444", "4444", "7777777", "88888888"]
@@ -209,6 +219,7 @@ async fn array_str_impl(
 
     // Write multiple chunks
     array
+        .clone()
         .async_store_chunks_elements(
             &ArraySubset::new_with_ranges(&[0..1, 0..2]),
             &["a", "bb", "ccc", "dddd", "C0", "C11", "C222", "C3333"],
@@ -216,18 +227,21 @@ async fn array_str_impl(
         .await?;
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunk_elements::<String>(&[0, 0])
             .await?,
         &["a", "bb", "C0", "C11"]
     );
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunk_elements::<String>(&[0, 1])
             .await?,
         &["ccc", "dddd", "C222", "C3333"]
     );
     assert_eq!(
         array
+            .clone()
             .async_retrieve_chunks_elements::<String>(&ArraySubset::new_with_ranges(&[0..1, 0..2]))
             .await?,
         &["a", "bb", "ccc", "dddd", "C0", "C11", "C222", "C3333"]
@@ -236,6 +250,7 @@ async fn array_str_impl(
     // Full chunk requests
     assert_eq!(
         array
+            .clone()
             .async_retrieve_array_subset_elements::<String>(&ArraySubset::new_with_ranges(&[
                 0..4,
                 0..4
@@ -250,6 +265,7 @@ async fn array_str_impl(
     // Partial chunk requests
     assert_eq!(
         array
+            .clone()
             .async_retrieve_array_subset_elements::<String>(&ArraySubset::new_with_ranges(&[
                 1..3,
                 1..3
@@ -260,10 +276,12 @@ async fn array_str_impl(
 
     // Incompatible chunks / bytes
     assert!(array
+        .clone()
         .async_store_chunks_elements(&ArraySubset::new_with_ranges(&[0..0, 0..2]), &["a", "bb"])
         .await
         .is_err());
     assert!(array
+        .clone()
         .async_store_chunks_elements(&ArraySubset::new_with_ranges(&[0..1, 0..2]), &["a", "bb"])
         .await
         .is_err());
@@ -286,7 +304,7 @@ async fn array_str_async_simple() -> Result<(), Box<dyn std::error::Error>> {
         Arc::new(zarrs::array::codec::GzipCodec::new(5)?),
     ]);
 
-    let array = builder.build(store, array_path).unwrap();
+    let array = builder.build_arc(store, array_path).unwrap();
     array_str_impl(array).await
 }
 
@@ -315,6 +333,6 @@ async fn array_str_async_sharded_transpose() -> Result<(), Box<dyn std::error::E
         .build(),
     ));
 
-    let array = builder.build(store, array_path).unwrap();
+    let array = builder.build_arc(store, array_path).unwrap();
     array_str_impl(array).await
 }


### PR DESCRIPTION
Using `self: Arc<Self>` for async `Array` methods makes external task spawning possible without using a crate like [`async-scoped`](https://crates.io/crates/async-scoped). But needing to `clone()` before every call is less ergonomic.

[Ergonomic ref counting](https://rust-lang.github.io/rust-project-goals/2024h2/ergonomic-rc.html) (unstable) does not really help, but at least `.use` is nicer than `.clone()`.