### PR TITLE
refactor: switch to `&ndarray::ArrayRef` (0.17.1) in `Array::store_*_ndarray` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Rename `RawBytesOffsets` to `ArrayBytesOffsets` and add deprecated alias
 - **Breaking**: `ArrayBytes::into_variable()` now returns `ArrayBytesVariableLength` instead of a bytes and offsets tuple
 - Move the `array::chunk_grid`, `array_subset`, and `indexer` submodules into `zarrs_chunk_grid`, and re-export
+- **Breaking**: Bump `ndarray` to 0.17.1
+- **Breaking**: Switch to `&ndarray::ArrayRef` from `impl Into<ndarray::Array<T, D>>` in `Array::store_*_ndarray` methods
 
 ### Removed
 
 - **Breaking**: Remove `ArraySize`
 - **Breaking**: Remove `{Array,Chunk}Representation::size()`
   - Use `num_elements()` and `element_size()` instead
+- Avoid an unnecessary copy in `Array::store_*_ndarray` when arrays are in standard layout
 
 [#280]: https://github.com/zarrs/zarrs/pull/280
 

--- a/zarrs/Cargo.toml
+++ b/zarrs/Cargo.toml
@@ -63,7 +63,7 @@ inventory.workspace = true
 itertools = "0.14.0"
 lru = "0.16.0"
 moka = { version = "0.12.8", features = ["sync"] }
-ndarray = { version = ">=0.15.4,<0.17", optional = true }
+ndarray = { version = "0.17.1", optional = true }
 num.workspace = true
 pco = { version = ">=0.4.0,<0.4.7", optional = true }
 rayon = "1.10.0"

--- a/zarrs/examples/array_write_read_ndarray.rs
+++ b/zarrs/examples/array_write_read_ndarray.rs
@@ -84,7 +84,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         })?;
         array.store_chunk_ndarray(
             &chunk_indices,
-            ArrayD::<f32>::from_shape_vec(
+            &ArrayD::<f32>::from_shape_vec(
                 chunk_subset.shape_usize(),
                 vec![i as f32 * 0.1; chunk_subset.num_elements() as usize],
             )
@@ -103,7 +103,10 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         [1.0, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1, 1.1,],
         [1.0, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1, 1.1,],
     ];
-    array.store_chunks_ndarray(&ArraySubset::new_with_ranges(&[1..2, 0..2]), ndarray_chunks)?;
+    array.store_chunks_ndarray(
+        &ArraySubset::new_with_ranges(&[1..2, 0..2]),
+        &ndarray_chunks,
+    )?;
     let data_all = array.retrieve_array_subset_ndarray::<f32>(&subset_all)?;
     println!("store_chunks [1..2, 0..2]:\n{data_all:+4.1}\n");
 
@@ -112,7 +115,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         array![[-3.3, -3.4, -3.5,], [-4.3, -4.4, -4.5,], [-5.3, -5.4, -5.5],];
     array.store_array_subset_ndarray(
         ArraySubset::new_with_ranges(&[3..6, 3..6]).start(),
-        ndarray_subset,
+        &ndarray_subset,
     )?;
     let data_all = array.retrieve_array_subset_ndarray::<f32>(&subset_all)?;
     println!("store_array_subset [3..6, 3..6]:\n{data_all:+4.1}\n");
@@ -130,7 +133,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     ];
     array.store_array_subset_ndarray(
         ArraySubset::new_with_ranges(&[0..8, 6..7]).start(),
-        ndarray_subset,
+        &ndarray_subset,
     )?;
     let data_all = array.retrieve_array_subset_ndarray::<f32>(&subset_all)?;
     println!("store_array_subset [0..8, 6..7]:\n{data_all:+4.1}\n");
@@ -142,7 +145,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         &[1, 1],
         // subset within chunk
         ArraySubset::new_with_ranges(&[3..4, 0..4]).start(),
-        ndarray_chunk_subset,
+        &ndarray_chunk_subset,
     )?;
     let data_all = array.retrieve_array_subset_ndarray::<f32>(&subset_all)?;
     println!("store_chunk_subset [3..4, 0..4] of chunk [1, 1]:\n{data_all:+4.1}\n");

