### PR TITLE
fix: upper bound on `ndarray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Avoid needlessly decoding entire chunks with `ChunkCache::retrieve_array_subset` on first read with a partial decoder cache
+- Upper bound `ndarray` to `<0.17` instead of `<17`
 
 ## [0.22.6] - 2025-10-31
 

--- a/zarrs/Cargo.toml
+++ b/zarrs/Cargo.toml
@@ -63,7 +63,7 @@ inventory.workspace = true
 itertools = "0.14.0"
 lru = "0.16.0"
 moka = { version = "0.12.8", features = ["sync"] }
-ndarray = { version = ">=0.15.4,<17", optional = true }
+ndarray = { version = ">=0.15.4,<0.17", optional = true }
 num.workspace = true
 pco = { version = ">=0.4.0,<0.4.7", optional = true }
 rayon = "1.10.0"


### PR DESCRIPTION
This is necessary to maintain the intended semver promise of the 0.22.x series.

Closes #298