### PR TITLE
refactor!: make `Element::into_array_bytes` take `Vec<self>` …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Switch to `&ndarray::ArrayRef` from `impl Into<ndarray::Array<T, D>>` in `Array::store_*_ndarray` methods
 - **Breaking**: Add `DataType` parameter to `ShardingCodecBuilder::new()`
   - This is necessary to choose an appropriate default array-to-bytes codec
+- **Breaking**: `Element::into_array_bytes()` now takes an owned `Vec<T>` instead of a slice `&[T]` to avoid unnecessary copies with some element types
+  - Added `Element::to_array_bytes()` matching the old signature
 
 ### Removed
 

--- a/zarrs/benches/codecs.rs
+++ b/zarrs/benches/codecs.rs
@@ -37,7 +37,7 @@ fn codec_bytes(c: &mut Criterion) {
         .unwrap();
 
         let data = vec![0u8; size3.try_into().unwrap()];
-        let bytes = Element::into_array_bytes(&DataType::UInt8, &data).unwrap();
+        let bytes = Element::into_array_bytes(&DataType::UInt8, data).unwrap();
         group.throughput(Throughput::Bytes(size3));
         // encode and decode have the same implementation
         group.bench_function(BenchmarkId::new("encode_decode", size3), |b| {

--- a/zarrs/examples/custom_data_type_fixed_size.rs
+++ b/zarrs/examples/custom_data_type_fixed_size.rs
@@ -105,7 +105,7 @@ impl Element for CustomDataTypeFixedSizeElement {
             .ok_or(ArrayError::IncompatibleElementType)
     }
 
-    fn into_array_bytes<'a>(
+    fn to_array_bytes<'a>(
         data_type: &DataType,
         elements: &'a [Self],
     ) -> Result<zarrs::array::ArrayBytes<'a>, ArrayError> {
@@ -116,6 +116,13 @@ impl Element for CustomDataTypeFixedSizeElement {
             bytes.extend_from_slice(&element.to_ne_bytes());
         }
         Ok(ArrayBytes::Fixed(Cow::Owned(bytes)))
+    }
+
+    fn into_array_bytes(
+        data_type: &DataType,
+        elements: Vec<Self>,
+    ) -> Result<zarrs::array::ArrayBytes<'static>, ArrayError> {
+        Ok(Self::to_array_bytes(data_type, &elements)?.into_owned())
     }
 }
 

--- a/zarrs/examples/custom_data_type_float8_e3m4.rs
+++ b/zarrs/examples/custom_data_type_float8_e3m4.rs
@@ -183,7 +183,7 @@ impl Element for CustomDataTypeFloat8e3m4Element {
             .ok_or(ArrayError::IncompatibleElementType)
     }
 
-    fn into_array_bytes<'a>(
+    fn to_array_bytes<'a>(
         data_type: &DataType,
         elements: &'a [Self],
     ) -> Result<zarrs::array::ArrayBytes<'a>, ArrayError> {
@@ -193,6 +193,13 @@ impl Element for CustomDataTypeFloat8e3m4Element {
             bytes.push(element.0);
         }
         Ok(ArrayBytes::Fixed(Cow::Owned(bytes)))
+    }
+
+    fn into_array_bytes(
+        data_type: &DataType,
+        elements: Vec<Self>,
+    ) -> Result<zarrs::array::ArrayBytes<'static>, ArrayError> {
+        Ok(Self::to_array_bytes(data_type, &elements)?.into_owned())
     }
 }
 

--- a/zarrs/examples/custom_data_type_uint12.rs
+++ b/zarrs/examples/custom_data_type_uint12.rs
@@ -169,7 +169,7 @@ impl Element for CustomDataTypeUInt12Element {
             .ok_or(ArrayError::IncompatibleElementType)
     }
 
-    fn into_array_bytes<'a>(
+    fn to_array_bytes<'a>(
         data_type: &DataType,
         elements: &'a [Self],
     ) -> Result<zarrs::array::ArrayBytes<'a>, ArrayError> {
@@ -180,6 +180,13 @@ impl Element for CustomDataTypeUInt12Element {
             bytes.extend_from_slice(&element.to_le_bytes());
         }
         Ok(ArrayBytes::Fixed(Cow::Owned(bytes)))
+    }
+
+    fn into_array_bytes(
+        data_type: &DataType,
+        elements: Vec<Self>,
+    ) -> Result<zarrs::array::ArrayBytes<'static>, ArrayError> {
+        Ok(Self::to_array_bytes(data_type, &elements)?.into_owned())
     }
 }
 

