### PR TITLE
refactor!: add `ArrayBytesDecodeIntoTarget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `VariableLengthBytes`
+- Add `ArrayBytesDecodeIntoTarget`
 
 ### Changed
 
@@ -18,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixes handling of Zarr V2 arrays with bool fill values
 - **Breaking**: `ArrayBytes::new_fill_value()` now takes a `data_type` and `num_elements` and is fallible
 - **Breaking**: The `ArrayBytes::Variable` variant now holds `VariableLengthBytes` rather than bytes and offsets
+- **Breaking**: Change various methods to take a `ArrayBytesDecodeIntoTarget` instead of a `ArrayBytesFixedDisjointView`
+  - `[Async]ArrayPartialDecoderTraits::partial_decode_into()`
+  - `ArrayToBytesCodecTraits::decode_into()`
+  - `[Async]Array::retrieve_chunk[_subset]_into()`
 
 ### Removed
 

--- a/zarrs/src/array/array_bytes.rs
+++ b/zarrs/src/array/array_bytes.rs
@@ -781,6 +781,21 @@ pub fn copy_fill_value_into(
     }
 }
 
+/// Helper function to decode `ArrayBytes` into a target, handling mask and data separately.
+///
+/// This function handles the common pattern of decoding `ArrayBytes` into an `ArrayBytesDecodeIntoTarget`.
+#[expect(clippy::needless_pass_by_value)]
+pub(crate) fn decode_into_array_bytes_target(
+    bytes: &ArrayBytes,
+    target: crate::array::codec::ArrayBytesDecodeIntoTarget<'_>,
+) -> Result<(), CodecError> {
+    // Handle data based on whether it's fixed or variable length
+    match &bytes {
+        ArrayBytes::Fixed(data_bytes) => Ok(target.data.copy_from_slice(data_bytes)?),
+        ArrayBytes::Variable(..) => Err(CodecError::ExpectedFixedLengthBytes),
+    }
+}
+
 impl<'a> From<RawBytes<'a>> for ArrayBytes<'a> {
     fn from(bytes: RawBytes<'a>) -> Self {
         Self::new_flen(bytes)


### PR DESCRIPTION
Wrapping `ArrayBytesFixedDisjointView`. This is intended to hold additional data, if required, such as a mask for optional data types.