### PR TITLE
chore: prepare zarrs `0.23.0-beta.0` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0-beta.0] - 2025-12-29
+
 ### Highlights
 - Generic array store and retrieve methods
 - Support for the `optional` data type and codec (aliased as `zarrs.optional`)
@@ -2006,6 +2008,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial public release
 
 [unreleased]: https://github.com/zarrs/zarrs/compare/zarrs-v0.22.10...HEAD
+[0.23.0-beta.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs-v0.23.0-beta.0
 [0.22.10]: https://github.com/LDeakin/zarrs/releases/tag/zarrs-v0.22.10
 [0.22.9]: https://github.com/LDeakin/zarrs/releases/tag/zarrs-v0.22.9
 [0.22.8]: https://github.com/LDeakin/zarrs/releases/tag/zarrs-v0.22.8

--- a/zarrs/Cargo.toml
+++ b/zarrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs"
-version = "0.23.0-dev"
+version = "0.23.0-beta.0"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2024"
 rust-version = "1.87"

--- a/zarrs_chunk_grid/CHANGELOG.md
+++ b/zarrs_chunk_grid/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2025-12-26
+
 ### Added
 - Initial release
 - Split from the `zarrs::array::chunk_grid`, `zarrs:array_subset` and `zarrs::indexer` modules of `zarrs` 0.23.0-dev
@@ -20,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Change `Item` associated type of `[Par]ContiguousIndices[Into]Iterator` from `(ArrayIndices, u64)` to `(ArrayIndicesTinyVec, u64)`
 - **Breaking**: Change return type `ChunkGridTraits::{array_shape,grid_shape}()` to `&[u64]` instead of `&ArrayShape`
 - **Breaking**: Change `ChunkGridPlugin::new()` `create_fn` signature from `fn(&(MetadataV3, ArrayShape))` to `fn(&MetadataV3, &ArrayShape)`
-- Bump `zarrs_plugin` to 0.2.3
 
 [unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_chunk_grid-v0.1.0...HEAD
 [0.1.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_chunk_grid-v0.1.0

--- a/zarrs_data_type/CHANGELOG.md
+++ b/zarrs_data_type/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-12-26
+
 ### Added
 - Add `FillValue::into_optional()`
 - Implement `From<Option<T>>` for `FillValue` where `FillValue: From<T>`
@@ -84,7 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - Split from the `zarrs::array::{data_type,fill_value}` modules of `zarrs` 0.20.0-dev
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_data_type-v0.4.2...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_data_type-v0.5.0...HEAD
+[0.5.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_data_type-v0.5.0
 [0.4.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_data_type-v0.4.2
 [0.4.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_data_type-v0.4.1
 [0.4.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_data_type-v0.4.0

--- a/zarrs_filesystem/CHANGELOG.md
+++ b/zarrs_filesystem/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2025-12-26
+
 ### Fixed
 - Improve read performance
 
@@ -84,7 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Split from the `zarrs_storage` crate
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_filesystem-v0.3.5...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_filesystem-v0.3.6...HEAD
+[0.3.6]: https://github.com/zarrs/zarrs/releases/tag/zarrs_filesystem-v0.3.6
 [0.3.5]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_filesystem-v0.3.5
 [0.3.4]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_filesystem-v0.3.4
 [0.3.3]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_filesystem-v0.3.3

--- a/zarrs_metadata/CHANGELOG.md
+++ b/zarrs_metadata/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2025-12-26
+
 ### Added
 - Implement `Eq` for `FillValueMetadataV3`
 
@@ -210,7 +212,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - Split from the `metadata` module of `zarrs` 0.17.0-dev
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_metadata-v0.6.2...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_metadata-v0.7.0...HEAD
+[0.7.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata-v0.7.0
 [0.6.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata-v0.6.2
 [0.6.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata-v0.6.1
 [0.6.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata-v0.6.0

--- a/zarrs_metadata_ext/CHANGELOG.md
+++ b/zarrs_metadata_ext/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-12-26
+
 ### Added
 - Add `optional` data type
 - Add `optional` codec
@@ -63,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rename `InvalidPermutationError` to `TransposeOrderError`
 - change the suffix of experimental codec configurations from V1 to V0 (`gdeflate`, `squeeze`, `vlen`, `vlen_v2`)
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_metadata_ext-v0.2.2...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_metadata_ext-v0.3.0...HEAD
+[0.3.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata_ext-v0.3.0
 [0.2.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata_ext-v0.2.2
 [0.2.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata_ext-v0.2.1
 [0.2.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata_ext-v0.2.0

--- a/zarrs_object_store/CHANGELOG.md
+++ b/zarrs_object_store/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-12-26
+
 ### Changed
 - **Breaking**: Bump `object_store` to 0.13
 
@@ -66,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Initial release
  - Split from the `storage` module of `zarrs` 0.17.0-dev
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_object_store-v0.5.0...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_object_store-v0.6.0...HEAD
+[0.6.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_object_store-v0.6.0
 [0.5.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_object_store-v0.5.0
 [0.4.3]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_object_store-v0.4.3
 [0.4.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_object_store-v0.4.2

--- a/zarrs_plugin/CHANGELOG.md
+++ b/zarrs_plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2025-12-26
+
 ### Added
 - Add `Plugin2` for plugins with two input parameters
 
@@ -51,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Initial release
  - Split from the `plugin` module of `zarrs` 0.20.0-dev
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_plugin-v0.2.2...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_plugin-v0.2.3...HEAD
+[0.2.3]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_plugin-v0.2.3
 [0.2.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_plugin-v0.2.2
 [0.2.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_plugin-v0.2.1
 [0.2.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_plugin-v0.2.0

--- a/zarrs_registry/CHANGELOG.md
+++ b/zarrs_registry/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2025-12-26
+
 ### Changed
 - Add `OPTIONAL` codec and data type identifier
 
@@ -67,7 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release (split from `zarrs_metadata` 0.4.0 during development)
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_registry-v0.1.8...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_registry-v0.1.9...HEAD
+[0.1.9]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_registry-v0.1.9
 [0.1.8]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_registry-v0.1.8
 [0.1.7]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_registry-v0.1.7
 [0.1.6]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_registry-v0.1.6


### PR DESCRIPTION
- `zarrs_chunk_grid`: 0.1.0
- `zarrs_data_type`: 0.5.0
- `zarrs_filesystem`: 0.3.6
- `zarrs_metadata`: 0.7.0
- `zarrs_metadata_ext`: 0.3.0
- `zarrs_plugin`: 0.2.3
- `zarrs_registry`: 0.1.9
- `zarrs_object_store`: 0.6.0