--- a/zarrs/examples/custom_data_type_uint4.rs
+++ b/zarrs/examples/custom_data_type_uint4.rs
@@ -169,7 +169,7 @@ impl Element for CustomDataTypeUInt4Element {
             .ok_or(ArrayError::IncompatibleElementType)
     }
 
-    fn into_array_bytes<'a>(
+    fn to_array_bytes<'a>(
         data_type: &DataType,
         elements: &'a [Self],
     ) -> Result<zarrs::array::ArrayBytes<'a>, ArrayError> {
@@ -180,6 +180,13 @@ impl Element for CustomDataTypeUInt4Element {
             bytes.push(element.0);
         }
         Ok(ArrayBytes::Fixed(Cow::Owned(bytes)))
+    }
+
+    fn into_array_bytes(
+        data_type: &DataType,
+        elements: Vec<Self>,
+    ) -> Result<zarrs::array::ArrayBytes<'static>, ArrayError> {
+        Ok(Self::to_array_bytes(data_type, &elements)?.into_owned())
     }
 }
 

--- a/zarrs/examples/custom_data_type_variable_size.rs
+++ b/zarrs/examples/custom_data_type_variable_size.rs
@@ -33,7 +33,7 @@ impl Element for CustomDataTypeVariableSizeElement {
             .ok_or(ArrayError::IncompatibleElementType)
     }
 
-    fn into_array_bytes<'a>(
+    fn to_array_bytes<'a>(
         data_type: &DataType,
         elements: &'a [Self],
     ) -> Result<zarrs::array::ArrayBytes<'a>, ArrayError> {
@@ -53,6 +53,13 @@ impl Element for CustomDataTypeVariableSizeElement {
             ArrayBytesOffsets::new_unchecked(offsets)
         };
         unsafe { Ok(ArrayBytes::new_vlen_unchecked(bytes, offsets)) }
+    }
+
+    fn into_array_bytes(
+        data_type: &DataType,
+        elements: Vec<Self>,
+    ) -> Result<zarrs::array::ArrayBytes<'static>, ArrayError> {
+        Ok(Self::to_array_bytes(data_type, &elements)?.into_owned())
     }
 }
 

--- a/zarrs/src/array/array_async_readable_writable.rs
+++ b/zarrs/src/array/array_async_readable_writable.rs
@@ -238,7 +238,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
         chunk_subset_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let chunk_subset_bytes = T::into_array_bytes(self.data_type(), chunk_subset_elements)?;
+        let chunk_subset_bytes = T::to_array_bytes(self.data_type(), chunk_subset_elements)?;
         self.async_store_chunk_subset_opt(chunk_indices, chunk_subset, chunk_subset_bytes, options)
             .await
     }
@@ -374,7 +374,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
         subset_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let subset_bytes = T::into_array_bytes(self.data_type(), subset_elements)?;
+        let subset_bytes = T::to_array_bytes(self.data_type(), subset_elements)?;
         self.async_store_array_subset_opt(array_subset, subset_bytes, options)
             .await
     }

--- a/zarrs/src/array/array_async_writable.rs
+++ b/zarrs/src/array/array_async_writable.rs
@@ -292,7 +292,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
         chunk_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let bytes = T::into_array_bytes(self.data_type(), chunk_elements)?;
+        let bytes = T::to_array_bytes(self.data_type(), chunk_elements)?;
         self.async_store_chunk_opt(chunk_indices, bytes, options)
             .await
     }
@@ -392,7 +392,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> Array<TStorage> {
         chunks_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let chunks_bytes = T::into_array_bytes(self.data_type(), chunks_elements)?;
+        let chunks_bytes = T::to_array_bytes(self.data_type(), chunks_elements)?;
         self.async_store_chunks_opt(chunks, chunks_bytes, options)
             .await
     }