--- a/zarrs/examples/array_write_read_string.rs
+++ b/zarrs/examples/array_write_read_string.rs
@@ -75,11 +75,11 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     // Write some chunks
     array.store_chunk_ndarray(
         &[0, 0],
-        ArrayD::<&str>::from_shape_vec(vec![2, 2], vec!["a", "bb", "ccc", "dddd"]).unwrap(),
+        &ArrayD::<&str>::from_shape_vec(vec![2, 2], vec!["a", "bb", "ccc", "dddd"]).unwrap(),
     )?;
     array.store_chunk_ndarray(
         &[0, 1],
-        ArrayD::<&str>::from_shape_vec(vec![2, 2], vec!["4444", "333", "22", "1"]).unwrap(),
+        &ArrayD::<&str>::from_shape_vec(vec![2, 2], vec!["4444", "333", "22", "1"]).unwrap(),
     )?;
     let subset_all = array.subset_all();
     let data_all = array.retrieve_array_subset_ndarray::<String>(&subset_all)?;
@@ -89,7 +89,7 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let ndarray_subset: Array2<&str> = array![["!", "@@"], ["###", "$$$$"]];
     array.store_array_subset_ndarray(
         ArraySubset::new_with_ranges(&[1..3, 1..3]).start(),
-        ndarray_subset,
+        &ndarray_subset,
     )?;
     let data_all = array.retrieve_array_subset_ndarray::<String>(&subset_all)?;
     println!("store_array_subset [1..3, 1..3]:\nndarray::ArrayD<String>\n{data_all}");

--- a/zarrs/examples/data_type_optional.rs
+++ b/zarrs/examples/data_type_optional.rs
@@ -61,7 +61,7 @@ N marks missing (`None`=`null`) values:
     .into_dyn();
 
     // Write the data
-    array.store_array_subset_ndarray(array.subset_all().start(), data.clone())?;
+    array.store_array_subset_ndarray(array.subset_all().start(), &data)?;
 
     // Read back the data
     let data_read = array.retrieve_array_subset_ndarray::<Option<u8>>(&array.subset_all())?;

--- a/zarrs/examples/data_type_optional_nested.rs
+++ b/zarrs/examples/data_type_optional_nested.rs
@@ -53,7 +53,7 @@ N marks missing (`None`=`null`) values. SN marks `Some(None)`=`[null]` values:
     .into_dyn();
 
     // Write the data
-    array.store_array_subset_ndarray(&array.subset_all().start(), data.clone())?; // FIXME: Borrow data
+    array.store_array_subset_ndarray(&array.subset_all().start(), &data)?;
     println!("Data written to array.");
 
     // Read back the data

--- a/zarrs/examples/rectangular_array_write_read.rs
+++ b/zarrs/examples/rectangular_array_write_read.rs
@@ -91,7 +91,7 @@ fn rectangular_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
                     .collect::<Vec<_>>(),
                 i as f32,
             );
