### PR TITLE
feat: Add Consolidated Metadata Reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add a `microfloat` feature for expanded subfloat and complex subfloat data type / element support
   - The `float8` feature is considered deprecated as the associated types are not IEEE 754-compliant
+- Use Zarr V3 consolidated metadata (when present on a root group) to populate child nodes — avoiding `list_dir` and per-array reads — for `Hierarchy::open`, `Node::open`, `Group::children`, `Group::traverse`, `Group::child_arrays`, `Group::child_groups`, `Group::child_paths`, `Group::child_array_paths`, `Group::child_group_paths`, and their async variants
+  - Add `UseConsolidatedMetadata` (`Auto` / `Must` / `Never`) and a new `Config::use_consolidated_metadata` global setting (default `Auto`)
+  - Add `NodeCreateError::MissingConsolidatedMetadata`, returned when `Must` is set but the field is absent
 
 ## [0.23.10](https://github.com/zarrs/zarrs/releases/tag/zarrs-v0.23.10) - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The `float8` feature is considered deprecated as the associated types are not IEEE 754-compliant
 - Use Zarr V3 consolidated metadata (when present on a root group) to populate child nodes — avoiding `list_dir` and per-array reads — for `Hierarchy::open`, `Node::open`, `Group::children`, `Group::traverse`, `Group::child_arrays`, `Group::child_groups`, `Group::child_paths`, `Group::child_array_paths`, `Group::child_group_paths`, and their async variants
   - Add `UseConsolidatedMetadata` (`Auto` / `Must` / `Never`) and a new `Config::use_consolidated_metadata` global setting (default `Auto`)
-  - Add `NodeCreateError::MissingConsolidatedMetadata`, returned when `Must` is set but the field is absent
+  - When `Must` is set but consolidated metadata is absent, return `NodeCreateError::MissingMetadata` with a descriptive message (a more specific variant may be added in a future breaking release)
 
 ### Changed
 - Bump `zarrs_metadata_ext` to 0.4.3

--- a/zarrs/src/config.rs
+++ b/zarrs/src/config.rs
@@ -108,6 +108,16 @@ use zarrs_codec::{CodecMetadataOptions, CodecOptions};
 ///
 /// If true, then aliased extension names will be replaced by the standard name if metadata is resaved.
 /// This sets the default for the association option of [`crate::array::ArrayMetadataOptions`].
+///
+/// ### Use Consolidated Metadata
+/// > default: [`UseConsolidatedMetadata::Auto`]
+///
+/// Controls whether [`crate::node::Node::open`], [`crate::hierarchy::Hierarchy::open`], and their async/`_opt` variants
+/// use the `consolidated_metadata` field of a Zarr V3 root group instead of listing children from storage.
+/// See [`UseConsolidatedMetadata`] for the available modes.
+///
+/// Consolidated metadata is a snapshot. If the hierarchy has been modified after the snapshot was written,
+/// the consolidated copy may be out of date. Set this to [`UseConsolidatedMetadata::Never`] to force re-discovery.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Config {
@@ -121,6 +131,7 @@ pub struct Config {
     include_zarrs_metadata: bool,
     experimental_partial_encoding: bool,
     convert_aliased_extension_names: bool,
+    use_consolidated_metadata: UseConsolidatedMetadata,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -137,6 +148,7 @@ impl Default for Config {
             include_zarrs_metadata: true,
             experimental_partial_encoding: false,
             convert_aliased_extension_names: false,
+            use_consolidated_metadata: UseConsolidatedMetadata::default(),
         }
     }
 }
@@ -301,6 +313,21 @@ impl Config {
         self.convert_aliased_extension_names = convert_aliased_extension_names;
         self
     }
+
+    /// Get the [use consolidated metadata](#use-consolidated-metadata) configuration.
+    #[must_use]
+    pub fn use_consolidated_metadata(&self) -> UseConsolidatedMetadata {
+        self.use_consolidated_metadata
+    }
+
+    /// Set the [use consolidated metadata](#use-consolidated-metadata) configuration.
+    pub fn set_use_consolidated_metadata(
+        &mut self,
+        use_consolidated_metadata: UseConsolidatedMetadata,
+    ) -> &mut Self {
+        self.use_consolidated_metadata = use_consolidated_metadata;
+        self
+    }
 }
 
 static CONFIG: LazyLock<RwLock<Config>> = LazyLock::new(|| RwLock::new(Config::default()));
