### PR TITLE
feat: add `NodePath::{is_root,parent,join}` and fix validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add a `microfloat` feature for expanded subfloat and complex subfloat data type / element support
   - The `float8` feature is considered deprecated as the associated types are not IEEE 754-compliant
+- Add `NodePath::is_root`, `NodePath::parent`, and `NodePath::join` for safer hierarchy path manipulation
 
 ### Changed
 - Bump `zarrs_metadata_ext` to 0.4.3
+
+### Fixed
+- `NodePath::validate` now rejects components starting with `__` (the reserved prefix) and components composed only of period characters (`.` / `..` / `...`), matching `NodeName` rules
 
 ## [0.23.10](https://github.com/zarrs/zarrs/releases/tag/zarrs-v0.23.10) - 2026-04-09
 

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -335,7 +335,7 @@ impl Node {
     /// Indicates if a node is the root.
     #[must_use]
     pub fn is_root(&self) -> bool {
-        self.path.as_str().eq("/")
+        self.path.is_root()
     }
 
     /// Returns the name of the node.

--- a/zarrs/src/node/node_path.rs
+++ b/zarrs/src/node/node_path.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use derive_more::Display;
 use thiserror::Error;
 
+use super::NodeName;
 use zarrs_storage::{StorePrefix, StorePrefixError};
 
 /// A Zarr hierarchy node path.
@@ -54,10 +55,68 @@ impl NodePath {
     /// - A path always starts with `/`, and
     /// - a non-root path cannot end with `/`, because node names must be non-empty and cannot contain `/`.
     ///
-    /// Additionally, it checks that there are no empty nodes (i.e. a `//` substring).
+    /// Additionally, every path component must be a valid [`NodeName`]:
+    /// - must not start with the reserved prefix `__`, and
+    /// - must not be composed only of period characters (`.` or `..`).
     #[must_use]
     pub fn validate(path: &str) -> bool {
-        path.eq("/") || (path.starts_with('/') && !path.ends_with('/') && !path.contains("//"))
+        if path == "/" {
+            return true;
+        }
+        if !path.starts_with('/') || path.ends_with('/') {
+            return false;
+        }
+        for component in path[1..].split('/') {
+            // An empty component means a `//` substring — reject it before checking
+            // NodeName rules (where empty is valid for the root node name).
+            if component.is_empty() || !NodeName::validate(component) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Returns `true` if this is the root path.
+    #[must_use]
+    pub fn is_root(&self) -> bool {
+        self.0.as_os_str() == "/"
+    }
+
+    /// Returns the parent path of this node, or `None` if this is the root path.
+    #[must_use]
+    pub fn parent(&self) -> Option<Self> {
+        self.0.parent().and_then(|p| {
+            if p.as_os_str().is_empty() {
+                // `PathBuf::parent("/")` returns `Some("")` — root has no parent.
+                None
+            } else {
+                let s = p.to_string_lossy();
+                Self::new(&s).ok()
+            }
+        })
+    }
+
+    /// Creates a new path by joining `relative` to this path.
+    ///
+    /// The `relative` argument should be a relative path segment (e.g., `"sub/foo"` or `"bar"`).
+    /// A leading `/` in `relative` is stripped.
+    ///
+    /// Returns an error if the resulting path is invalid according to [`NodePath::validate`].
+    pub fn join(&self, relative: &str) -> Result<Self, NodePathError> {
+        // Strip leading slash if present
+        let relative = relative.strip_prefix('/').unwrap_or(relative);
+        if relative.is_empty() {
+            return Ok(self.clone());
+        }
+
+        let mut path_buf = self.0.clone();
+        path_buf.push(relative);
+        let joined = path_buf.to_string_lossy().to_string();
+        if Self::validate(&joined) {
+            Ok(Self(path_buf))
+        } else {
+            Err(NodePathError(joined))
+        }
     }
 }
 
@@ -109,5 +168,123 @@ mod tests {
         );
         assert!(NodePath::new("/a//b").is_err());
         assert_eq!(NodePath::new("/a/b").unwrap().as_path(), Path::new("/a/b/"));
+    }
+
+    #[test]
+    fn node_path_is_root() {
+        assert!(NodePath::root().is_root());
+        assert!(NodePath::new("/").unwrap().is_root());
+        assert!(!NodePath::new("/foo").unwrap().is_root());
+        assert!(!NodePath::new("/a/b/c").unwrap().is_root());
+    }
+
+    #[test]
+    fn node_path_validate_rejects_invalid_components() {
+        // Reserved prefix `__`
+        assert!(!NodePath::validate("/__foo"));
+        assert!(!NodePath::validate("/foo/__bar"));
+        assert!(!NodePath::validate("/foo/__bar/baz"));
+
+        // Period-only names
+        assert!(!NodePath::validate("/."));
+        assert!(!NodePath::validate("/.."));
+        assert!(!NodePath::validate("/foo/../bar"));
+        assert!(!NodePath::validate("/..."));
+        assert!(!NodePath::validate("////"));
+
+        // Valid paths still pass
+        assert!(NodePath::validate("/"));
+        assert!(NodePath::validate("/a/b"));
+        assert!(NodePath::validate("/foo__bar")); // `__` not at start is OK
+        assert!(NodePath::validate("/foo./bar")); // `.` not the only char is OK
+        assert!(NodePath::validate("/foo/bar..")); // `..` not the only char is OK
+    }
+
+    #[test]
+    fn node_path_join() {
+        // Base root
+        let root = NodePath::root();
+        assert_eq!(root.join("foo").unwrap().as_str(), "/foo");
+        assert_eq!(root.join("sub/leaf").unwrap().as_str(), "/sub/leaf");
+        // Leading slash stripped
+        assert_eq!(root.join("/foo").unwrap().as_str(), "/foo");
+        // Empty relative returns clone
+        assert_eq!(root.join("").unwrap(), root);
+
+        // Non-root base
+        let base = NodePath::new("/group").unwrap();
+        assert_eq!(base.join("sub").unwrap().as_str(), "/group/sub");
+        assert_eq!(base.join("sub/leaf").unwrap().as_str(), "/group/sub/leaf");
+        assert_eq!(base.join("/sub").unwrap().as_str(), "/group/sub");
+
+        // Reject `.` components (period-only)
+        assert!(NodePath::new("/foo").unwrap().join("./bar").is_err());
+        assert!(root.join("./bar").is_err());
+
+        // Reject `..` components (period-only)
+        assert!(root.join("../bar").is_err());
+        assert!(base.join("sub/../other").is_err());
+        assert!(base.join("../other").is_err());
+
+        // Reject `...` (period-only)
+        assert!(root.join(".../bar").is_err());
+
+        // Reject empty components (from `//`)
+        assert!(root.join("foo//bar").is_err());
+
+        // Reject trailing slash (becomes empty component after split)
+        assert!(root.join("foo/").is_err());
+
+        // Reject `__` reserved prefix
+        assert!(root.join("__bar").is_err());
+        assert!(root.join("foo/__bar").is_err());
+    }
+
+    #[test]
+    fn node_path_join_valid_prefixes() {
+        // `__` not at start is valid
+        assert_eq!(
+            NodePath::root().join("foo__bar").unwrap().as_str(),
+            "/foo__bar"
+        );
+        assert_eq!(
+            NodePath::root().join("foo__bar/baz").unwrap().as_str(),
+            "/foo__bar/baz"
+        );
+
+        // `.` or `..` not the only chars is valid
+        assert_eq!(NodePath::root().join("foo.").unwrap().as_str(), "/foo.");
+        assert_eq!(NodePath::root().join("..foo").unwrap().as_str(), "/..foo");
+        assert_eq!(NodePath::root().join("foo..").unwrap().as_str(), "/foo..");
+    }
+
+    #[test]
+    fn node_path_parent() {
+        // Root has no parent
+        assert!(NodePath::root().parent().is_none());
+
+        // Direct child of root
+        assert_eq!(
+            NodePath::new("/foo").unwrap().parent().unwrap().as_str(),
+            "/"
+        );
+
+        // Nested
+        assert_eq!(
+            NodePath::new("/foo/bar")
+                .unwrap()
+                .parent()
+                .unwrap()
+                .as_str(),
+            "/foo"
+        );
+        assert_eq!(
+            NodePath::new("/foo/bar/baz")
+                .unwrap()
+                .parent()
+                .unwrap()
+                .as_str(),
+            "/foo/bar"
+        );
     }
 }

--- a/zarrs/src/node/node_path.rs
+++ b/zarrs/src/node/node_path.rs
@@ -85,15 +85,17 @@ impl NodePath {
     /// Returns the parent path of this node, or `None` if this is the root path.
     #[must_use]
     pub fn parent(&self) -> Option<Self> {
-        self.0.parent().and_then(|p| {
-            if p.as_os_str().is_empty() {
-                // `PathBuf::parent("/")` returns `Some("")` — root has no parent.
-                None
-            } else {
-                let s = p.to_string_lossy();
-                Self::new(&s).ok()
-            }
-        })
+        let s = self.as_str();
+        let (parent, child) = s.rsplit_once('/')?;
+        if child.is_empty() {
+            // Root path (`/`) splits into `("", "")` — no parent.
+            None
+        } else if parent.is_empty() {
+            // Direct child of root (`/foo`) — parent is root.
+            Some(Self::root())
+        } else {
+            Self::new(parent).ok()
+        }
     }
 
     /// Creates a new path by joining `relative` to this path.
@@ -109,14 +111,21 @@ impl NodePath {
             return Ok(self.clone());
         }
 
-        let mut path_buf = self.0.clone();
-        path_buf.push(relative);
-        let joined = path_buf.to_string_lossy().to_string();
-        if Self::validate(&joined) {
-            Ok(Self(path_buf))
-        } else {
-            Err(NodePathError(joined))
+        // Reject components that are empty (from `//` or trailing `/`), start with `__`, or are period-only (`.` / `..`).
+        for component in relative.split('/') {
+            if component.is_empty() || !NodeName::validate(component) {
+                return Err(NodePathError(format!(
+                    "invalid node name `{component}` in '{relative}'"
+                )));
+            }
         }
+
+        let joined = if self.is_root() {
+            format!("/{}", relative)
+        } else {
+            format!("{}/{}", self.as_str(), relative)
+        };
+        Self::new(&joined)
     }
 }
 


### PR DESCRIPTION
Validation was not strict enough before.

These methods could tidy up the string logic in #376.