-            array.store_chunk_ndarray(&chunk_indices, chunk_array)
+            array.store_chunk_ndarray(&chunk_indices, &chunk_array)
         } else {
             Err(zarrs::array::ArrayError::InvalidChunkGridIndicesError(
                 chunk_indices.to_vec(),
@@ -107,7 +107,7 @@ fn rectangular_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     // Write a subset spanning multiple chunks, including updating chunks already written
     array.store_array_subset_ndarray(
         &[3, 3], // start
-        ndarray::ArrayD::<f32>::from_shape_vec(
+        &ndarray::ArrayD::<f32>::from_shape_vec(
             vec![3, 3],
             vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
         )?,

--- a/zarrs/examples/sharded_array_write_read.rs
+++ b/zarrs/examples/sharded_array_write_read.rs
@@ -105,7 +105,7 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
                         + ij[1] as u64) as u16
                 },
             );
-            array.store_chunk_ndarray(&chunk_indices, chunk_array)
+            array.store_chunk_ndarray(&chunk_indices, &chunk_array)
         } else {
             Err(zarrs::array::ArrayError::InvalidChunkGridIndicesError(
                 chunk_indices.to_vec(),

--- a/zarrs/src/array/array_sync_readable_writable.rs
+++ b/zarrs/src/array/array_sync_readable_writable.rs
@@ -89,7 +89,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         &self,
         chunk_indices: &[u64],
         chunk_subset_start: &[u64],
-        chunk_subset_array: impl Into<ndarray::Array<T, D>>,
+        chunk_subset_array: &ndarray::ArrayRef<T, D>,
     ) -> Result<(), ArrayError> {
         self.store_chunk_subset_ndarray_opt(
             chunk_indices,
@@ -153,7 +153,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
     pub fn store_array_subset_ndarray<T: Element, D: ndarray::Dimension>(
         &self,
         subset_start: &[u64],
-        subset_array: impl Into<ndarray::Array<T, D>>,
+        subset_array: &ndarray::ArrayRef<T, D>,
     ) -> Result<(), ArrayError> {
         self.store_array_subset_ndarray_opt(subset_start, subset_array, &CodecOptions::default())
     }
@@ -283,10 +283,9 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         &self,
         chunk_indices: &[u64],
         chunk_subset_start: &[u64],
-        chunk_subset_array: impl Into<ndarray::Array<T, D>>,
+        chunk_subset_array: &ndarray::ArrayRef<T, D>,
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let chunk_subset_array: ndarray::Array<T, D> = chunk_subset_array.into();
         let subset = ArraySubset::new_with_start_shape(
             chunk_subset_start.to_vec(),
             chunk_subset_array
@@ -295,7 +294,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
                 .map(|u| *u as u64)
                 .collect(),
         )?;
-        let chunk_subset_array = super::ndarray_into_vec(chunk_subset_array);
+        let chunk_subset_array = super::ndarray_to_cow(chunk_subset_array);
         self.store_chunk_subset_elements_opt(chunk_indices, &subset, &chunk_subset_array, options)
     }
 
@@ -403,15 +402,14 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
     pub fn store_array_subset_ndarray_opt<T: Element, D: ndarray::Dimension>(
         &self,
         subset_start: &[u64],
-        subset_array: impl Into<ndarray::Array<T, D>>,
+        subset_array: &ndarray::ArrayRef<T, D>,
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let subset_array: ndarray::Array<T, D> = subset_array.into();
         let subset = ArraySubset::new_with_start_shape(
             subset_start.to_vec(),
             subset_array.shape().iter().map(|u| *u as u64).collect(),
         )?;
-        let subset_array = super::ndarray_into_vec(subset_array);
+        let subset_array = super::ndarray_to_cow(subset_array);
         self.store_array_subset_elements_opt(&subset, &subset_array, options)
     }
 

--- a/zarrs/src/lib.rs
+++ b/zarrs/src/lib.rs
@@ -155,7 +155,7 @@
 //! )?;
 //! array.store_array_subset_ndarray::<f32, _>(
 //!     &[1, 1], // array index (start of subset)
-//!     ndarray::array![[-1.1, -1.2], [-2.1, -2.2]]
+//!     &ndarray::array![[-1.1, -1.2], [-2.1, -2.2]]
 //! )?;
 //! array.erase_chunk(&[1, 1])?;
 //!

--- a/zarrs/tests/optional_codec.rs
+++ b/zarrs/tests/optional_codec.rs
@@ -37,7 +37,7 @@ fn optional_array_basic_operations() -> Result<(), Box<dyn std::error::Error>> {
         [Some(9), Some(10), Some(11), Some(12)],
         [Some(13), Some(14), None, Some(16)],
     ];
-    array.store_chunk_ndarray(&[0, 0], data0.clone())?;
+    array.store_chunk_ndarray(&[0, 0], &data0)?;
 
     // Chunk [0,1]: half None, half Some
     let data1 = array![
@@ -46,7 +46,7 @@ fn optional_array_basic_operations() -> Result<(), Box<dyn std::error::Error>> {
         [Some(1), Some(2), Some(3), Some(4)],
         [Some(5), Some(6), Some(7), Some(8)],
     ];
-    array.store_chunk_ndarray(&[0, 1], data1.clone())?;
+    array.store_chunk_ndarray(&[0, 1], &data1)?;
 
     // Chunk [1,0]: all None
     let data2 = array![
@@ -55,7 +55,7 @@ fn optional_array_basic_operations() -> Result<(), Box<dyn std::error::Error>> {
         [None, None, None, None],
         [None, None, None, None],
     ];
-    array.store_chunk_ndarray(&[1, 0], data2.clone())?;
+    array.store_chunk_ndarray(&[1, 0], &data2)?;
 
     // Chunk [1,1]: alternating Some/None
     let data3 = array![
@@ -64,7 +64,7 @@ fn optional_array_basic_operations() -> Result<(), Box<dyn std::error::Error>> {
         [Some(8), None, Some(10), None],
         [Some(12), None, Some(14), None],
     ];
-    array.store_chunk_ndarray(&[1, 1], data3.clone())?;
+    array.store_chunk_ndarray(&[1, 1], &data3)?;
 
     // Verify all chunks
     let retrieved0 = array.retrieve_chunk_ndarray::<Option<u8>>(&[0, 0])?;
@@ -106,7 +106,7 @@ fn optional_array_basic_operations() -> Result<(), Box<dyn std::error::Error>> {
         [Some(95), None, Some(94), None],
         [None, Some(93), None, Some(92)],
     ];
-    array.store_array_subset_ndarray(&[0, 2], update_data.clone())?;
+    array.store_array_subset_ndarray(&[0, 2], &update_data)?;
 
     // Verify partial update
     let retrieved_update =
@@ -149,7 +149,7 @@ fn optional_array_nested_2_level() -> Result<(), Box<dyn std::error::Error>> {
         [Some(Some(9)), None, Some(Some(11)), Some(None)],
         [Some(Some(13)), Some(Some(14)), None, Some(Some(16))],
     ];
-    array.store_chunk_ndarray(&[0, 0], data.clone())?;
+    array.store_chunk_ndarray(&[0, 0], &data)?;
 
     // Retrieve and verify
     let retrieved = array.retrieve_chunk_ndarray::<Option<Option<u8>>>(&[0, 0])?;
@@ -195,7 +195,7 @@ fn optional_array_nested_3_level() -> Result<(), Box<dyn std::error::Error>> {
             None
         ],
     ];
-    array.store_chunk_ndarray(&[0, 0], data.clone())?;
+    array.store_chunk_ndarray(&[0, 0], &data)?;
 
     // Retrieve and verify
     let retrieved = array.retrieve_chunk_ndarray::<Option<Option<Option<u16>>>>(&[0, 0])?;
@@ -229,7 +229,7 @@ fn optional_array_with_non_null_fill_value() -> Result<(), Box<dyn std::error::E
         [None, Some(10), Some(11), Some(12)],
         [Some(13), Some(14), None, Some(16)],
     ];
-    array.store_chunk_ndarray(&[0, 0], data.clone())?;
+    array.store_chunk_ndarray(&[0, 0], &data)?;
 
     // Retrieve and verify
     let retrieved = array.retrieve_chunk_ndarray::<Option<u8>>(&[0, 0])?;
@@ -279,7 +279,7 @@ fn optional_array_string() -> Result<(), Box<dyn std::error::Error>> {
             Some("encoding".to_string())
         ],
     ];
-    array.store_chunk_ndarray(&[0, 0], data.clone())?;
+    array.store_chunk_ndarray(&[0, 0], &data)?;
 
     // Retrieve and verify
     let retrieved = array.retrieve_chunk_ndarray::<Option<String>>(&[0, 0])?;
@@ -320,7 +320,7 @@ fn optional_array_string() -> Result<(), Box<dyn std::error::Error>> {
         ],
         [None, None, Some("final".to_string()), None],
     ];
-    array.store_chunk_ndarray(&[0, 1], data2.clone())?;
+    array.store_chunk_ndarray(&[0, 1], &data2)?;
 
     let retrieved2 = array.retrieve_chunk_ndarray::<Option<String>>(&[0, 1])?;
     let retrieved2: Array2<Option<String>> = retrieved2.into_dimensionality()?;


### PR DESCRIPTION
Fixes an unnecessary copy in these methods