@@ -341,6 +368,23 @@ pub enum MetadataConvertVersion {
     Default,
     /// Write Zarr V3 metadata. Zarr V2 metadata will not be automatically removed if it exists.
     V3,
+}
+
+/// Controls whether `consolidated_metadata` (if present in a Zarr V3 root group) is used to populate
+/// child nodes when opening a [`Node`](crate::node::Node) or [`Hierarchy`](crate::hierarchy::Hierarchy).
+///
+/// Consolidated metadata is a snapshot of the hierarchy embedded in the root group. Using it
+/// avoids `list_dir` calls and per-node metadata reads, but it may be stale if the hierarchy was
+/// modified after the snapshot was written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum UseConsolidatedMetadata {
+    /// Use consolidated metadata if it is present on the root group; otherwise fall back to listing storage.
+    #[default]
+    Auto,
+    /// Require consolidated metadata to be present on the root group. If absent, opening fails.
+    Must,
+    /// Never use consolidated metadata, even if it is present. Always re-discover children from storage.
+    Never,
 }
 
 /// Version options for [`Array::erase_metadata`](crate::array::Array::erase_metadata) and [`Group::erase_metadata`](crate::group::Group::erase_metadata), and their async variants.

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -345,7 +345,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
         if let Some(consolidated) =
             resolve_consolidated_policy(&self.path, self.consolidated_metadata(), policy)?
         {
-            let flat = expand_consolidated_metadata(&self.path, &consolidated)?;
+            let flat = expand_consolidated_metadata(&self.path, consolidated)?;
             return Ok(if recursive {
                 build_node_tree(&self.path, flat)
             } else {
@@ -369,7 +369,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
         if let Some(consolidated) =
             resolve_consolidated_policy(&self.path, self.consolidated_metadata(), policy)?
         {
-            return expand_consolidated_metadata(&self.path, &consolidated);
+            return expand_consolidated_metadata(&self.path, consolidated);
         }
         get_all_nodes_of(&self.storage, &self.path, &MetadataRetrieveVersion::Default)
     }
@@ -538,7 +538,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits>
         if let Some(consolidated) =
             resolve_consolidated_policy(&self.path, self.consolidated_metadata(), policy)?
         {
-            let flat = expand_consolidated_metadata(&self.path, &consolidated)?;
+            let flat = expand_consolidated_metadata(&self.path, consolidated)?;
             return Ok(if recursive {
                 build_node_tree(&self.path, flat)
             } else {
@@ -562,7 +562,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits>
         if let Some(consolidated) =
             resolve_consolidated_policy(&self.path, self.consolidated_metadata(), policy)?
         {
-            return expand_consolidated_metadata(&self.path, &consolidated);
+            return expand_consolidated_metadata(&self.path, consolidated);
         }
         async_get_all_nodes_of(&self.storage, &self.path, &MetadataRetrieveVersion::Default).await
     }

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -39,8 +39,9 @@ use crate::config::{
 };
 use crate::convert::group_metadata_v2_to_v3;
 use crate::node::{
-    Node, NodeCreateError, NodePath, NodePathError, get_all_nodes_of, get_child_nodes,
-    meta_key_v2_attributes, meta_key_v2_group, meta_key_v3,
+    Node, NodeCreateError, NodePath, NodePathError, build_node_tree, direct_children_from_flat,
+    expand_consolidated_metadata, get_all_nodes_of, get_child_nodes, meta_key_v2_attributes,
+    meta_key_v2_group, meta_key_v3, resolve_consolidated_policy,
 };
 #[cfg(feature = "async")]
 use crate::{
@@ -332,17 +333,44 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
     /// The `recursive` argument determines whether the returned `Node`s will have their
     /// children (and their children, etc.) populated.
     ///
+    /// If the group's V3 metadata contains a `consolidated_metadata` block and the
+    /// global [`UseConsolidatedMetadata`](crate::config::UseConsolidatedMetadata)
+    /// policy permits, children are populated from the inline map without any
+    /// per-node storage reads.
+    ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is a metadata related error, or an underlying store error.
     pub fn children(&self, recursive: bool) -> Result<Vec<Node>, NodeCreateError> {
+        let policy = global_config().use_consolidated_metadata();
+        if let Some(consolidated) =
+            resolve_consolidated_policy(&self.path, self.consolidated_metadata(), policy)?
+        {
+            let flat = expand_consolidated_metadata(&self.path, &consolidated)?;
+            return Ok(if recursive {
+                build_node_tree(&self.path, flat)
+            } else {
+                direct_children_from_flat(&self.path, flat)
+            });
+        }
         get_child_nodes(&self.storage, &self.path, recursive)
     }
 
     /// Return all the Nodes under the group, recursively
     ///
+    /// If the group's V3 metadata contains a `consolidated_metadata` block and the
+    /// global [`UseConsolidatedMetadata`](crate::config::UseConsolidatedMetadata)
+    /// policy permits, the result is populated from the inline map without any
+    /// per-node storage reads.
+    ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is a metadata related error, or an underlying store error.
     pub fn traverse(&self) -> Result<Vec<(NodePath, NodeMetadata)>, NodeCreateError> {
+        let policy = global_config().use_consolidated_metadata();
+        if let Some(consolidated) =
+            resolve_consolidated_policy(&self.path, self.consolidated_metadata(), policy)?
+        {
+            return expand_consolidated_metadata(&self.path, &consolidated);
+        }
         get_all_nodes_of(&self.storage, &self.path, &MetadataRetrieveVersion::Default)
     }
 
@@ -498,17 +526,44 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits>
     /// The `recursive` argument determines whether the returned `Node`s will have their
     /// children (and their children, etc.) populated.
     ///
+    /// If the group's V3 metadata contains a `consolidated_metadata` block and the
+    /// global [`UseConsolidatedMetadata`](crate::config::UseConsolidatedMetadata)
+    /// policy permits, children are populated from the inline map without any
+    /// per-node storage reads.
+    ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is a metadata related error, or an underlying store error.
     pub async fn async_children(&self, recursive: bool) -> Result<Vec<Node>, NodeCreateError> {
+        let policy = global_config().use_consolidated_metadata();
+        if let Some(consolidated) =
+            resolve_consolidated_policy(&self.path, self.consolidated_metadata(), policy)?
+        {
+            let flat = expand_consolidated_metadata(&self.path, &consolidated)?;
+            return Ok(if recursive {
+                build_node_tree(&self.path, flat)
+            } else {
+                direct_children_from_flat(&self.path, flat)
+            });
+        }
         async_get_child_nodes(&self.storage, &self.path, recursive).await
     }
 
     /// Return all the Nodes under the group, recursively
     ///
+    /// If the group's V3 metadata contains a `consolidated_metadata` block and the
+    /// global [`UseConsolidatedMetadata`](crate::config::UseConsolidatedMetadata)
+    /// policy permits, the result is populated from the inline map without any
+    /// per-node storage reads.
+    ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is a metadata related error, or an underlying store error.
     pub async fn async_traverse(&self) -> Result<Vec<(NodePath, NodeMetadata)>, NodeCreateError> {
+        let policy = global_config().use_consolidated_metadata();
+        if let Some(consolidated) =
+            resolve_consolidated_policy(&self.path, self.consolidated_metadata(), policy)?
+        {
+            return expand_consolidated_metadata(&self.path, &consolidated);
+        }
         async_get_all_nodes_of(&self.storage, &self.path, &MetadataRetrieveVersion::Default).await
     }
 

--- a/zarrs/src/hierarchy.rs
+++ b/zarrs/src/hierarchy.rs
@@ -12,9 +12,9 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::array::{Array, ArrayMetadata};
-use crate::config::MetadataRetrieveVersion;
+use crate::config::{MetadataRetrieveVersion, global_config};
 use crate::group::Group;
-use crate::node::get_all_nodes_of;
+use crate::node::{consolidated_metadata_for_open, expand_consolidated_metadata, get_all_nodes_of};
 pub use crate::node::{Node, NodeCreateError, NodePath, NodePathError};
 #[cfg(feature = "async")]
 use crate::{
@@ -67,10 +67,17 @@ impl Hierarchy {
         let node_metadata = Node::get_metadata(storage, &node_path, version)?;
         let mut hierarchy = Hierarchy::new();
 
-        let nodes = match node_metadata {
+        let nodes = match &node_metadata {
             NodeMetadata::Array(_) => Vec::default(),
-            // TODO: Add consolidated metadata support
-            NodeMetadata::Group(_) => get_all_nodes_of(storage, &node_path, version)?,
+            NodeMetadata::Group(_) => {
+                let policy = global_config().use_consolidated_metadata();
+                match consolidated_metadata_for_open(&node_path, &node_metadata, policy)? {
+                    Some(consolidated) => {
+                        expand_consolidated_metadata(&node_path, &consolidated)?
+                    }
+                    None => get_all_nodes_of(storage, &node_path, version)?,
+                }
+            }
         };
 
         hierarchy.0.insert(node_path, node_metadata);
@@ -109,10 +116,17 @@ impl Hierarchy {
         let node_metadata = Node::async_get_metadata(storage, &node_path, version).await?;
         let mut hierarchy = Hierarchy::new();
 
-        let nodes = match node_metadata {
+        let nodes = match &node_metadata {
             NodeMetadata::Array(_) => Vec::default(),
-            // TODO: Add consolidated metadata support
-            NodeMetadata::Group(_) => async_get_all_nodes_of(storage, &node_path, version).await?,
+            NodeMetadata::Group(_) => {
+                let policy = global_config().use_consolidated_metadata();
+                match consolidated_metadata_for_open(&node_path, &node_metadata, policy)? {
+                    Some(consolidated) => {
+                        expand_consolidated_metadata(&node_path, &consolidated)?
+                    }
+                    None => async_get_all_nodes_of(storage, &node_path, version).await?,
+                }
+            }
         };
 
         hierarchy.0.insert(node_path, node_metadata);

--- a/zarrs/src/hierarchy.rs
+++ b/zarrs/src/hierarchy.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 use crate::array::{Array, ArrayMetadata};
 use crate::config::{MetadataRetrieveVersion, global_config};
 use crate::group::Group;
-use crate::node::{consolidated_metadata_for_open, expand_consolidated_metadata, get_all_nodes_of};
 pub use crate::node::{Node, NodeCreateError, NodePath, NodePathError};
+use crate::node::{consolidated_metadata_for_open, expand_consolidated_metadata, get_all_nodes_of};
 #[cfg(feature = "async")]
 use crate::{
     node::async_get_all_nodes_of,
@@ -72,9 +72,7 @@ impl Hierarchy {
             NodeMetadata::Group(_) => {
                 let policy = global_config().use_consolidated_metadata();
                 match consolidated_metadata_for_open(&node_path, &node_metadata, policy)? {
-                    Some(consolidated) => {
-                        expand_consolidated_metadata(&node_path, &consolidated)?
-                    }
+                    Some(consolidated) => expand_consolidated_metadata(&node_path, &consolidated)?,
                     None => get_all_nodes_of(storage, &node_path, version)?,
                 }
             }
@@ -121,9 +119,7 @@ impl Hierarchy {
             NodeMetadata::Group(_) => {
                 let policy = global_config().use_consolidated_metadata();
                 match consolidated_metadata_for_open(&node_path, &node_metadata, policy)? {
-                    Some(consolidated) => {
-                        expand_consolidated_metadata(&node_path, &consolidated)?
-                    }
+                    Some(consolidated) => expand_consolidated_metadata(&node_path, &consolidated)?,
                     None => async_get_all_nodes_of(storage, &node_path, version).await?,
                 }
             }

--- a/zarrs/src/hierarchy.rs
+++ b/zarrs/src/hierarchy.rs
@@ -72,7 +72,7 @@ impl Hierarchy {
             NodeMetadata::Group(_) => {
                 let policy = global_config().use_consolidated_metadata();
                 match consolidated_metadata_for_open(&node_path, &node_metadata, policy)? {
-                    Some(consolidated) => expand_consolidated_metadata(&node_path, &consolidated)?,
+                    Some(consolidated) => expand_consolidated_metadata(&node_path, consolidated)?,
                     None => get_all_nodes_of(storage, &node_path, version)?,
                 }
             }
@@ -119,7 +119,7 @@ impl Hierarchy {
             NodeMetadata::Group(_) => {
                 let policy = global_config().use_consolidated_metadata();
                 match consolidated_metadata_for_open(&node_path, &node_metadata, policy)? {
-                    Some(consolidated) => expand_consolidated_metadata(&node_path, &consolidated)?,
+                    Some(consolidated) => expand_consolidated_metadata(&node_path, consolidated)?,
                     None => async_get_all_nodes_of(storage, &node_path, version).await?,
                 }
             }

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -773,4 +773,192 @@ mod tests {
         );
         assert!(node.is_root());
     }
+
+    #[test]
+    fn parent_path_str_branches() {
+        // root has no parent
+        assert_eq!(super::parent_path_str("/"), "");
+        // direct child of root
+        assert_eq!(super::parent_path_str("/foo"), "/");
+        // nested
+        assert_eq!(super::parent_path_str("/foo/bar"), "/foo");
+        assert_eq!(super::parent_path_str("/foo/bar/baz"), "/foo/bar");
+        // pathological: no slash at all (should not happen for real NodePath, but fn must handle it)
+        assert_eq!(super::parent_path_str("foo"), "");
+    }
+
+    fn array_md(shape: u64) -> NodeMetadata {
+        NodeMetadata::Array(
+            serde_json::from_str::<zarrs_metadata::v3::ArrayMetadataV3>(&format!(
+                r#"{{
+                    "zarr_format": 3,
+                    "node_type": "array",
+                    "shape": [{shape}],
+                    "data_type": "float32",
+                    "chunk_grid": {{"name": "regular", "configuration": {{"chunk_shape": [{shape}]}}}},
+                    "chunk_key_encoding": {{"name": "default", "configuration": {{"separator": "/"}}}},
+                    "fill_value": 0,
+                    "codecs": [{{"name": "bytes", "configuration": {{"endian": "little"}}}}]
+                }}"#
+            ))
+            .unwrap()
+            .into(),
+        )
+    }
+
+    fn group_md() -> NodeMetadata {
+        NodeMetadata::Group(GroupMetadataV3::default().into())
+    }
+
+    #[test]
+    fn expand_consolidated_metadata_root_and_nested_bases() {
+        // Base is root: rel "foo" → "/foo"
+        let mut c = ConsolidatedMetadata::default();
+        c.metadata.insert("foo".to_string(), array_md(1));
+        c.metadata.insert("/bar".to_string(), array_md(2));
+        c.metadata.insert(String::new(), group_md()); // base group entry — must be skipped
+        c.metadata.insert("/".to_string(), group_md()); // also base entry after stripping leading slash
+        let out = super::expand_consolidated_metadata(&NodePath::root(), &c).unwrap();
+        let paths: Vec<_> = out.iter().map(|(p, _)| p.as_str().to_string()).collect();
+        assert!(paths.contains(&"/foo".to_string()));
+        assert!(paths.contains(&"/bar".to_string()));
+        assert!(!paths.iter().any(|p| p == "/"), "base group must be skipped");
+
+        // Base is non-root: rel "foo" → "/group/foo"
+        let base = NodePath::new("/group").unwrap();
+        let mut c = ConsolidatedMetadata::default();
+        c.metadata.insert("foo".to_string(), array_md(3));
+        c.metadata.insert("sub/leaf".to_string(), array_md(4));
+        let out = super::expand_consolidated_metadata(&base, &c).unwrap();
+        let mut paths: Vec<_> = out.iter().map(|(p, _)| p.as_str().to_string()).collect();
+        paths.sort();
+        assert_eq!(paths, vec!["/group/foo", "/group/sub/leaf"]);
+    }
+
+    #[test]
+    fn build_node_tree_and_direct_children() {
+        // Hierarchy: /a (group), /a/x (array), /a/y (group, no children)
+        let entries = vec![
+            (NodePath::new("/a").unwrap(), group_md()),
+            (NodePath::new("/a/x").unwrap(), array_md(1)),
+            (NodePath::new("/a/y").unwrap(), group_md()),
+        ];
+
+        // From root: only /a is direct.
+        let direct = super::direct_children_from_flat(&NodePath::root(), entries.clone());
+        let names: Vec<_> = direct.iter().map(|n| n.path().as_str().to_string()).collect();
+        assert_eq!(names, vec!["/a"]);
+        assert!(direct[0].children().is_empty(), "direct must not populate descendants");
+
+        // Tree from root.
+        let tree = super::build_node_tree(&NodePath::root(), entries.clone());
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].path().as_str(), "/a");
+        let mut child_names: Vec<_> = tree[0]
+            .children()
+            .iter()
+            .map(|n| n.path().as_str().to_string())
+            .collect();
+        child_names.sort();
+        assert_eq!(child_names, vec!["/a/x", "/a/y"]);
+        // /a/y is an empty group — collect_children_from_map's "no entries" branch.
+        let y = tree[0]
+            .children()
+            .iter()
+            .find(|n| n.path().as_str() == "/a/y")
+            .unwrap();
+        assert!(y.children().is_empty());
+    }
+
+    #[test]
+    fn consolidated_metadata_for_open_v2_and_array_return_none() {
+        use crate::config::UseConsolidatedMetadata;
+
+        // V2 group metadata → never has consolidated metadata.
+        let v2_group = NodeMetadata::Group(zarrs_metadata::v2::GroupMetadataV2::new().into());
+        let result = super::consolidated_metadata_for_open(
+            &NodePath::root(),
+            &v2_group,
+            UseConsolidatedMetadata::Auto,
+        )
+        .unwrap();
+        assert!(result.is_none());
+
+        // Array metadata → never has consolidated metadata.
+        let arr = array_md(1);
+        let result = super::consolidated_metadata_for_open(
+            &NodePath::root(),
+            &arr,
+            UseConsolidatedMetadata::Auto,
+        )
+        .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_consolidated_policy_branches() {
+        use crate::config::UseConsolidatedMetadata;
+        let path = NodePath::root();
+        let some_md = ConsolidatedMetadata::default();
+
+        // Never always returns None even when present.
+        assert!(super::resolve_consolidated_policy(
+            &path,
+            Some(some_md.clone()),
+            UseConsolidatedMetadata::Never,
+        )
+        .unwrap()
+        .is_none());
+
+        // Auto with present returns Some.
+        assert!(super::resolve_consolidated_policy(
+            &path,
+            Some(some_md.clone()),
+            UseConsolidatedMetadata::Auto,
+        )
+        .unwrap()
+        .is_some());
+
+        // Auto with absent returns None.
+        assert!(super::resolve_consolidated_policy(
+            &path,
+            None,
+            UseConsolidatedMetadata::Auto,
+        )
+        .unwrap()
+        .is_none());
+
+        // Must with absent errors.
+        let err = super::resolve_consolidated_policy(
+            &path,
+            None,
+            UseConsolidatedMetadata::Must,
+        )
+        .unwrap_err();
+        assert!(matches!(err, NodeCreateError::MissingConsolidatedMetadata(_)));
+    }
+
+    #[test]
+    fn missing_consolidated_metadata_error_conversions() {
+        // Cover the From<NodeCreateError> for ArrayCreateError / GroupCreateError arms.
+        let err = NodeCreateError::MissingConsolidatedMetadata("/x".to_string());
+        let s = err.to_string();
+        assert!(s.contains("Consolidated metadata required but missing"));
+
+        let err = NodeCreateError::MissingConsolidatedMetadata("/x".to_string());
+        let arr_err: ArrayCreateError = err.into();
+        assert!(
+            arr_err
+                .to_string()
+                .contains("Consolidated metadata required but missing")
+        );
+
+        let err = NodeCreateError::MissingConsolidatedMetadata("/x".to_string());
+        let group_err: GroupCreateError = err.into();
+        assert!(
+            group_err
+                .to_string()
+                .contains("Consolidated metadata required but missing")
+        );
+    }
 }

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -224,9 +224,9 @@ pub(crate) fn resolve_consolidated_policy(
     }
     match (consolidated, policy) {
         (Some(c), _) => Ok(Some(c)),
-        (None, UseConsolidatedMetadata::Must) => {
-            Err(NodeCreateError::MissingConsolidatedMetadata(path.to_string()))
-        }
+        (None, UseConsolidatedMetadata::Must) => Err(NodeCreateError::MissingConsolidatedMetadata(
+            path.to_string(),
+        )),
         (None, _) => Ok(None),
     }
 }
@@ -242,7 +242,9 @@ pub(crate) fn consolidated_metadata_for_open(
         NodeMetadata::Group(GroupMetadata::V3(group_metadata)) => group_metadata
             .additional_fields
             .get("consolidated_metadata")
-            .and_then(|f| serde_json::from_value::<ConsolidatedMetadata>(f.as_value().clone()).ok()),
+            .and_then(|f| {
+                serde_json::from_value::<ConsolidatedMetadata>(f.as_value().clone()).ok()
+            }),
         NodeMetadata::Group(GroupMetadata::V2(_)) | NodeMetadata::Array(_) => None,
     };
     resolve_consolidated_policy(path, consolidated, policy)
@@ -577,7 +579,7 @@ impl Node {
 
     /// Consolidate metadata. Returns [`None`] for an array.
     ///
-    /// [`ConsolidatedMetadataMetadata`] can be converted into [`ConsolidatedMetadata`](zarrs_metadata_ext::group::consolidated_metadata::ConsolidatedMetadata) in [`GroupMetadataV3`](crate::metadata::v3::GroupMetadataV3).
+    /// [`ConsolidatedMetadataMetadata`] can be converted into [`ConsolidatedMetadata`] in [`GroupMetadataV3`](crate::metadata::v3::GroupMetadataV3).
     #[must_use]
     #[allow(clippy::items_after_statements)]
     pub fn consolidate_metadata(&self) -> Option<ConsolidatedMetadataMetadata> {

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -23,7 +23,7 @@ pub use key::{
 
 #[cfg(feature = "async")]
 mod node_async;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 #[cfg(feature = "async")]
@@ -135,50 +135,33 @@ impl From<NodeCreateError> for GroupCreateError {
 /// `/` is tolerated for compatibility with implementations that include it.
 pub(crate) fn expand_consolidated_metadata(
     base_path: &NodePath,
-    consolidated: &ConsolidatedMetadata,
+    consolidated: ConsolidatedMetadata,
 ) -> Result<Vec<(NodePath, NodeMetadata)>, NodeCreateError> {
-    let base = base_path.as_str();
-    let base_no_trailing = if base == "/" { "" } else { base };
     let mut out = Vec::with_capacity(consolidated.metadata.len());
-    for (rel, md) in &consolidated.metadata {
-        let rel = rel.strip_prefix('/').unwrap_or(rel);
-        if rel.is_empty() {
+    for (rel, md) in consolidated.metadata {
+        let path = base_path.join(&rel)?;
+        if path == *base_path {
             // The base group is conventionally not included in its own consolidated map; skip it if it is.
             continue;
         }
-        let full = format!("{base_no_trailing}/{rel}");
-        let path = NodePath::new(&full)?;
-        out.push((path, md.clone()));
+        out.push((path, md));
     }
     Ok(out)
 }
 
-/// Return the parent of a node-path string, or the empty string if no parent exists.
-fn parent_path_str(p: &str) -> &str {
-    if p == "/" {
-        return "";
-    }
-    match p.rfind('/') {
-        Some(0) => "/",
-        Some(idx) => &p[..idx],
-        None => "",
-    }
-}
-
 /// Recursively collect the children of `parent` from the parent-keyed map.
 fn collect_children_from_map(
-    parent: &str,
-    by_parent: &mut HashMap<String, Vec<(NodePath, NodeMetadata)>>,
+    parent: &NodePath,
+    by_parent: &mut BTreeMap<NodePath, BTreeMap<NodePath, NodeMetadata>>,
 ) -> Vec<Node> {
-    let Some(mut entries) = by_parent.remove(parent) else {
+    let Some(entries) = by_parent.remove(parent) else {
         return Vec::new();
     };
-    entries.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
     entries
         .into_iter()
         .map(|(path, md)| {
             let children = match &md {
-                NodeMetadata::Group(_) => collect_children_from_map(path.as_str(), by_parent),
+                NodeMetadata::Group(_) => collect_children_from_map(&path, by_parent),
                 NodeMetadata::Array(_) => Vec::new(),
             };
             Node::new_with_metadata(path, md, children)
@@ -192,12 +175,13 @@ pub(crate) fn build_node_tree(
     base_path: &NodePath,
     flat: Vec<(NodePath, NodeMetadata)>,
 ) -> Vec<Node> {
-    let mut by_parent: HashMap<String, Vec<(NodePath, NodeMetadata)>> = HashMap::new();
+    let mut by_parent: BTreeMap<NodePath, BTreeMap<NodePath, NodeMetadata>> = BTreeMap::new();
     for (path, md) in flat {
-        let parent = parent_path_str(path.as_str()).to_string();
-        by_parent.entry(parent).or_default().push((path, md));
+        if let Some(parent) = path.parent() {
+            by_parent.entry(parent).or_default().insert(path, md);
+        }
     }
-    collect_children_from_map(base_path.as_str(), &mut by_parent)
+    collect_children_from_map(base_path, &mut by_parent)
 }
 
 /// Apply the [`UseConsolidatedMetadata`] policy to an already-extracted optional
@@ -251,13 +235,12 @@ pub(crate) fn direct_children_from_flat(
     base_path: &NodePath,
     flat: Vec<(NodePath, NodeMetadata)>,
 ) -> Vec<Node> {
-    let base = base_path.as_str();
     let mut out: Vec<Node> = flat
         .into_iter()
-        .filter(|(p, _)| parent_path_str(p.as_str()) == base)
+        .filter(|(p, _)| p.parent().as_ref() == Some(base_path))
         .map(|(p, m)| Node::new_with_metadata(p, m, vec![]))
         .collect();
-    out.sort_by(|a, b| a.path().as_str().cmp(b.path().as_str()));
+    out.sort_by(|a, b| a.path().cmp(b.path()));
     out
 }
 
@@ -409,7 +392,7 @@ impl Node {
                 let policy = crate::config::global_config().use_consolidated_metadata();
                 match consolidated_metadata_for_open(&path, &metadata, policy)? {
                     Some(consolidated) => {
-                        let flat = expand_consolidated_metadata(&path, &consolidated)?;
+                        let flat = expand_consolidated_metadata(&path, consolidated)?;
                         build_node_tree(&path, flat)
                     }
                     None => get_child_nodes_opt(storage, &path, true, version)?,
@@ -458,7 +441,7 @@ impl Node {
                 let policy = crate::config::global_config().use_consolidated_metadata();
                 match consolidated_metadata_for_open(&path, &metadata, policy)? {
                     Some(consolidated) => {
-                        let flat = expand_consolidated_metadata(&path, &consolidated)?;
+                        let flat = expand_consolidated_metadata(&path, consolidated)?;
                         build_node_tree(&path, flat)
                     }
                     None => async_get_child_nodes_opt(&storage, &path, true, version).await?,
@@ -769,19 +752,6 @@ mod tests {
         assert!(node.is_root());
     }
 
-    #[test]
-    fn parent_path_str_branches() {
-        // root has no parent
-        assert_eq!(super::parent_path_str("/"), "");
-        // direct child of root
-        assert_eq!(super::parent_path_str("/foo"), "/");
-        // nested
-        assert_eq!(super::parent_path_str("/foo/bar"), "/foo");
-        assert_eq!(super::parent_path_str("/foo/bar/baz"), "/foo/bar");
-        // pathological: no slash at all (should not happen for real NodePath, but fn must handle it)
-        assert_eq!(super::parent_path_str("foo"), "");
-    }
-
     fn array_md(shape: u64) -> NodeMetadata {
         NodeMetadata::Array(
             serde_json::from_str::<zarrs_metadata::v3::ArrayMetadataV3>(&format!(
@@ -813,7 +783,7 @@ mod tests {
         c.metadata.insert("/bar".to_string(), array_md(2));
         c.metadata.insert(String::new(), group_md()); // base group entry — must be skipped
         c.metadata.insert("/".to_string(), group_md()); // also base entry after stripping leading slash
-        let out = super::expand_consolidated_metadata(&NodePath::root(), &c).unwrap();
+        let out = super::expand_consolidated_metadata(&NodePath::root(), c).unwrap();
         let paths: Vec<_> = out.iter().map(|(p, _)| p.as_str().to_string()).collect();
         assert!(paths.contains(&"/foo".to_string()));
         assert!(paths.contains(&"/bar".to_string()));
@@ -827,7 +797,7 @@ mod tests {
         let mut c = ConsolidatedMetadata::default();
         c.metadata.insert("foo".to_string(), array_md(3));
         c.metadata.insert("sub/leaf".to_string(), array_md(4));
-        let out = super::expand_consolidated_metadata(&base, &c).unwrap();
+        let out = super::expand_consolidated_metadata(&base, c).unwrap();
         let mut paths: Vec<_> = out.iter().map(|(p, _)| p.as_str().to_string()).collect();
         paths.sort();
         assert_eq!(paths, vec!["/group/foo", "/group/sub/leaf"]);
@@ -945,7 +915,7 @@ mod tests {
         // A key with a trailing slash produces an invalid NodePath ("/foo/").
         let mut c = ConsolidatedMetadata::default();
         c.metadata.insert("foo/".to_string(), array_md(1));
-        let err = super::expand_consolidated_metadata(&NodePath::root(), &c).unwrap_err();
+        let err = super::expand_consolidated_metadata(&NodePath::root(), c).unwrap_err();
         assert!(matches!(err, NodeCreateError::NodePathError(_)));
     }
 

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -92,9 +92,8 @@ pub enum NodeCreateError {
     /// Missing metadata.
     #[error("Metadata is missing for {0}")]
     MissingMetadata(String),
-    /// Consolidated metadata was required but not present on the root group.
-    #[error("Consolidated metadata required but missing on group {0}")]
-    MissingConsolidatedMetadata(String),
+    // TODO: In a future breaking release, consider adding a more specific
+    // `MissingConsolidatedMetadata` variant instead of using `MissingMetadata`.
 }
 
 impl From<NodeCreateError> for ArrayCreateError {
@@ -108,9 +107,6 @@ impl From<NodeCreateError> for ArrayCreateError {
             }
             NodeCreateError::MissingMetadata(err) => {
                 StorageError::Other(NodeCreateError::MissingMetadata(err).to_string())
-            }
-            NodeCreateError::MissingConsolidatedMetadata(err) => {
-                StorageError::Other(NodeCreateError::MissingConsolidatedMetadata(err).to_string())
             }
         })
     }
@@ -127,9 +123,6 @@ impl From<NodeCreateError> for GroupCreateError {
             }
             NodeCreateError::MissingMetadata(err) => {
                 StorageError::Other(NodeCreateError::MissingMetadata(err).to_string())
-            }
-            NodeCreateError::MissingConsolidatedMetadata(err) => {
-                StorageError::Other(NodeCreateError::MissingConsolidatedMetadata(err).to_string())
             }
         })
     }
@@ -212,8 +205,8 @@ pub(crate) fn build_node_tree(
 ///
 /// Returns `Ok(Some(...))` when consolidated metadata should be used, `Ok(None)`
 /// when it is absent and the policy permits falling back to listing, and
-/// [`NodeCreateError::MissingConsolidatedMetadata`] when the policy requires it
-/// but it is absent.
+/// [`NodeCreateError::MissingMetadata`] when the policy requires consolidated
+/// metadata but it is absent.
 pub(crate) fn resolve_consolidated_policy(
     path: &NodePath,
     consolidated: Option<ConsolidatedMetadata>,
@@ -224,9 +217,11 @@ pub(crate) fn resolve_consolidated_policy(
     }
     match (consolidated, policy) {
         (Some(c), _) => Ok(Some(c)),
-        (None, UseConsolidatedMetadata::Must) => Err(NodeCreateError::MissingConsolidatedMetadata(
-            path.to_string(),
-        )),
+        // TODO: In a future breaking release, consider using a more specific
+        // `MissingConsolidatedMetadata` error variant instead of `MissingMetadata`.
+        (None, UseConsolidatedMetadata::Must) => Err(NodeCreateError::MissingMetadata(format!(
+            "Consolidated metadata required but missing on group {path}"
+        ))),
         (None, _) => Ok(None),
     }
 }
@@ -942,10 +937,7 @@ mod tests {
         // Must with absent errors.
         let err = super::resolve_consolidated_policy(&path, None, UseConsolidatedMetadata::Must)
             .unwrap_err();
-        assert!(matches!(
-            err,
-            NodeCreateError::MissingConsolidatedMetadata(_)
-        ));
+        assert!(matches!(err, NodeCreateError::MissingMetadata(_)));
     }
 
     #[test]
@@ -958,21 +950,22 @@ mod tests {
     }
 
     #[test]
-    fn missing_consolidated_metadata_error_conversions() {
-        // Cover the From<NodeCreateError> for ArrayCreateError / GroupCreateError arms.
-        let err = NodeCreateError::MissingConsolidatedMetadata("/x".to_string());
+    fn missing_consolidated_metadata_error_message() {
+        // Verify that missing consolidated metadata uses MissingMetadata with a descriptive message.
+        let path = NodePath::root();
+        let err = super::resolve_consolidated_policy(&path, None, UseConsolidatedMetadata::Must)
+            .unwrap_err();
         let s = err.to_string();
         assert!(s.contains("Consolidated metadata required but missing"));
 
-        let err = NodeCreateError::MissingConsolidatedMetadata("/x".to_string());
-        let arr_err: ArrayCreateError = err.into();
+        // Verify the error converts correctly to ArrayCreateError and GroupCreateError.
+        let arr_err: ArrayCreateError = err.clone().into();
         assert!(
             arr_err
                 .to_string()
                 .contains("Consolidated metadata required but missing")
         );
 
-        let err = NodeCreateError::MissingConsolidatedMetadata("/x".to_string());
         let group_err: GroupCreateError = err.into();
         assert!(
             group_err

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -822,7 +822,10 @@ mod tests {
         let paths: Vec<_> = out.iter().map(|(p, _)| p.as_str().to_string()).collect();
         assert!(paths.contains(&"/foo".to_string()));
         assert!(paths.contains(&"/bar".to_string()));
-        assert!(!paths.iter().any(|p| p == "/"), "base group must be skipped");
+        assert!(
+            !paths.iter().any(|p| p == "/"),
+            "base group must be skipped"
+        );
 
         // Base is non-root: rel "foo" → "/group/foo"
         let base = NodePath::new("/group").unwrap();
@@ -846,9 +849,15 @@ mod tests {
 
         // From root: only /a is direct.
         let direct = super::direct_children_from_flat(&NodePath::root(), entries.clone());
-        let names: Vec<_> = direct.iter().map(|n| n.path().as_str().to_string()).collect();
+        let names: Vec<_> = direct
+            .iter()
+            .map(|n| n.path().as_str().to_string())
+            .collect();
         assert_eq!(names, vec!["/a"]);
-        assert!(direct[0].children().is_empty(), "direct must not populate descendants");
+        assert!(
+            direct[0].children().is_empty(),
+            "direct must not populate descendants"
+        );
 
         // Tree from root.
         let tree = super::build_node_tree(&NodePath::root(), entries.clone());
@@ -902,40 +911,41 @@ mod tests {
         let some_md = ConsolidatedMetadata::default();
 
         // Never always returns None even when present.
-        assert!(super::resolve_consolidated_policy(
-            &path,
-            Some(some_md.clone()),
-            UseConsolidatedMetadata::Never,
-        )
-        .unwrap()
-        .is_none());
+        assert!(
+            super::resolve_consolidated_policy(
+                &path,
+                Some(some_md.clone()),
+                UseConsolidatedMetadata::Never,
+            )
+            .unwrap()
+            .is_none()
+        );
 
         // Auto with present returns Some.
-        assert!(super::resolve_consolidated_policy(
-            &path,
-            Some(some_md.clone()),
-            UseConsolidatedMetadata::Auto,
-        )
-        .unwrap()
-        .is_some());
+        assert!(
+            super::resolve_consolidated_policy(
+                &path,
+                Some(some_md.clone()),
+                UseConsolidatedMetadata::Auto,
+            )
+            .unwrap()
+            .is_some()
+        );
 
         // Auto with absent returns None.
-        assert!(super::resolve_consolidated_policy(
-            &path,
-            None,
-            UseConsolidatedMetadata::Auto,
-        )
-        .unwrap()
-        .is_none());
+        assert!(
+            super::resolve_consolidated_policy(&path, None, UseConsolidatedMetadata::Auto,)
+                .unwrap()
+                .is_none()
+        );
 
         // Must with absent errors.
-        let err = super::resolve_consolidated_policy(
-            &path,
-            None,
-            UseConsolidatedMetadata::Must,
-        )
-        .unwrap_err();
-        assert!(matches!(err, NodeCreateError::MissingConsolidatedMetadata(_)));
+        let err = super::resolve_consolidated_policy(&path, None, UseConsolidatedMetadata::Must)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            NodeCreateError::MissingConsolidatedMetadata(_)
+        ));
     }
 
     #[test]

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -207,28 +207,21 @@ pub(crate) fn build_node_tree(
     collect_children_from_map(base_path.as_str(), &mut by_parent)
 }
 
-/// Read the v3 consolidated metadata from a group's metadata, honouring the
-/// configured [`UseConsolidatedMetadata`] policy.
+/// Apply the [`UseConsolidatedMetadata`] policy to an already-extracted optional
+/// [`ConsolidatedMetadata`].
 ///
 /// Returns `Ok(Some(...))` when consolidated metadata should be used, `Ok(None)`
 /// when it is absent and the policy permits falling back to listing, and
 /// [`NodeCreateError::MissingConsolidatedMetadata`] when the policy requires it
 /// but it is absent.
-pub(crate) fn consolidated_metadata_for_open(
+pub(crate) fn resolve_consolidated_policy(
     path: &NodePath,
-    metadata: &NodeMetadata,
+    consolidated: Option<ConsolidatedMetadata>,
     policy: UseConsolidatedMetadata,
 ) -> Result<Option<ConsolidatedMetadata>, NodeCreateError> {
     if policy == UseConsolidatedMetadata::Never {
         return Ok(None);
     }
-    let consolidated = match metadata {
-        NodeMetadata::Group(GroupMetadata::V3(group_metadata)) => group_metadata
-            .additional_fields
-            .get("consolidated_metadata")
-            .and_then(|f| serde_json::from_value::<ConsolidatedMetadata>(f.as_value().clone()).ok()),
-        NodeMetadata::Group(GroupMetadata::V2(_)) | NodeMetadata::Array(_) => None,
-    };
     match (consolidated, policy) {
         (Some(c), _) => Ok(Some(c)),
         (None, UseConsolidatedMetadata::Must) => {
@@ -236,6 +229,39 @@ pub(crate) fn consolidated_metadata_for_open(
         }
         (None, _) => Ok(None),
     }
+}
+
+/// Read the v3 consolidated metadata from a group's metadata, honouring the
+/// configured [`UseConsolidatedMetadata`] policy.
+pub(crate) fn consolidated_metadata_for_open(
+    path: &NodePath,
+    metadata: &NodeMetadata,
+    policy: UseConsolidatedMetadata,
+) -> Result<Option<ConsolidatedMetadata>, NodeCreateError> {
+    let consolidated = match metadata {
+        NodeMetadata::Group(GroupMetadata::V3(group_metadata)) => group_metadata
+            .additional_fields
+            .get("consolidated_metadata")
+            .and_then(|f| serde_json::from_value::<ConsolidatedMetadata>(f.as_value().clone()).ok()),
+        NodeMetadata::Group(GroupMetadata::V2(_)) | NodeMetadata::Array(_) => None,
+    };
+    resolve_consolidated_policy(path, consolidated, policy)
+}
+
+/// Build a `Vec<Node>` containing only the direct children of `base_path`
+/// from a flat `(NodePath, NodeMetadata)` list. Nested descendants are dropped.
+pub(crate) fn direct_children_from_flat(
+    base_path: &NodePath,
+    flat: Vec<(NodePath, NodeMetadata)>,
+) -> Vec<Node> {
+    let base = base_path.as_str();
+    let mut out: Vec<Node> = flat
+        .into_iter()
+        .filter(|(p, _)| parent_path_str(p.as_str()) == base)
+        .map(|(p, m)| Node::new_with_metadata(p, m, vec![]))
+        .collect();
+    out.sort_by(|a, b| a.path().as_str().cmp(b.path().as_str()));
+    out
 }
 
 impl Node {

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -939,6 +939,15 @@ mod tests {
     }
 
     #[test]
+    fn expand_consolidated_metadata_malformed_key_errors() {
+        // A key with a trailing slash produces an invalid NodePath ("/foo/").
+        let mut c = ConsolidatedMetadata::default();
+        c.metadata.insert("foo/".to_string(), array_md(1));
+        let err = super::expand_consolidated_metadata(&NodePath::root(), &c).unwrap_err();
+        assert!(matches!(err, NodeCreateError::NodePathError(_)));
+    }
+
+    #[test]
     fn missing_consolidated_metadata_error_conversions() {
         // Cover the From<NodeCreateError> for ArrayCreateError / GroupCreateError arms.
         let err = NodeCreateError::MissingConsolidatedMetadata("/x".to_string());

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -35,12 +35,14 @@ pub use node_async::{
 use thiserror::Error;
 
 use crate::array::{ArrayCreateError, ArrayMetadata};
-use crate::config::MetadataRetrieveVersion;
+use crate::config::{MetadataRetrieveVersion, UseConsolidatedMetadata};
 use crate::group::GroupCreateError;
 use zarrs_metadata::GroupMetadata;
 pub use zarrs_metadata::NodeMetadata;
 use zarrs_metadata::v2::{ArrayMetadataV2, GroupMetadataV2};
-use zarrs_metadata_ext::group::consolidated_metadata::ConsolidatedMetadataMetadata;
+use zarrs_metadata_ext::group::consolidated_metadata::{
+    ConsolidatedMetadata, ConsolidatedMetadataMetadata,
+};
 #[cfg(feature = "async")]
 use zarrs_storage::{AsyncListableStorageTraits, AsyncReadableStorageTraits};
 use zarrs_storage::{ListableStorageTraits, ReadableStorageTraits, StorageError, StorePrefixError};
@@ -90,6 +92,9 @@ pub enum NodeCreateError {
     /// Missing metadata.
     #[error("Metadata is missing for {0}")]
     MissingMetadata(String),
+    /// Consolidated metadata was required but not present on the root group.
+    #[error("Consolidated metadata required but missing on group {0}")]
+    MissingConsolidatedMetadata(String),
 }
 
 impl From<NodeCreateError> for ArrayCreateError {
@@ -103,6 +108,9 @@ impl From<NodeCreateError> for ArrayCreateError {
             }
             NodeCreateError::MissingMetadata(err) => {
                 StorageError::Other(NodeCreateError::MissingMetadata(err).to_string())
+            }
+            NodeCreateError::MissingConsolidatedMetadata(err) => {
+                StorageError::Other(NodeCreateError::MissingConsolidatedMetadata(err).to_string())
             }
         })
     }
@@ -120,7 +128,113 @@ impl From<NodeCreateError> for GroupCreateError {
             NodeCreateError::MissingMetadata(err) => {
                 StorageError::Other(NodeCreateError::MissingMetadata(err).to_string())
             }
+            NodeCreateError::MissingConsolidatedMetadata(err) => {
+                StorageError::Other(NodeCreateError::MissingConsolidatedMetadata(err).to_string())
+            }
         })
+    }
+}
+
+/// Expand the inline `metadata` map of a [`ConsolidatedMetadata`] into a flat
+/// list of `(NodePath, NodeMetadata)` rooted under `base_path`.
+///
+/// Keys in the consolidated map are relative paths to `base_path`. A leading
+/// `/` is tolerated for compatibility with implementations that include it.
+pub(crate) fn expand_consolidated_metadata(
+    base_path: &NodePath,
+    consolidated: &ConsolidatedMetadata,
+) -> Result<Vec<(NodePath, NodeMetadata)>, NodeCreateError> {
+    let base = base_path.as_str();
+    let base_no_trailing = if base == "/" { "" } else { base };
+    let mut out = Vec::with_capacity(consolidated.metadata.len());
+    for (rel, md) in &consolidated.metadata {
+        let rel = rel.strip_prefix('/').unwrap_or(rel);
+        if rel.is_empty() {
+            // The base group is conventionally not included in its own consolidated map; skip it if it is.
+            continue;
+        }
+        let full = format!("{base_no_trailing}/{rel}");
+        let path = NodePath::new(&full)?;
+        out.push((path, md.clone()));
+    }
+    Ok(out)
+}
+
+/// Return the parent of a node-path string, or the empty string if no parent exists.
+fn parent_path_str(p: &str) -> &str {
+    if p == "/" {
+        return "";
+    }
+    match p.rfind('/') {
+        Some(0) => "/",
+        Some(idx) => &p[..idx],
+        None => "",
+    }
+}
+
+/// Recursively collect the children of `parent` from the parent-keyed map.
+fn collect_children_from_map(
+    parent: &str,
+    by_parent: &mut HashMap<String, Vec<(NodePath, NodeMetadata)>>,
+) -> Vec<Node> {
+    let Some(mut entries) = by_parent.remove(parent) else {
+        return Vec::new();
+    };
+    entries.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+    entries
+        .into_iter()
+        .map(|(path, md)| {
+            let children = match &md {
+                NodeMetadata::Group(_) => collect_children_from_map(path.as_str(), by_parent),
+                NodeMetadata::Array(_) => Vec::new(),
+            };
+            Node::new_with_metadata(path, md, children)
+        })
+        .collect()
+}
+
+/// Build a tree of [`Node`]s from a flat list of `(NodePath, NodeMetadata)` entries
+/// and the `base_path` of the parent group whose direct children are returned.
+pub(crate) fn build_node_tree(
+    base_path: &NodePath,
+    flat: Vec<(NodePath, NodeMetadata)>,
+) -> Vec<Node> {
+    let mut by_parent: HashMap<String, Vec<(NodePath, NodeMetadata)>> = HashMap::new();
+    for (path, md) in flat {
+        let parent = parent_path_str(path.as_str()).to_string();
+        by_parent.entry(parent).or_default().push((path, md));
+    }
+    collect_children_from_map(base_path.as_str(), &mut by_parent)
+}
+
+/// Read the v3 consolidated metadata from a group's metadata, honouring the
+/// configured [`UseConsolidatedMetadata`] policy.
+///
+/// Returns `Ok(Some(...))` when consolidated metadata should be used, `Ok(None)`
+/// when it is absent and the policy permits falling back to listing, and
+/// [`NodeCreateError::MissingConsolidatedMetadata`] when the policy requires it
+/// but it is absent.
+pub(crate) fn consolidated_metadata_for_open(
+    path: &NodePath,
+    metadata: &NodeMetadata,
+    policy: UseConsolidatedMetadata,
+) -> Result<Option<ConsolidatedMetadata>, NodeCreateError> {
+    if policy == UseConsolidatedMetadata::Never {
+        return Ok(None);
+    }
+    let consolidated = match metadata {
+        NodeMetadata::Group(GroupMetadata::V3(group_metadata)) => group_metadata
+            .additional_fields
+            .get("consolidated_metadata")
+            .and_then(|f| serde_json::from_value::<ConsolidatedMetadata>(f.as_value().clone()).ok()),
+        NodeMetadata::Group(GroupMetadata::V2(_)) | NodeMetadata::Array(_) => None,
+    };
+    match (consolidated, policy) {
+        (Some(c), _) => Ok(Some(c)),
+        (None, UseConsolidatedMetadata::Must) => {
+            Err(NodeCreateError::MissingConsolidatedMetadata(path.to_string()))
+        }
+        (None, _) => Ok(None),
     }
 }
 
@@ -266,10 +380,18 @@ impl Node {
     ) -> Result<Self, NodeCreateError> {
         let path: NodePath = path.try_into()?;
         let metadata = Self::get_metadata(storage, &path, version)?;
-        let children = match metadata {
+        let children = match &metadata {
             NodeMetadata::Array(_) => Vec::default(),
-            // TODO: Add consolidated metadata support
-            NodeMetadata::Group(_) => get_child_nodes_opt(storage, &path, true, version)?,
+            NodeMetadata::Group(_) => {
+                let policy = crate::config::global_config().use_consolidated_metadata();
+                match consolidated_metadata_for_open(&path, &metadata, policy)? {
+                    Some(consolidated) => {
+                        let flat = expand_consolidated_metadata(&path, &consolidated)?;
+                        build_node_tree(&path, flat)
+                    }
+                    None => get_child_nodes_opt(storage, &path, true, version)?,
+                }
+            }
         };
         let node = Self {
             path,
@@ -307,11 +429,17 @@ impl Node {
     ) -> Result<Self, NodeCreateError> {
         let path: NodePath = path.try_into()?;
         let metadata = Self::async_get_metadata(&storage, &path, version).await?;
-        let children = match metadata {
+        let children = match &metadata {
             NodeMetadata::Array(_) => Vec::default(),
-            // TODO: Add consolidated metadata support
             NodeMetadata::Group(_) => {
-                async_get_child_nodes_opt(&storage, &path, true, version).await?
+                let policy = crate::config::global_config().use_consolidated_metadata();
+                match consolidated_metadata_for_open(&path, &metadata, policy)? {
+                    Some(consolidated) => {
+                        let flat = expand_consolidated_metadata(&path, &consolidated)?;
+                        build_node_tree(&path, flat)
+                    }
+                    None => async_get_child_nodes_opt(&storage, &path, true, version).await?,
+                }
             }
         };
         let node = Self {

--- a/zarrs/tests/hierarchy.rs
+++ b/zarrs/tests/hierarchy.rs
@@ -319,9 +319,10 @@ mod consolidated_open {
         .unwrap();
 
         let mut consolidated = ConsolidatedMetadata::default();
-        consolidated
-            .metadata
-            .insert("real".to_string(), NodeMetadata::Array(real_child.metadata().clone()));
+        consolidated.metadata.insert(
+            "real".to_string(),
+            NodeMetadata::Array(real_child.metadata().clone()),
+        );
         consolidated
             .metadata
             .insert("phantom".to_string(), phantom_metadata);
@@ -352,11 +353,18 @@ mod consolidated_open {
         // Default policy is Auto: phantom child is reported via consolidated metadata.
         let h = Hierarchy::open(&store, "/").unwrap();
         let tree = h.tree();
-        assert!(tree.contains("phantom"), "tree should include phantom: {tree}");
+        assert!(
+            tree.contains("phantom"),
+            "tree should include phantom: {tree}"
+        );
         assert!(tree.contains("real"), "tree should include real: {tree}");
 
         let node = Node::open(&store, "/").unwrap();
-        let names: Vec<_> = node.children().iter().map(|c| c.name().to_string()).collect();
+        let names: Vec<_> = node
+            .children()
+            .iter()
+            .map(|c| c.name().to_string())
+            .collect();
         assert!(names.contains(&"phantom".to_string()), "names: {names:?}");
         assert!(names.contains(&"real".to_string()), "names: {names:?}");
 
@@ -373,11 +381,18 @@ mod consolidated_open {
         // With Never, only the actually-stored child is discovered.
         let h = Hierarchy::open(&store, "/").unwrap();
         let tree = h.tree();
-        assert!(!tree.contains("phantom"), "tree should not include phantom: {tree}");
+        assert!(
+            !tree.contains("phantom"),
+            "tree should not include phantom: {tree}"
+        );
         assert!(tree.contains("real"), "tree should include real: {tree}");
 
         let node = Node::open(&store, "/").unwrap();
-        let names: Vec<_> = node.children().iter().map(|c| c.name().to_string()).collect();
+        let names: Vec<_> = node
+            .children()
+            .iter()
+            .map(|c| c.name().to_string())
+            .collect();
         assert!(!names.contains(&"phantom".to_string()), "names: {names:?}");
         assert!(names.contains(&"real".to_string()), "names: {names:?}");
 
@@ -400,13 +415,15 @@ mod consolidated_open {
 
         let err = Hierarchy::open(&store, "/").expect_err("should fail under Must");
         assert!(
-            err.to_string().contains("Consolidated metadata required but missing"),
+            err.to_string()
+                .contains("Consolidated metadata required but missing"),
             "unexpected error: {err}"
         );
 
         let err = Node::open(&store, "/").expect_err("should fail under Must");
         assert!(
-            err.to_string().contains("Consolidated metadata required but missing"),
+            err.to_string()
+                .contains("Consolidated metadata required but missing"),
             "unexpected error: {err}"
         );
 
@@ -452,10 +469,8 @@ mod consolidated_open {
             .build(store.clone(), "/")
             .unwrap();
 
-        let sub_group_md: NodeMetadata = serde_json::from_str(
-            r#"{"zarr_format": 3, "node_type": "group"}"#,
-        )
-        .unwrap();
+        let sub_group_md: NodeMetadata =
+            serde_json::from_str(r#"{"zarr_format": 3, "node_type": "group"}"#).unwrap();
         let leaf_array_md: NodeMetadata = serde_json::from_str(
             r#"{
                 "zarr_format": 3,
@@ -471,7 +486,9 @@ mod consolidated_open {
         .unwrap();
 
         let mut consolidated = ConsolidatedMetadata::default();
-        consolidated.metadata.insert("sub".to_string(), sub_group_md);
+        consolidated
+            .metadata
+            .insert("sub".to_string(), sub_group_md);
         consolidated
             .metadata
             .insert("sub/leaf".to_string(), leaf_array_md);
@@ -552,7 +569,11 @@ mod consolidated_open {
         assert!(h.tree().contains("phantom"));
 
         let node = Node::async_open(store.clone(), "/").await.unwrap();
-        let names: Vec<_> = node.children().iter().map(|c| c.name().to_string()).collect();
+        let names: Vec<_> = node
+            .children()
+            .iter()
+            .map(|c| c.name().to_string())
+            .collect();
         assert!(names.contains(&"phantom".to_string()), "names: {names:?}");
 
         reset_config();
@@ -649,7 +670,9 @@ mod consolidated_open {
         .unwrap();
 
         let mut consolidated = ConsolidatedMetadata::default();
-        consolidated.metadata.insert("sub".to_string(), sub_group_md);
+        consolidated
+            .metadata
+            .insert("sub".to_string(), sub_group_md);
         consolidated
             .metadata
             .insert("sub/leaf".to_string(), leaf_array_md);
@@ -667,7 +690,10 @@ mod consolidated_open {
         let direct = group.children(false).unwrap();
         assert_eq!(direct.len(), 1);
         assert_eq!(direct[0].path().as_str(), "/sub");
-        assert!(direct[0].children().is_empty(), "non-recursive should not populate descendants");
+        assert!(
+            direct[0].children().is_empty(),
+            "non-recursive should not populate descendants"
+        );
 
         // recursive=true: tree rooted at /sub with leaf as a child.
         let tree = group.children(true).unwrap();

--- a/zarrs/tests/hierarchy.rs
+++ b/zarrs/tests/hierarchy.rs
@@ -812,6 +812,196 @@ mod consolidated_open {
 
     #[test]
     #[serial]
+    fn node_open_falls_back_when_no_consolidated() {
+        reset_config();
+
+        // V3 group with one real child, no consolidated_metadata.
+        let store: Arc<MemoryStore> = Arc::new(MemoryStore::new());
+        let root = zarrs::group::GroupBuilder::default()
+            .build(store.clone(), "/")
+            .unwrap();
+        let arr = zarrs::array::ArrayBuilder::new(
+            vec![5],
+            vec![5],
+            zarrs::array::data_type::float32(),
+            0.0f32,
+        )
+        .build(store.clone(), "/only")
+        .unwrap();
+        root.store_metadata().unwrap();
+        arr.store_metadata().unwrap();
+
+        // Node::open must fall back to listing storage and find /only.
+        let node = Node::open(&store, "/").unwrap();
+        let names: Vec<_> = node
+            .children()
+            .iter()
+            .map(|c| c.name().to_string())
+            .collect();
+        assert!(names.contains(&"only".to_string()), "names: {names:?}");
+
+        reset_config();
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    #[serial]
+    async fn async_node_open_falls_back_when_no_consolidated() {
+        use object_store::memory::InMemory;
+        use zarrs_object_store::AsyncObjectStore;
+        use zarrs_storage::AsyncWritableStorageTraits;
+
+        reset_config();
+
+        let store = Arc::new(AsyncObjectStore::new(InMemory::new()));
+        let root_md = serde_json::json!({"zarr_format": 3, "node_type": "group"});
+        store
+            .set(
+                &StoreKey::new("zarr.json").unwrap(),
+                serde_json::to_vec(&root_md).unwrap().into(),
+            )
+            .await
+            .unwrap();
+        let arr_md = serde_json::json!({
+            "zarr_format": 3,
+            "node_type": "array",
+            "shape": [5],
+            "data_type": "float32",
+            "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": [5]}},
+            "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/"}},
+            "fill_value": 0,
+            "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}]
+        });
+        store
+            .set(
+                &StoreKey::new("only/zarr.json").unwrap(),
+                serde_json::to_vec(&arr_md).unwrap().into(),
+            )
+            .await
+            .unwrap();
+
+        let node = Node::async_open(store.clone(), "/").await.unwrap();
+        let names: Vec<_> = node
+            .children()
+            .iter()
+            .map(|c| c.name().to_string())
+            .collect();
+        assert!(names.contains(&"only".to_string()), "names: {names:?}");
+
+        reset_config();
+    }
+
+    /// Trigger the malformed-key error path in `expand_consolidated_metadata`
+    /// through `Node::open` / `Group::children` / async variants. This covers
+    /// the `?` propagation arms.
+    #[test]
+    #[serial]
+    fn malformed_consolidated_key_propagates_error() {
+        reset_config();
+
+        // Build a root group with consolidated metadata containing an invalid
+        // relative path ("foo/", which yields "/foo/" — invalid NodePath).
+        let store: Arc<MemoryStore> = Arc::new(MemoryStore::new());
+        let root = zarrs::group::GroupBuilder::default()
+            .build(store.clone(), "/")
+            .unwrap();
+
+        let bad_array_md: NodeMetadata = serde_json::from_str(
+            r#"{
+                "zarr_format": 3,
+                "node_type": "array",
+                "shape": [3],
+                "data_type": "float32",
+                "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": [3]}},
+                "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/"}},
+                "fill_value": 0,
+                "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}]
+            }"#,
+        )
+        .unwrap();
+
+        let mut consolidated = ConsolidatedMetadata::default();
+        consolidated.metadata.insert("foo/".to_string(), bad_array_md);
+
+        let mut root = root;
+        root.set_consolidated_metadata(Some(consolidated));
+        let serialized = serde_json::to_vec(root.metadata()).unwrap();
+        store
+            .set(&StoreKey::new("zarr.json").unwrap(), serialized.into())
+            .unwrap();
+
+        // Hierarchy::open propagates the NodePath error (covers expand `?`).
+        assert!(Hierarchy::open(&store, "/").is_err());
+        // Node::open same.
+        assert!(Node::open(&store, "/").is_err());
+        // Group::children same (covers Group::children's `?`).
+        let group = zarrs::group::Group::open(store.clone(), "/").unwrap();
+        assert!(group.children(false).is_err());
+        assert!(group.traverse().is_err());
+
+        reset_config();
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    #[serial]
+    async fn async_malformed_consolidated_key_propagates_error() {
+        use object_store::memory::InMemory;
+        use zarrs_object_store::AsyncObjectStore;
+        use zarrs_storage::AsyncWritableStorageTraits;
+
+        reset_config();
+
+        let bad_array_md: NodeMetadata = serde_json::from_str(
+            r#"{
+                "zarr_format": 3,
+                "node_type": "array",
+                "shape": [3],
+                "data_type": "float32",
+                "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": [3]}},
+                "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/"}},
+                "fill_value": 0,
+                "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}]
+            }"#,
+        )
+        .unwrap();
+        let mut consolidated = ConsolidatedMetadata::default();
+        consolidated.metadata.insert("foo/".to_string(), bad_array_md);
+
+        let mut consolidated_value = serde_json::to_value(&consolidated).unwrap();
+        consolidated_value
+            .as_object_mut()
+            .unwrap()
+            .insert("must_understand".to_string(), serde_json::Value::Bool(false));
+        let root_md = serde_json::json!({
+            "zarr_format": 3,
+            "node_type": "group",
+            "consolidated_metadata": consolidated_value,
+        });
+
+        let store = Arc::new(AsyncObjectStore::new(InMemory::new()));
+        store
+            .set(
+                &StoreKey::new("zarr.json").unwrap(),
+                serde_json::to_vec(&root_md).unwrap().into(),
+            )
+            .await
+            .unwrap();
+
+        // Node::async_open propagates the error (covers expand `?` in async path).
+        assert!(Node::async_open(store.clone(), "/").await.is_err());
+        // Group::async_children same.
+        let group = zarrs::group::Group::async_open(store.clone(), "/")
+            .await
+            .unwrap();
+        assert!(group.async_children(false).await.is_err());
+        assert!(group.async_traverse().await.is_err());
+
+        reset_config();
+    }
+
+    #[test]
+    #[serial]
     fn group_must_errors_when_absent() {
         reset_config();
 

--- a/zarrs/tests/hierarchy.rs
+++ b/zarrs/tests/hierarchy.rs
@@ -1038,7 +1038,7 @@ mod consolidated_open {
         );
 
         // child_arrays propagates as ArrayCreateError — covers the
-        // From<NodeCreateError> for ArrayCreateError MissingConsolidatedMetadata arm.
+        // From<NodeCreateError> for ArrayCreateError path for missing consolidated metadata.
         let err = group
             .child_arrays()
             .expect_err("child_arrays should fail under Must when consolidated absent");
@@ -1049,7 +1049,7 @@ mod consolidated_open {
         );
 
         // child_groups propagates as GroupCreateError — covers the
-        // From<NodeCreateError> for GroupCreateError MissingConsolidatedMetadata arm.
+        // From<NodeCreateError> for GroupCreateError path for missing consolidated metadata.
         let err = group
             .child_groups()
             .expect_err("child_groups should fail under Must when consolidated absent");

--- a/zarrs/tests/hierarchy.rs
+++ b/zarrs/tests/hierarchy.rs
@@ -267,3 +267,294 @@ async fn async_child_array_paths() {
         .collect();
     assert_eq!(path_strings, ["/a/baz", "/a/foo"]);
 }
+
+mod consolidated_open {
+    use std::sync::Arc;
+
+    use serial_test::serial;
+
+    use zarrs::config::{UseConsolidatedMetadata, global_config_mut};
+    use zarrs::hierarchy::{Hierarchy, NodePath};
+    use zarrs::metadata::NodeMetadata;
+    use zarrs::metadata_ext::group::consolidated_metadata::ConsolidatedMetadata;
+    use zarrs::node::Node;
+    use zarrs_storage::store::MemoryStore;
+    use zarrs_storage::{StoreKey, WritableStorageTraits};
+
+    /// Build a v3 root group with a `consolidated_metadata` block that lists a
+    /// phantom child array `phantom`. The child is *not* written to storage.
+    /// Opening with consolidated metadata enabled must surface `phantom`;
+    /// disabling it must not.
+    fn build_store_with_phantom() -> Arc<MemoryStore> {
+        let store = Arc::new(MemoryStore::new());
+
+        // Create root + child via the builder, then attach a "phantom" child
+        // through consolidated metadata only.
+        let root_builder = zarrs::group::GroupBuilder::default();
+        let root = root_builder.build(store.clone(), "/").unwrap();
+
+        let real_child = zarrs::array::ArrayBuilder::new(
+            vec![10],
+            vec![5],
+            zarrs::array::data_type::float32(),
+            0.0f32,
+        )
+        .build(store.clone(), "/real")
+        .unwrap();
+        real_child.store_metadata().unwrap();
+
+        // Phantom child: only present in consolidated metadata.
+        let phantom_metadata: NodeMetadata = serde_json::from_str(
+            r#"{
+                "zarr_format": 3,
+                "node_type": "array",
+                "shape": [42],
+                "data_type": "float32",
+                "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": [42]}},
+                "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/"}},
+                "fill_value": 0,
+                "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}]
+            }"#,
+        )
+        .unwrap();
+
+        let mut consolidated = ConsolidatedMetadata::default();
+        consolidated
+            .metadata
+            .insert("real".to_string(), NodeMetadata::Array(real_child.metadata().clone()));
+        consolidated
+            .metadata
+            .insert("phantom".to_string(), phantom_metadata);
+
+        let mut root = root;
+        root.set_consolidated_metadata(Some(consolidated));
+        // Manually overwrite with the populated metadata. (`store_metadata`
+        // would re-serialize from the in-memory metadata, which now includes
+        // the consolidated_metadata field.)
+        let serialized = serde_json::to_vec(root.metadata()).unwrap();
+        store
+            .set(&StoreKey::new("zarr.json").unwrap(), serialized.into())
+            .unwrap();
+
+        store
+    }
+
+    fn reset_config() {
+        global_config_mut().set_use_consolidated_metadata(UseConsolidatedMetadata::default());
+    }
+
+    #[test]
+    #[serial]
+    fn auto_uses_consolidated() {
+        reset_config();
+        let store = build_store_with_phantom();
+
+        // Default policy is Auto: phantom child is reported via consolidated metadata.
+        let h = Hierarchy::open(&store, "/").unwrap();
+        let tree = h.tree();
+        assert!(tree.contains("phantom"), "tree should include phantom: {tree}");
+        assert!(tree.contains("real"), "tree should include real: {tree}");
+
+        let node = Node::open(&store, "/").unwrap();
+        let names: Vec<_> = node.children().iter().map(|c| c.name().to_string()).collect();
+        assert!(names.contains(&"phantom".to_string()), "names: {names:?}");
+        assert!(names.contains(&"real".to_string()), "names: {names:?}");
+
+        reset_config();
+    }
+
+    #[test]
+    #[serial]
+    fn never_ignores_consolidated() {
+        reset_config();
+        let store = build_store_with_phantom();
+        global_config_mut().set_use_consolidated_metadata(UseConsolidatedMetadata::Never);
+
+        // With Never, only the actually-stored child is discovered.
+        let h = Hierarchy::open(&store, "/").unwrap();
+        let tree = h.tree();
+        assert!(!tree.contains("phantom"), "tree should not include phantom: {tree}");
+        assert!(tree.contains("real"), "tree should include real: {tree}");
+
+        let node = Node::open(&store, "/").unwrap();
+        let names: Vec<_> = node.children().iter().map(|c| c.name().to_string()).collect();
+        assert!(!names.contains(&"phantom".to_string()), "names: {names:?}");
+        assert!(names.contains(&"real".to_string()), "names: {names:?}");
+
+        reset_config();
+    }
+
+    #[test]
+    #[serial]
+    fn must_errors_when_absent() {
+        reset_config();
+
+        // Build a store with a v3 group but NO consolidated_metadata.
+        let store: Arc<MemoryStore> = Arc::new(MemoryStore::new());
+        let root = zarrs::group::GroupBuilder::default()
+            .build(store.clone(), "/")
+            .unwrap();
+        root.store_metadata().unwrap();
+
+        global_config_mut().set_use_consolidated_metadata(UseConsolidatedMetadata::Must);
+
+        let err = Hierarchy::open(&store, "/").expect_err("should fail under Must");
+        assert!(
+            err.to_string().contains("Consolidated metadata required but missing"),
+            "unexpected error: {err}"
+        );
+
+        let err = Node::open(&store, "/").expect_err("should fail under Must");
+        assert!(
+            err.to_string().contains("Consolidated metadata required but missing"),
+            "unexpected error: {err}"
+        );
+
+        reset_config();
+    }
+
+    #[test]
+    #[serial]
+    fn auto_falls_back_when_absent() {
+        reset_config();
+        // No consolidated metadata; Auto should fall back to listing.
+        let store: Arc<MemoryStore> = Arc::new(MemoryStore::new());
+        let root = zarrs::group::GroupBuilder::default()
+            .build(store.clone(), "/")
+            .unwrap();
+        let arr = zarrs::array::ArrayBuilder::new(
+            vec![10],
+            vec![5],
+            zarrs::array::data_type::float32(),
+            0.0f32,
+        )
+        .build(store.clone(), "/only")
+        .unwrap();
+        root.store_metadata().unwrap();
+        arr.store_metadata().unwrap();
+
+        let h = Hierarchy::open(&store, "/").unwrap();
+        assert!(h.tree().contains("only"));
+
+        reset_config();
+    }
+
+    #[test]
+    #[serial]
+    fn nested_consolidated_tree() {
+        reset_config();
+
+        // /
+        //   sub/        (group, only in consolidated_metadata)
+        //     leaf      (array, only in consolidated_metadata)
+        let store: Arc<MemoryStore> = Arc::new(MemoryStore::new());
+        let root = zarrs::group::GroupBuilder::default()
+            .build(store.clone(), "/")
+            .unwrap();
+
+        let sub_group_md: NodeMetadata = serde_json::from_str(
+            r#"{"zarr_format": 3, "node_type": "group"}"#,
+        )
+        .unwrap();
+        let leaf_array_md: NodeMetadata = serde_json::from_str(
+            r#"{
+                "zarr_format": 3,
+                "node_type": "array",
+                "shape": [4],
+                "data_type": "int32",
+                "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": [4]}},
+                "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/"}},
+                "fill_value": 0,
+                "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}]
+            }"#,
+        )
+        .unwrap();
+
+        let mut consolidated = ConsolidatedMetadata::default();
+        consolidated.metadata.insert("sub".to_string(), sub_group_md);
+        consolidated
+            .metadata
+            .insert("sub/leaf".to_string(), leaf_array_md);
+
+        let mut root = root;
+        root.set_consolidated_metadata(Some(consolidated));
+        let serialized = serde_json::to_vec(root.metadata()).unwrap();
+        store
+            .set(&StoreKey::new("zarr.json").unwrap(), serialized.into())
+            .unwrap();
+
+        // Hierarchy: flat map should contain both /sub and /sub/leaf.
+        let h = Hierarchy::open(&store, "/").unwrap();
+        let tree = h.tree();
+        assert!(tree.contains("sub"), "{tree}");
+        assert!(tree.contains("leaf"), "{tree}");
+
+        // Node: tree should be nested correctly.
+        let node = Node::open(&store, "/").unwrap();
+        assert_eq!(node.children().len(), 1);
+        let sub = &node.children()[0];
+        assert_eq!(sub.path(), &NodePath::try_from("/sub").unwrap());
+        assert_eq!(sub.children().len(), 1);
+        assert_eq!(
+            sub.children()[0].path(),
+            &NodePath::try_from("/sub/leaf").unwrap()
+        );
+
+        reset_config();
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    #[serial]
+    async fn async_auto_uses_consolidated() {
+        use object_store::memory::InMemory;
+        use zarrs_object_store::AsyncObjectStore;
+        use zarrs_storage::AsyncWritableStorageTraits;
+
+        reset_config();
+
+        let store = Arc::new(AsyncObjectStore::new(InMemory::new()));
+
+        // Manually serialize a root v3 group with a phantom child via consolidated metadata.
+        let phantom_md: NodeMetadata = serde_json::from_str(
+            r#"{
+                "zarr_format": 3,
+                "node_type": "array",
+                "shape": [3],
+                "data_type": "float32",
+                "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": [3]}},
+                "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/"}},
+                "fill_value": 0,
+                "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}]
+            }"#,
+        )
+        .unwrap();
+        let mut consolidated = ConsolidatedMetadata::default();
+        consolidated
+            .metadata
+            .insert("phantom".to_string(), phantom_md);
+
+        let root_md = serde_json::json!({
+            "zarr_format": 3,
+            "node_type": "group",
+            "consolidated_metadata": serde_json::to_value(&consolidated).unwrap(),
+        });
+
+        store
+            .set(
+                &StoreKey::new("zarr.json").unwrap(),
+                serde_json::to_vec(&root_md).unwrap().into(),
+            )
+            .await
+            .unwrap();
+
+        let h = Hierarchy::async_open(&store, "/").await.unwrap();
+        assert!(h.tree().contains("phantom"));
+
+        let node = Node::async_open(store.clone(), "/").await.unwrap();
+        let names: Vec<_> = node.children().iter().map(|c| c.name().to_string()).collect();
+        assert!(names.contains(&"phantom".to_string()), "names: {names:?}");
+
+        reset_config();
+    }
+}

--- a/zarrs/tests/hierarchy.rs
+++ b/zarrs/tests/hierarchy.rs
@@ -557,4 +557,230 @@ mod consolidated_open {
 
         reset_config();
     }
+
+    #[test]
+    #[serial]
+    fn group_child_arrays_uses_consolidated() {
+        reset_config();
+        let store = build_store_with_phantom();
+
+        // Group::child_arrays must surface the phantom array purely from
+        // consolidated metadata — there is no /phantom/zarr.json in storage.
+        let group = zarrs::group::Group::open(store.clone(), "/").unwrap();
+        let arrays = group.child_arrays().unwrap();
+        let names: Vec<_> = arrays
+            .iter()
+            .map(|a| a.path().as_str().to_string())
+            .collect();
+        assert!(names.contains(&"/phantom".to_string()), "names: {names:?}");
+        assert!(names.contains(&"/real".to_string()), "names: {names:?}");
+
+        // The phantom array carries the consolidated metadata's shape (42).
+        let phantom = arrays
+            .iter()
+            .find(|a| a.path().as_str() == "/phantom")
+            .unwrap();
+        assert_eq!(phantom.shape(), &[42]);
+
+        reset_config();
+    }
+
+    #[test]
+    #[serial]
+    fn group_child_arrays_never_skips_consolidated() {
+        reset_config();
+        let store = build_store_with_phantom();
+        global_config_mut().set_use_consolidated_metadata(UseConsolidatedMetadata::Never);
+
+        let group = zarrs::group::Group::open(store.clone(), "/").unwrap();
+        let arrays = group.child_arrays().unwrap();
+        let names: Vec<_> = arrays
+            .iter()
+            .map(|a| a.path().as_str().to_string())
+            .collect();
+        assert!(!names.contains(&"/phantom".to_string()), "names: {names:?}");
+        assert!(names.contains(&"/real".to_string()), "names: {names:?}");
+
+        reset_config();
+    }
+
+    #[test]
+    #[serial]
+    fn group_traverse_uses_consolidated() {
+        reset_config();
+        let store = build_store_with_phantom();
+
+        let group = zarrs::group::Group::open(store.clone(), "/").unwrap();
+        let nodes = group.traverse().unwrap();
+        let paths: Vec<_> = nodes.iter().map(|(p, _)| p.as_str().to_string()).collect();
+        assert!(paths.contains(&"/phantom".to_string()), "paths: {paths:?}");
+        assert!(paths.contains(&"/real".to_string()), "paths: {paths:?}");
+
+        reset_config();
+    }
+
+    #[test]
+    #[serial]
+    fn group_children_recursive_uses_consolidated() {
+        reset_config();
+
+        // /
+        //   sub/        (group, only in consolidated_metadata)
+        //     leaf      (array, only in consolidated_metadata)
+        let store: Arc<MemoryStore> = Arc::new(MemoryStore::new());
+        let root = zarrs::group::GroupBuilder::default()
+            .build(store.clone(), "/")
+            .unwrap();
+
+        let sub_group_md: NodeMetadata =
+            serde_json::from_str(r#"{"zarr_format": 3, "node_type": "group"}"#).unwrap();
+        let leaf_array_md: NodeMetadata = serde_json::from_str(
+            r#"{
+                "zarr_format": 3,
+                "node_type": "array",
+                "shape": [4],
+                "data_type": "int32",
+                "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": [4]}},
+                "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/"}},
+                "fill_value": 0,
+                "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}]
+            }"#,
+        )
+        .unwrap();
+
+        let mut consolidated = ConsolidatedMetadata::default();
+        consolidated.metadata.insert("sub".to_string(), sub_group_md);
+        consolidated
+            .metadata
+            .insert("sub/leaf".to_string(), leaf_array_md);
+
+        let mut root = root;
+        root.set_consolidated_metadata(Some(consolidated));
+        let serialized = serde_json::to_vec(root.metadata()).unwrap();
+        store
+            .set(&StoreKey::new("zarr.json").unwrap(), serialized.into())
+            .unwrap();
+
+        let group = zarrs::group::Group::open(store.clone(), "/").unwrap();
+
+        // recursive=false: only direct children (/sub).
+        let direct = group.children(false).unwrap();
+        assert_eq!(direct.len(), 1);
+        assert_eq!(direct[0].path().as_str(), "/sub");
+        assert!(direct[0].children().is_empty(), "non-recursive should not populate descendants");
+
+        // recursive=true: tree rooted at /sub with leaf as a child.
+        let tree = group.children(true).unwrap();
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].path().as_str(), "/sub");
+        assert_eq!(tree[0].children().len(), 1);
+        assert_eq!(tree[0].children()[0].path().as_str(), "/sub/leaf");
+
+        reset_config();
+    }
+
+    /// Hard guarantee: opening a Group with consolidated metadata and then
+    /// calling `child_arrays()` performs **exactly one** `get` on the store
+    /// (the root `zarr.json`). No per-array fetches occur.
+    #[test]
+    #[serial]
+    fn group_child_arrays_no_per_array_reads() {
+        use std::sync::Mutex;
+
+        use zarrs_storage::byte_range::{ByteRange, ByteRangeIterator};
+        use zarrs_storage::{
+            ListableStorageTraits, MaybeBytes, MaybeBytesIterator, ReadableStorageTraits,
+            StorageError, StoreKeys, StoreKeysPrefixes, StorePrefix,
+        };
+
+        struct CountingStore {
+            inner: Arc<MemoryStore>,
+            gets: Mutex<Vec<String>>,
+            list_dirs: Mutex<usize>,
+        }
+
+        impl CountingStore {
+            fn new(inner: Arc<MemoryStore>) -> Self {
+                Self {
+                    inner,
+                    gets: Mutex::new(Vec::new()),
+                    list_dirs: Mutex::new(0),
+                }
+            }
+        }
+
+        impl ReadableStorageTraits for CountingStore {
+            fn get(&self, key: &StoreKey) -> Result<MaybeBytes, StorageError> {
+                self.gets.lock().unwrap().push(key.as_str().to_string());
+                self.inner.get(key)
+            }
+            fn get_partial_many<'a>(
+                &'a self,
+                key: &StoreKey,
+                byte_ranges: ByteRangeIterator<'a>,
+            ) -> Result<MaybeBytesIterator<'a>, StorageError> {
+                self.gets.lock().unwrap().push(key.as_str().to_string());
+                self.inner.get_partial_many(key, byte_ranges)
+            }
+            fn get_partial(
+                &self,
+                key: &StoreKey,
+                byte_range: ByteRange,
+            ) -> Result<MaybeBytes, StorageError> {
+                self.gets.lock().unwrap().push(key.as_str().to_string());
+                self.inner.get_partial(key, byte_range)
+            }
+            fn size_key(&self, key: &StoreKey) -> Result<Option<u64>, StorageError> {
+                self.inner.size_key(key)
+            }
+            fn supports_get_partial(&self) -> bool {
+                self.inner.supports_get_partial()
+            }
+        }
+
+        impl ListableStorageTraits for CountingStore {
+            fn list(&self) -> Result<StoreKeys, StorageError> {
+                self.inner.list()
+            }
+            fn list_prefix(&self, prefix: &StorePrefix) -> Result<StoreKeys, StorageError> {
+                self.inner.list_prefix(prefix)
+            }
+            fn list_dir(&self, prefix: &StorePrefix) -> Result<StoreKeysPrefixes, StorageError> {
+                *self.list_dirs.lock().unwrap() += 1;
+                self.inner.list_dir(prefix)
+            }
+            fn size_prefix(&self, prefix: &StorePrefix) -> Result<u64, StorageError> {
+                self.inner.size_prefix(prefix)
+            }
+        }
+
+        reset_config();
+
+        // Build the same phantom-store, then wrap it.
+        let inner = build_store_with_phantom();
+        let store = Arc::new(CountingStore::new(inner));
+
+        let group = zarrs::group::Group::open(store.clone(), "/").unwrap();
+        // Reset counters after the open.
+        store.gets.lock().unwrap().clear();
+        *store.list_dirs.lock().unwrap() = 0;
+
+        let arrays = group.child_arrays().unwrap();
+        assert_eq!(arrays.len(), 2, "should see real + phantom");
+
+        let gets = store.gets.lock().unwrap();
+        let list_dirs = *store.list_dirs.lock().unwrap();
+        assert_eq!(
+            gets.len(),
+            0,
+            "child_arrays should not perform any storage reads when consolidated metadata is present, got: {:?}",
+            *gets
+        );
+        assert_eq!(
+            list_dirs, 0,
+            "child_arrays should not perform any list_dir calls when consolidated metadata is present"
+        );
+
+        reset_config();
+    }
 }

--- a/zarrs/tests/hierarchy.rs
+++ b/zarrs/tests/hierarchy.rs
@@ -921,7 +921,9 @@ mod consolidated_open {
         .unwrap();
 
         let mut consolidated = ConsolidatedMetadata::default();
-        consolidated.metadata.insert("foo/".to_string(), bad_array_md);
+        consolidated
+            .metadata
+            .insert("foo/".to_string(), bad_array_md);
 
         let mut root = root;
         root.set_consolidated_metadata(Some(consolidated));
@@ -966,13 +968,15 @@ mod consolidated_open {
         )
         .unwrap();
         let mut consolidated = ConsolidatedMetadata::default();
-        consolidated.metadata.insert("foo/".to_string(), bad_array_md);
+        consolidated
+            .metadata
+            .insert("foo/".to_string(), bad_array_md);
 
         let mut consolidated_value = serde_json::to_value(&consolidated).unwrap();
-        consolidated_value
-            .as_object_mut()
-            .unwrap()
-            .insert("must_understand".to_string(), serde_json::Value::Bool(false));
+        consolidated_value.as_object_mut().unwrap().insert(
+            "must_understand".to_string(),
+            serde_json::Value::Bool(false),
+        );
         let root_md = serde_json::json!({
             "zarr_format": 3,
             "node_type": "group",
@@ -1094,10 +1098,10 @@ mod consolidated_open {
 
         let mut consolidated_value = serde_json::to_value(&consolidated).unwrap();
         // Mark the additional field as not must-understand so Group::async_open accepts it.
-        consolidated_value
-            .as_object_mut()
-            .unwrap()
-            .insert("must_understand".to_string(), serde_json::Value::Bool(false));
+        consolidated_value.as_object_mut().unwrap().insert(
+            "must_understand".to_string(),
+            serde_json::Value::Bool(false),
+        );
         let root_md = serde_json::json!({
             "zarr_format": 3,
             "node_type": "group",
@@ -1137,7 +1141,10 @@ mod consolidated_open {
             .map(|(p, _)| p.as_str().to_string())
             .collect();
         tpaths.sort();
-        assert_eq!(tpaths, vec!["/phantom".to_string(), "/subgroup".to_string()]);
+        assert_eq!(
+            tpaths,
+            vec!["/phantom".to_string(), "/subgroup".to_string()]
+        );
 
         // async_child_arrays — only the array.
         let arrays = group.async_child_arrays().await.unwrap();

--- a/zarrs/tests/hierarchy.rs
+++ b/zarrs/tests/hierarchy.rs
@@ -809,4 +809,205 @@ mod consolidated_open {
 
         reset_config();
     }
+
+    #[test]
+    #[serial]
+    fn group_must_errors_when_absent() {
+        reset_config();
+
+        // V3 group with no consolidated_metadata.
+        let store: Arc<MemoryStore> = Arc::new(MemoryStore::new());
+        let root = zarrs::group::GroupBuilder::default()
+            .build(store.clone(), "/")
+            .unwrap();
+        root.store_metadata().unwrap();
+
+        global_config_mut().set_use_consolidated_metadata(UseConsolidatedMetadata::Must);
+
+        let group = zarrs::group::Group::open(store.clone(), "/").unwrap();
+        let err = group
+            .children(false)
+            .expect_err("children should fail under Must when consolidated absent");
+        assert!(
+            err.to_string()
+                .contains("Consolidated metadata required but missing"),
+            "unexpected error: {err}"
+        );
+
+        let err = group
+            .traverse()
+            .expect_err("traverse should fail under Must when consolidated absent");
+        assert!(
+            err.to_string()
+                .contains("Consolidated metadata required but missing"),
+            "unexpected error: {err}"
+        );
+
+        // child_arrays propagates as ArrayCreateError — covers the
+        // From<NodeCreateError> for ArrayCreateError MissingConsolidatedMetadata arm.
+        let err = group
+            .child_arrays()
+            .expect_err("child_arrays should fail under Must when consolidated absent");
+        assert!(
+            err.to_string()
+                .contains("Consolidated metadata required but missing"),
+            "unexpected error: {err}"
+        );
+
+        // child_groups propagates as GroupCreateError — covers the
+        // From<NodeCreateError> for GroupCreateError MissingConsolidatedMetadata arm.
+        let err = group
+            .child_groups()
+            .expect_err("child_groups should fail under Must when consolidated absent");
+        assert!(
+            err.to_string()
+                .contains("Consolidated metadata required but missing"),
+            "unexpected error: {err}"
+        );
+
+        reset_config();
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    #[serial]
+    async fn async_group_consolidated_methods() {
+        use object_store::memory::InMemory;
+        use zarrs_object_store::AsyncObjectStore;
+        use zarrs_storage::AsyncWritableStorageTraits;
+
+        reset_config();
+
+        // Manually serialize a root v3 group with phantom + real children via consolidated metadata.
+        let phantom_md: NodeMetadata = serde_json::from_str(
+            r#"{
+                "zarr_format": 3,
+                "node_type": "array",
+                "shape": [42],
+                "data_type": "float32",
+                "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": [42]}},
+                "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/"}},
+                "fill_value": 0,
+                "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}]
+            }"#,
+        )
+        .unwrap();
+        let subgroup_md: NodeMetadata =
+            serde_json::from_str(r#"{"zarr_format": 3, "node_type": "group"}"#).unwrap();
+        let mut consolidated = ConsolidatedMetadata::default();
+        consolidated
+            .metadata
+            .insert("phantom".to_string(), phantom_md);
+        consolidated
+            .metadata
+            .insert("subgroup".to_string(), subgroup_md);
+
+        let mut consolidated_value = serde_json::to_value(&consolidated).unwrap();
+        // Mark the additional field as not must-understand so Group::async_open accepts it.
+        consolidated_value
+            .as_object_mut()
+            .unwrap()
+            .insert("must_understand".to_string(), serde_json::Value::Bool(false));
+        let root_md = serde_json::json!({
+            "zarr_format": 3,
+            "node_type": "group",
+            "consolidated_metadata": consolidated_value,
+        });
+
+        let store = Arc::new(AsyncObjectStore::new(InMemory::new()));
+        store
+            .set(
+                &StoreKey::new("zarr.json").unwrap(),
+                serde_json::to_vec(&root_md).unwrap().into(),
+            )
+            .await
+            .unwrap();
+
+        let group = zarrs::group::Group::async_open(store.clone(), "/")
+            .await
+            .unwrap();
+
+        // async_children(false) — direct children only, from inline map.
+        let direct = group.async_children(false).await.unwrap();
+        let mut names: Vec<_> = direct
+            .iter()
+            .map(|n| n.path().as_str().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["/phantom".to_string(), "/subgroup".to_string()]);
+
+        // async_children(true) — recursive (here equivalent since no nested children).
+        let tree = group.async_children(true).await.unwrap();
+        assert_eq!(tree.len(), 2);
+
+        // async_traverse — flat list.
+        let traversed = group.async_traverse().await.unwrap();
+        let mut tpaths: Vec<_> = traversed
+            .iter()
+            .map(|(p, _)| p.as_str().to_string())
+            .collect();
+        tpaths.sort();
+        assert_eq!(tpaths, vec!["/phantom".to_string(), "/subgroup".to_string()]);
+
+        // async_child_arrays — only the array.
+        let arrays = group.async_child_arrays().await.unwrap();
+        let array_paths: Vec<_> = arrays
+            .iter()
+            .map(|a| a.path().as_str().to_string())
+            .collect();
+        assert_eq!(array_paths, vec!["/phantom".to_string()]);
+
+        reset_config();
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    #[serial]
+    async fn async_group_must_errors_when_absent() {
+        use object_store::memory::InMemory;
+        use zarrs_object_store::AsyncObjectStore;
+        use zarrs_storage::AsyncWritableStorageTraits;
+
+        reset_config();
+
+        // V3 group with no consolidated_metadata.
+        let root_md = serde_json::json!({
+            "zarr_format": 3,
+            "node_type": "group",
+        });
+        let store = Arc::new(AsyncObjectStore::new(InMemory::new()));
+        store
+            .set(
+                &StoreKey::new("zarr.json").unwrap(),
+                serde_json::to_vec(&root_md).unwrap().into(),
+            )
+            .await
+            .unwrap();
+
+        global_config_mut().set_use_consolidated_metadata(UseConsolidatedMetadata::Must);
+
+        let group = zarrs::group::Group::async_open(store.clone(), "/")
+            .await
+            .unwrap();
+        let err = group
+            .async_children(false)
+            .await
+            .expect_err("async_children should fail under Must when consolidated absent");
+        assert!(
+            err.to_string()
+                .contains("Consolidated metadata required but missing"),
+            "unexpected error: {err}"
+        );
+        let err = group
+            .async_traverse()
+            .await
+            .expect_err("async_traverse should fail under Must when consolidated absent");
+        assert!(
+            err.to_string()
+                .contains("Consolidated metadata required but missing"),
+            "unexpected error: {err}"
+        );
+
+        reset_config();
+    }
 }


### PR DESCRIPTION
Add the ability to read from consolidated metadata with options to deactivate it and tests to verify everything.

Ran `just check` and everything is green. It'd be great to get this feature in, makes the initial zarr read a lot faster where consolidated metadata is available!