### PR TITLE
feat: add `[Async]WritableStorageTraits::supports_set_partial`

### DIFF
--- a/zarrs_filesystem/src/lib.rs
+++ b/zarrs_filesystem/src/lib.rs
@@ -363,6 +363,10 @@ impl WritableStorageTraits for FilesystemStore {
             Ok(())
         }
     }
+
+    fn supports_set_partial(&self) -> bool {
+        true
+    }
 }
 
 impl ListableStorageTraits for FilesystemStore {

--- a/zarrs_object_store/src/lib.rs
+++ b/zarrs_object_store/src/lib.rs
@@ -178,6 +178,10 @@ impl<T: object_store::ObjectStore> AsyncWritableStorageTraits for AsyncObjectSto
         )?;
         Ok(())
     }
+
+    fn supports_set_partial(&self) -> bool {
+        false
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]

--- a/zarrs_storage/CHANGELOG.md
+++ b/zarrs_storage/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Rename `[Async]WritableStorageTraits::set_partial_values` to `set_partial_many` and `[async_]store_set_partial_values` to `[async_]store_set_partial_many`
   - Change parameter `key_offset_values: &[StoreKeyOffsetValue]` to `key: &StoreKey` and `offset_values: OffsetBytesIterator`
 - **Breaking**: Rename `[Async]WritableStorageTraits::erase_values` to `erase_many`
+- **Breaking**: Add `[Async]WritableStorageTraits::supports_set_partial`
 - Optimise `MemoryStore`
 
 ### Removed

--- a/zarrs_storage/src/storage_adapter/async_to_sync.rs
+++ b/zarrs_storage/src/storage_adapter/async_to_sync.rs
@@ -123,4 +123,8 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits, TBlockOn: AsyncToSyncBlockOn
     fn erase_prefix(&self, prefix: &StorePrefix) -> Result<(), StorageError> {
         self.block_on(self.storage.erase_prefix(prefix))
     }
+
+    fn supports_set_partial(&self) -> bool {
+        self.storage.supports_set_partial()
+    }
 }

--- a/zarrs_storage/src/storage_adapter/performance_metrics.rs
+++ b/zarrs_storage/src/storage_adapter/performance_metrics.rs
@@ -202,6 +202,10 @@ impl<TStorage: ?Sized + WritableStorageTraits> WritableStorageTraits
     fn erase_prefix(&self, prefix: &StorePrefix) -> Result<(), StorageError> {
         self.storage.erase_prefix(prefix)
     }
+
+    fn supports_set_partial(&self) -> bool {
+        self.storage.supports_set_partial()
+    }
 }
 
 #[cfg(feature = "async")]
@@ -319,6 +323,10 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> AsyncWritableStorageTraits
 
     async fn erase_prefix(&self, prefix: &StorePrefix) -> Result<(), StorageError> {
         self.storage.erase_prefix(prefix).await
+    }
+
+    fn supports_set_partial(&self) -> bool {
+        self.storage.supports_set_partial()
     }
 }
 

--- a/zarrs_storage/src/storage_adapter/usage_log.rs
+++ b/zarrs_storage/src/storage_adapter/usage_log.rs
@@ -278,6 +278,10 @@ impl<TStorage: ?Sized + WritableStorageTraits> WritableStorageTraits
         )?;
         result
     }
+
+    fn supports_set_partial(&self) -> bool {
+        self.storage.supports_set_partial()
+    }
 }
 
 #[cfg(feature = "async")]
@@ -474,6 +478,10 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> AsyncWritableStorageTraits
             (self.prefix_func)()
         )?;
         result
+    }
+
+    fn supports_set_partial(&self) -> bool {
+        self.storage.supports_set_partial()
     }
 }
 

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -222,6 +222,12 @@ pub trait AsyncWritableStorageTraits: MaybeSend + MaybeSync {
     /// # Errors
     /// Returns a [`StorageError`] if there is an underlying storage error.
     async fn erase_prefix(&self, prefix: &StorePrefix) -> Result<(), StorageError>;
+
+    /// Returns whether this store supports partial writes.
+    ///
+    /// If this returns `true`, the store can efficiently handle `set_partial` and `set_partial_many` operations.
+    /// If this returns `false`, partial sets will fall back to a full read and write operation.
+    fn supports_set_partial(&self) -> bool;
 }
 
 /// A supertrait of [`AsyncReadableStorageTraits`] and [`AsyncWritableStorageTraits`].

--- a/zarrs_storage/src/storage_handle.rs
+++ b/zarrs_storage/src/storage_handle.rs
@@ -96,6 +96,10 @@ impl<TStorage: ?Sized + WritableStorageTraits> WritableStorageTraits for Storage
     fn erase_prefix(&self, prefix: &super::StorePrefix) -> Result<(), super::StorageError> {
         self.0.erase_prefix(prefix)
     }
+
+    fn supports_set_partial(&self) -> bool {
+        self.0.supports_set_partial()
+    }
 }
 
 #[cfg(feature = "async")]
@@ -182,6 +186,10 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> AsyncWritableStorageTraits
 
     async fn erase_prefix(&self, prefix: &super::StorePrefix) -> Result<(), super::StorageError> {
         self.0.erase_prefix(prefix).await
+    }
+
+    fn supports_set_partial(&self) -> bool {
+        self.0.supports_set_partial()
     }
 }
 

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -179,6 +179,12 @@ pub trait WritableStorageTraits: MaybeSend + MaybeSync {
     /// # Errors
     /// Returns a [`StorageError`] is the prefix is not in the store, or the erase otherwise fails.
     fn erase_prefix(&self, prefix: &StorePrefix) -> Result<(), StorageError>;
+
+    /// Returns whether this store supports partial writes.
+    ///
+    /// If this returns `true`, the store can efficiently handle `set_partial` and `set_partial_many` operations.
+    /// If this returns `false`, partial sets will fall back to a full read and write operation.
+    fn supports_set_partial(&self) -> bool;
 }
 
 /// A supertrait of [`ReadableStorageTraits`] and [`WritableStorageTraits`].

--- a/zarrs_storage/src/store/memory_store.rs
+++ b/zarrs_storage/src/store/memory_store.rs
@@ -128,6 +128,10 @@ impl WritableStorageTraits for MemoryStore {
         }
         Ok(())
     }
+
+    fn supports_set_partial(&self) -> bool {
+        true
+    }
 }
 
 impl ListableStorageTraits for MemoryStore {


### PR DESCRIPTION
So `zarrs` can choose between partial / full encoding when propagated up to codecs