--- a/zarrs/src/array/array_bytes.rs
+++ b/zarrs/src/array/array_bytes.rs
@@ -1055,12 +1055,13 @@ mod tests {
 
     #[test]
     fn array_bytes_flen() -> Result<(), Box<dyn Error>> {
-        let data = [0u32, 1, 2, 3, 4];
-        let bytes = Element::into_array_bytes(&DataType::UInt32, &data)?;
+        let data = vec![0u32, 1, 2, 3, 4];
+        let n_elements = data.len();
+        let bytes = Element::into_array_bytes(&DataType::UInt32, data)?;
         let ArrayBytes::Fixed(bytes) = bytes else {
             panic!()
         };
-        assert_eq!(bytes.len(), size_of::<u32>() * data.len());
+        assert_eq!(bytes.len(), size_of::<u32>() * n_elements);
 
         Ok(())
     }
@@ -1078,11 +1079,9 @@ mod tests {
 
     #[test]
     fn array_bytes_str() -> Result<(), Box<dyn Error>> {
-        let data = ["a", "bb", "ccc"];
-        let bytes = Element::into_array_bytes(&DataType::String, &data)?;
-        let ArrayBytes::Variable(ArrayBytesVariableLength { bytes, offsets }) = bytes else {
-            panic!()
-        };
+        let data = vec!["a", "bb", "ccc"];
+        let bytes = Element::into_array_bytes(&DataType::String, data)?;
+        let (bytes, offsets) = bytes.into_variable().unwrap().into_parts();
         assert_eq!(bytes, "abbccc".as_bytes());
         assert_eq!(*offsets, [0, 1, 3, 6]);
 

--- a/zarrs/src/array/array_sync_readable_writable.rs
+++ b/zarrs/src/array/array_sync_readable_writable.rs
@@ -272,7 +272,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         chunk_subset_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let chunk_subset_bytes = T::into_array_bytes(self.data_type(), chunk_subset_elements)?;
+        let chunk_subset_bytes = T::to_array_bytes(self.data_type(), chunk_subset_elements)?;
         self.store_chunk_subset_opt(chunk_indices, chunk_subset, chunk_subset_bytes, options)
     }
 
@@ -392,7 +392,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
         subset_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let subset_bytes = T::into_array_bytes(self.data_type(), subset_elements)?;
+        let subset_bytes = T::to_array_bytes(self.data_type(), subset_elements)?;
         self.store_array_subset_opt(array_subset, subset_bytes, options)
     }
 

--- a/zarrs/src/array/array_sync_writable.rs
+++ b/zarrs/src/array/array_sync_writable.rs
@@ -320,7 +320,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> Array<TStorage> {
         chunk_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let chunk_bytes = T::into_array_bytes(self.data_type(), chunk_elements)?;
+        let chunk_bytes = T::to_array_bytes(self.data_type(), chunk_elements)?;
         self.store_chunk_opt(chunk_indices, chunk_bytes, options)
     }
 
@@ -407,7 +407,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> Array<TStorage> {
         chunks_elements: &[T],
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        let chunks_bytes = T::into_array_bytes(self.data_type(), chunks_elements)?;
+        let chunks_bytes = T::to_array_bytes(self.data_type(), chunks_elements)?;
         self.store_chunks_opt(chunks, chunks_bytes, options)
     }
 

--- a/zarrs/src/array/codec/array_to_array/transpose.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose.rs
@@ -331,7 +331,7 @@ mod tests {
 
         // Create test data: 6 strings in row-major order
         let strings: Vec<&str> = vec!["s00", "s01a", "s02ab", "s10abc", "s11abcd", "s12abcde"];
-        let bytes = <&str as Element>::into_array_bytes(&DataType::String, &strings).unwrap();
+        let bytes = Element::into_array_bytes(&DataType::String, strings).unwrap();
 
         // Create transpose codec with order [1, 0] (swap axes)
         let codec = TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap());
@@ -362,14 +362,14 @@ mod tests {
         // Create test data: 6 strings in row-major order for shape [2, 3]
         // [[s00, s01, s02], [s10, s11, s12]]
         let strings: Vec<&str> = vec!["s00", "s01a", "s02ab", "s10abc", "s11abcd", "s12abcde"];
-        let original = <&str as Element>::into_array_bytes(&DataType::String, &strings).unwrap();
+        let original = Element::into_array_bytes(&DataType::String, strings).unwrap();
 
         // Encode: apply transpose order [1, 0] to get shape [3, 2]
         // Transposed should be: [[s00, s10], [s01, s11], [s02, s12]]
         let transposed_strings: Vec<&str> =
             vec!["s00", "s10abc", "s01a", "s11abcd", "s02ab", "s12abcde"];
         let expected_transposed =
-            <&str as Element>::into_array_bytes(&DataType::String, &transposed_strings).unwrap();
+            Element::into_array_bytes(&DataType::String, transposed_strings).unwrap();
 
         // Test encoding (forward permutation)
         let encoded = apply_permutation(&original, &[2, 3], &order.0, &DataType::String).unwrap();

--- a/zarrs/src/array/codec/array_to_bytes/packbits.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits.rs
@@ -274,7 +274,7 @@ mod tests {
             let chunk_representation =
                 ChunkRepresentation::new(chunk_shape, data_type.clone(), fill_value).unwrap();
             let elements: Vec<bool> = (0..40).map(|i| i % 3 == 0).collect();
-            let bytes = bool::into_array_bytes(&data_type, &elements)?.into_owned();
+            let bytes = bool::into_array_bytes(&data_type, elements)?.into_owned();
             // T F F T F
             // F T F F T
             // F F T F F
@@ -337,7 +337,7 @@ mod tests {
             let chunk_representation =
                 ChunkRepresentation::new(chunk_shape, data_type.clone(), fill_value).unwrap();
             let elements: Vec<f32> = (0..40).map(|i| i as f32).collect();
-            let bytes = f32::into_array_bytes(&data_type, &elements)?.into_owned();
+            let bytes = f32::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
             let encoded = codec.encode(
@@ -392,7 +392,7 @@ mod tests {
                         ChunkRepresentation::new(chunk_shape, data_type.clone(), fill_value)
                             .unwrap();
                     let elements: Vec<i16> = (-20..20).map(|i| (i as i16) << first_bit).collect();
-                    let bytes = i16::into_array_bytes(&data_type, &elements)?.into_owned();
+                    let bytes = i16::to_array_bytes(&data_type, &elements)?.into_owned();
 
                     // Encoding
                     let encoded = codec.encode(
@@ -434,7 +434,7 @@ mod tests {
             let chunk_representation =
                 ChunkRepresentation::new(chunk_shape, data_type.clone(), fill_value).unwrap();
             let elements: Vec<u8> = (0..4).map(|i| i as u8).collect();
-            let bytes = u8::into_array_bytes(&data_type, &elements)?.into_owned();
+            let bytes = u8::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
             let encoded = codec.encode(
@@ -472,7 +472,7 @@ mod tests {
             let chunk_representation =
                 ChunkRepresentation::new(chunk_shape, data_type.clone(), fill_value).unwrap();
             let elements: Vec<u8> = (0..16).map(|i| i as u8).collect();
-            let bytes = u8::into_array_bytes(&data_type, &elements)?.into_owned();
+            let bytes = u8::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
             let encoded = codec.encode(
@@ -510,7 +510,7 @@ mod tests {
             let chunk_representation =
                 ChunkRepresentation::new(chunk_shape, data_type.clone(), fill_value).unwrap();
             let elements: Vec<i8> = (-2..2).map(|i| i as i8).collect();
-            let bytes = i8::into_array_bytes(&data_type, &elements)?.into_owned();
+            let bytes = i8::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
             let encoded = codec.encode(
@@ -548,7 +548,7 @@ mod tests {
             let chunk_representation =
                 ChunkRepresentation::new(chunk_shape, data_type.clone(), fill_value).unwrap();
             let elements: Vec<i8> = (-8..8).map(|i| i as i8).collect();
-            let bytes = i8::into_array_bytes(&data_type, &elements)?.into_owned();
+            let bytes = i8::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
             let encoded = codec.encode(

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -479,7 +479,7 @@ mod tests {
         let elements: Vec<T> = (0..chunk_representation.num_elements())
             .map(|i: u64| i.as_())
             .collect();
-        let bytes = T::into_array_bytes(chunk_representation.data_type(), &elements).unwrap();
+        let bytes = T::to_array_bytes(chunk_representation.data_type(), &elements).unwrap();
 
         let configuration: ZfpCodecConfiguration = serde_json::from_str(configuration).unwrap();
         let codec = CodecChain::new(

--- a/zarrs/src/array/element/numpy/datetime64.rs
+++ b/zarrs/src/array/element/numpy/datetime64.rs
@@ -6,7 +6,7 @@ use crate::array::{
 
 #[cfg(feature = "chrono")]
 impl Element for chrono::DateTime<chrono::Utc> {
-    fn into_array_bytes<'a>(
+    fn to_array_bytes<'a>(
         data_type: &DataType,
         elements: &'a [Self],
     ) -> Result<ArrayBytes<'a>, ArrayError> {
@@ -35,6 +35,13 @@ impl Element for chrono::DateTime<chrono::Utc> {
             }
         }
         Ok(bytes.into())
+    }
+
+    fn into_array_bytes(
+        data_type: &DataType,
+        elements: Vec<Self>,
+    ) -> Result<ArrayBytes<'static>, ArrayError> {
+        Ok(Self::to_array_bytes(data_type, &elements)?.into_owned())
     }
 
     fn validate_data_type(data_type: &DataType) -> Result<(), ArrayError> {
@@ -92,7 +99,7 @@ impl ElementOwned for chrono::DateTime<chrono::Utc> {
 
 #[cfg(feature = "jiff")]
 impl Element for jiff::Timestamp {
-    fn into_array_bytes<'a>(
+    fn to_array_bytes<'a>(
         data_type: &DataType,
         elements: &'a [Self],
     ) -> Result<ArrayBytes<'a>, ArrayError> {
@@ -119,6 +126,13 @@ impl Element for jiff::Timestamp {
             }
         }
         Ok(bytes.into())
+    }
+
+    fn into_array_bytes(
+        data_type: &DataType,
+        elements: Vec<Self>,
+    ) -> Result<ArrayBytes<'static>, ArrayError> {
+        Ok(Self::to_array_bytes(data_type, &elements)?.into_owned())
     }
 
     fn validate_data_type(data_type: &DataType) -> Result<(), ArrayError> {

--- a/zarrs/src/array/element/numpy/timedelta64.rs
+++ b/zarrs/src/array/element/numpy/timedelta64.rs
@@ -6,7 +6,7 @@ use crate::array::{
 
 #[cfg(feature = "chrono")]
 impl Element for chrono::TimeDelta {
-    fn into_array_bytes<'a>(
+    fn to_array_bytes<'a>(
         data_type: &DataType,
         elements: &'a [Self],
     ) -> Result<ArrayBytes<'a>, ArrayError> {
@@ -30,6 +30,13 @@ impl Element for chrono::TimeDelta {
             }
         }
         Ok(bytes.into())
+    }
+
+    fn into_array_bytes(
+        data_type: &DataType,
+        elements: Vec<Self>,
+    ) -> Result<ArrayBytes<'static>, ArrayError> {
+        Ok(Self::to_array_bytes(data_type, &elements)?.into_owned())
     }
 
     fn validate_data_type(data_type: &DataType) -> Result<(), ArrayError> {
@@ -82,7 +89,7 @@ impl ElementOwned for chrono::TimeDelta {
 
 #[cfg(feature = "jiff")]
 impl Element for jiff::SignedDuration {
-    fn into_array_bytes<'a>(
+    fn to_array_bytes<'a>(
         data_type: &DataType,
         elements: &'a [Self],
     ) -> Result<ArrayBytes<'a>, ArrayError> {
@@ -105,6 +112,13 @@ impl Element for jiff::SignedDuration {
             }
         }
         Ok(bytes.into())
+    }
+
+    fn into_array_bytes(
+        data_type: &DataType,
+        elements: Vec<Self>,
+    ) -> Result<ArrayBytes<'static>, ArrayError> {
+        Ok(Self::to_array_bytes(data_type, &elements)?.into_owned())
     }
 
     fn validate_data_type(data_type: &DataType) -> Result<(), ArrayError> {

--- a/zarrs/tests/indexer.rs
+++ b/zarrs/tests/indexer.rs
@@ -258,7 +258,7 @@ fn indexer_partial_decode_impl<T: ElementOwned>(
     let encoded_chunk = Arc::new(
         codec
             .encode(
-                T::into_array_bytes(&data_type, bytes).unwrap(),
+                T::to_array_bytes(&data_type, bytes).unwrap(),
                 &decoded_representation,
                 &CodecOptions::default(),
             )
@@ -315,7 +315,7 @@ fn indexer_partial_encode_impl<T: ElementOwned>(
     let encoded_chunk = Arc::new(
         codec
             .encode(
-                T::into_array_bytes(&data_type, bytes).unwrap(),
+                T::to_array_bytes(&data_type, bytes).unwrap(),
                 &decoded_representation,
                 &CodecOptions::default(),
             )
@@ -345,7 +345,7 @@ fn indexer_partial_encode_impl<T: ElementOwned>(
     partial_encoder
         .partial_encode(
             indexer,
-            &T::into_array_bytes(&data_type, elements_partial_encode).unwrap(),
+            &T::to_array_bytes(&data_type, elements_partial_encode).unwrap(),
             &CodecOptions::default(),
         )
         .unwrap();


### PR DESCRIPTION
… and add `to_array_bytes` with the old signature