### PR TITLE
refactor: always enable sharding codec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           toolchain: "stable"
           targets: "wasm32-unknown-unknown"
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --target wasm32-unknown-unknown --no-default-features --features "ndarray crc32c gzip sharding transpose async zstd blosc"
+      - run: cargo build --target wasm32-unknown-unknown --no-default-features --features "ndarray crc32c gzip transpose async zstd blosc"
         working-directory: ./zarrs
   test_windows:
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implement `IntoArrayBytes` for `&ndarray::ArrayBase`
 
+### Changed
+- Soft deprecate the `sharding` feature flag
+  - The sharding codec and associated utilities are now always available and no longer require opting in via the `sharding` feature
+
 ## [0.23.12](https://github.com/zarrs/zarrs/releases/tag/zarrs-v0.23.12) - 2026-05-16
 
 ### Added

--- a/justfile
+++ b/justfile
@@ -34,11 +34,11 @@ check: build test clippy doc
 
 # Build (WASM)
 build_wasm:
-    cargo check -p zarrs --target wasm32-unknown-unknown --no-default-features --features "ndarray crc32c gzip sharding transpose async"
+    cargo check -p zarrs --target wasm32-unknown-unknown --no-default-features --features "ndarray crc32c gzip transpose async"
 
 # Build/clippy (WASM)
 check_wasm: build_wasm
-    cargo clippy -p zarrs --target wasm32-unknown-unknown --no-default-features --features "ndarray crc32c gzip sharding transpose async" -- -A clippy::arc_with_non_send_sync
+    cargo clippy -p zarrs --target wasm32-unknown-unknown --no-default-features --features "ndarray crc32c gzip transpose async" -- -A clippy::arc_with_non_send_sync
 
 # Run clippy with extra lints
 _clippy_extra:

--- a/zarrs/Cargo.toml
+++ b/zarrs/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["encoding", "science"]
 exclude = [".github/", "doc/TODO.md", "tests/"]
 
 [features]
-default = ["filesystem", "ndarray", "blosc", "crc32c", "gzip", "transpose", "zstd"]
+default = ["filesystem", "ndarray", "blosc", "crc32c", "gzip", "sharding", "transpose", "zstd"]
 filesystem = ["dep:zarrs_filesystem"] # Re-export zarrs_filesystem as zarrs::filesystem
 adler32 = ["dep:simd-adler32"] # Enable the adler32 checksum codec
 bitround = [] # Enable the bitround codec

--- a/zarrs/Cargo.toml
+++ b/zarrs/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["encoding", "science"]
 exclude = [".github/", "doc/TODO.md", "tests/"]
 
 [features]
-default = ["filesystem", "ndarray", "blosc", "crc32c", "gzip", "sharding", "transpose", "zstd"]
+default = ["filesystem", "ndarray", "blosc", "crc32c", "gzip", "transpose", "zstd"]
 filesystem = ["dep:zarrs_filesystem"] # Re-export zarrs_filesystem as zarrs::filesystem
 adler32 = ["dep:simd-adler32"] # Enable the adler32 checksum codec
 bitround = [] # Enable the bitround codec
@@ -25,7 +25,7 @@ fletcher32 = [] # Enable the fletcher32 checksum codec
 gdeflate = ["dep:gdeflate-sys"] # Enable the experimental gdeflate codec
 gzip = ["dep:flate2"] # Enable the gzip codec
 pcodec = ["dep:pco"] # Enable the pcodec codec
-sharding = [] # Enable the sharding codec
+sharding = [] # Enable the sharding codec (DEPRECATED, now always enabled)
 transpose = ["dep:ndarray"] # Enable the transpose codec
 zfp = ["dep:zfp-sys"] # Enable the zfp codec
 zlib = ["dep:flate2"] # Enable the zlib codec
@@ -168,7 +168,7 @@ doc-scrape-examples = true
 
 [[example]]
 name = "sharded_array_write_read"
-required-features = ["filesystem", "ndarray", "sharding"]
+required-features = ["filesystem", "ndarray"]
 
 [[bench]]
 name = "array_subset"
@@ -193,4 +193,4 @@ harness = false
 [[bench]]
 name = "sharded_partial_read"
 harness = false
-required-features = ["sharding", "filesystem"]
+required-features = ["filesystem"]

--- a/zarrs/doc/status/codecs.md
+++ b/zarrs/doc/status/codecs.md
@@ -7,7 +7,7 @@
 |                | 🚧[`zarrs.squeeze`]                | -                                   |               |
 | Array to Bytes | [`bytes`]                          | (implicit array-to-bytes)           |               |
 |                | 🚧[`zarrs.optional`]               | -                                   |               |
-|                | [`sharding_indexed`]               | -                                   | **sharding**  |
+|                | [`sharding_indexed`]               | -                                   |               |
 |                | 🚧[`vlen-array`]                   | `vlen-array`                        |               |
 |                | [`vlen-bytes`]                     | `vlen-bytes`                        |               |
 |                | [`vlen-utf8`]                      | `vlen-utf8`                         |               |

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -40,9 +40,7 @@ pub mod storage_transformer;
 
 #[cfg(feature = "dlpack")]
 mod array_dlpack_ext;
-#[cfg(feature = "sharding")]
 mod array_sharded_ext;
-#[cfg(feature = "sharding")]
 mod array_sync_sharded_readable_ext;
 
 use std::borrow::Cow;
@@ -103,13 +101,11 @@ pub use self::from_array_bytes::FromArrayBytes;
 pub use self::into_array_bytes::IntoArrayBytes;
 pub use self::storage_transformer::{StorageTransformerChain, StorageTransformerTraits};
 pub use self::tensor::{Tensor, TensorError};
-#[cfg(all(feature = "sharding", feature = "async"))]
+#[cfg(feature = "async")]
 pub use array_async_sharded_readable_ext::{
     AsyncArrayShardedReadableExt, AsyncArrayShardedReadableExtCache,
 };
-#[cfg(feature = "sharding")]
 pub use array_sharded_ext::ArrayShardedExt;
-#[cfg(feature = "sharding")]
 pub use array_sync_sharded_readable_ext::{ArrayShardedReadableExt, ArrayShardedReadableExtCache};
 
 /// Convert a [`ChunkShape`] reference to an [`ArrayShape`].
@@ -1308,7 +1304,7 @@ mod array_async_writable;
 #[cfg(feature = "async")]
 mod array_async_readable_writable;
 
-#[cfg(all(feature = "sharding", feature = "async"))]
+#[cfg(feature = "async")]
 mod array_async_sharded_readable_ext;
 
 /// Transmute from `&[u8]` to `Vec<T>`.

--- a/zarrs/src/array/builder.rs
+++ b/zarrs/src/array/builder.rs
@@ -121,7 +121,6 @@ pub struct ArrayBuilder {
     /// Additional fields.
     additional_fields: AdditionalFieldsV3,
     /// Subchunk (inner chunk) shape for sharding.
-    #[cfg(feature = "sharding")]
     subchunk_shape: Option<ArrayShape>,
     /// Codec options.
     codec_options: CodecOptions,
@@ -172,7 +171,6 @@ impl ArrayBuilder {
             storage_transformers: StorageTransformerChain::default(),
             dimension_names: None,
             additional_fields: AdditionalFieldsV3::default(),
-            #[cfg(feature = "sharding")]
             subchunk_shape: None,
             codec_options,
             codec_specific_options: CodecSpecificOptions::default(),
@@ -207,7 +205,6 @@ impl ArrayBuilder {
             storage_transformers: StorageTransformerChain::default(),
             dimension_names: None,
             additional_fields: AdditionalFieldsV3::default(),
-            #[cfg(feature = "sharding")]
             subchunk_shape: None,
             codec_options,
             codec_specific_options: CodecSpecificOptions::default(),
@@ -384,7 +381,6 @@ impl ArrayBuilder {
     /// .build(store, "/array")
     /// .unwrap();
     /// ```
-    #[cfg(feature = "sharding")]
     pub fn subchunk_shape(&mut self, subchunk_shape: impl Into<Option<ArrayShape>>) -> &mut Self {
         self.subchunk_shape = subchunk_shape.into();
         self
@@ -546,7 +542,6 @@ impl ArrayBuilder {
             .unwrap_or_else(|| super::codec::default_array_to_bytes_codec(&data_type));
 
         // If subchunk_shape is set, wrap the codec chain with a sharding codec
-        #[cfg(feature = "sharding")]
         let codec_chain = if let Some(subchunk_shape) = &self.subchunk_shape {
             use super::codec::array_to_bytes::sharding::ShardingCodecBuilder;
 
@@ -572,13 +567,6 @@ impl ArrayBuilder {
                 self.bytes_to_bytes_codecs.clone(),
             )
         };
-
-        #[cfg(not(feature = "sharding"))]
-        let codec_chain = CodecChain::new(
-            self.array_to_array_codecs.clone(),
-            array_to_bytes_codec,
-            self.bytes_to_bytes_codecs.clone(),
-        );
 
         Ok(codec_chain)
     }
@@ -922,7 +910,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "sharding")]
     fn array_builder_codec_specific_options_impl(
         write_order: crate::array::codec::array_to_bytes::sharding::SubchunkWriteOrder,
     ) {
@@ -953,20 +940,18 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "sharding")]
     fn array_builder_codec_specific_options_random() {
         use crate::array::codec::array_to_bytes::sharding::SubchunkWriteOrder;
         array_builder_codec_specific_options_impl(SubchunkWriteOrder::Random);
     }
 
     #[test]
-    #[cfg(feature = "sharding")]
     fn array_builder_codec_specific_options_c() {
         use crate::array::codec::array_to_bytes::sharding::SubchunkWriteOrder;
         array_builder_codec_specific_options_impl(SubchunkWriteOrder::C);
     }
 
-    #[cfg(all(feature = "sharding", feature = "zstd"))]
+    #[cfg(feature = "zstd")]
     fn array_builder_codec_options_preserved_from_codec_object_impl(
         write_order: crate::array::codec::array_to_bytes::sharding::SubchunkWriteOrder,
     ) {
@@ -1029,14 +1014,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "sharding", feature = "zstd"))]
+    #[cfg(feature = "zstd")]
     fn array_builder_codec_options_preserved_from_codec_object_random() {
         use crate::array::codec::array_to_bytes::sharding::SubchunkWriteOrder;
         array_builder_codec_options_preserved_from_codec_object_impl(SubchunkWriteOrder::Random);
     }
 
     #[test]
-    #[cfg(all(feature = "sharding", feature = "zstd"))]
+    #[cfg(feature = "zstd")]
     fn array_builder_codec_options_preserved_from_codec_object_c() {
         use crate::array::codec::array_to_bytes::sharding::SubchunkWriteOrder;
         array_builder_codec_options_preserved_from_codec_object_impl(SubchunkWriteOrder::C);

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -33,7 +33,6 @@ pub use array_to_bytes::optional::*;
 pub use array_to_bytes::packbits::*;
 #[cfg(feature = "pcodec")]
 pub use array_to_bytes::pcodec::*;
-#[cfg(feature = "sharding")]
 pub use array_to_bytes::sharding::*;
 pub use array_to_bytes::vlen::*;
 pub use array_to_bytes::vlen_array::*;

--- a/zarrs/src/array/codec/array_to_bytes.rs
+++ b/zarrs/src/array/codec/array_to_bytes.rs
@@ -12,7 +12,6 @@ pub mod vlen_v2;
 
 #[cfg(feature = "pcodec")]
 pub mod pcodec;
-#[cfg(feature = "sharding")]
 pub mod sharding;
 #[cfg(feature = "zfp")]
 pub mod zfp;

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec_builder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec_builder.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use super::{ShardingCodec, ShardingIndexLocation};
-use crate::array::codec::{BytesCodec, CodecChain, Crc32cCodec, default_array_to_bytes_codec};
+#[cfg(feature = "crc32c")]
+use crate::array::codec::Crc32cCodec;
+use crate::array::codec::{BytesCodec, CodecChain, default_array_to_bytes_codec};
 use crate::array::{ChunkShape, DataType};
 use zarrs_codec::{ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, BytesToBytesCodecTraits};
 

--- a/zarrs/src/lib.rs
+++ b/zarrs/src/lib.rs
@@ -195,7 +195,7 @@
 //! #### Default
 //!  - `filesystem`: Re-export [`zarrs_filesystem`] as [`zarrs::filesystem`](crate::filesystem`).
 //!  - `ndarray`: [`ndarray`] utility functions for [`Array`](crate::array::Array).
-//!  - Codecs: `blosc`, `crc32c`, `gzip`, `sharding`, `transpose`, `zstd`.
+//!  - Codecs: `blosc`, `crc32c`, `gzip`, `transpose`, `zstd`.
 //!
 //! #### Non-Default
 //!  - `async`: an **experimental** asynchronous API for [`stores`](storage), [`Array`](crate::array::Array), and [`Group`](group::Group).

--- a/zarrs/tests/array_async.rs
+++ b/zarrs/tests/array_async.rs
@@ -25,7 +25,6 @@ async fn array_async_read(shard: bool) -> Result<(), Box<dyn std::error::Error>>
     );
     // builder.storage_transformers(vec![].into());
     if shard {
-        #[cfg(feature = "sharding")]
         builder
             .subchunk_shape(vec![1, 1])
             .bytes_to_bytes_codecs(vec![
@@ -386,7 +385,6 @@ async fn array_async_read_into_uncompressed() -> Result<(), Box<dyn std::error::
     array_async_read_into(&array).await
 }
 
-#[cfg(feature = "sharding")]
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn array_async_read_into_sharded() -> Result<(), Box<dyn std::error::Error>> {

--- a/zarrs/tests/array_partial_encode.rs
+++ b/zarrs/tests/array_partial_encode.rs
@@ -1,5 +1,4 @@
 #![allow(missing_docs)]
-#![cfg(feature = "sharding")]
 
 use std::num::NonZeroU64;
 use std::sync::Arc;

--- a/zarrs/tests/array_sync.rs
+++ b/zarrs/tests/array_sync.rs
@@ -132,7 +132,6 @@ fn array_sync_read_uncompressed() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(feature = "sharding")]
 #[test]
 #[cfg_attr(miri, ignore)]
 fn array_sync_read_shard_compress() -> Result<(), Box<dyn std::error::Error>> {
@@ -276,7 +275,6 @@ fn array_str_sync_simple() -> Result<(), Box<dyn std::error::Error>> {
     array_str_impl(array)
 }
 
-#[cfg(feature = "sharding")]
 #[test]
 fn array_str_sync_sharded_transpose() -> Result<(), Box<dyn std::error::Error>> {
     use zarrs::array::codec::array_to_bytes::vlen::VlenCodec;
@@ -527,7 +525,6 @@ fn array_sync_read_into_uncompressed() -> Result<(), Box<dyn std::error::Error>>
     array_sync_read_into(&array)
 }
 
-#[cfg(feature = "sharding")]
 #[test]
 #[cfg_attr(miri, ignore)]
 fn array_sync_read_into_sharded() -> Result<(), Box<dyn std::error::Error>> {

--- a/zarrs/tests/cities.rs
+++ b/zarrs/tests/cities.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-#![cfg(all(feature = "sharding", feature = "zstd"))]
+#![cfg(feature = "zstd")]
 
 use std::error::Error;
 use std::fs::File;

--- a/zarrs/tests/codec_snapshot_tests.rs
+++ b/zarrs/tests/codec_snapshot_tests.rs
@@ -1593,7 +1593,6 @@ fn codec_registry() -> Vec<CodecDef> {
         dt.as_optional().is_some()
     }
 
-    #[cfg(feature = "sharding")]
     codecs.push(CodecDef {
         name: ShardingCodec::aliases_v3().default_name.clone(),
         category: CodecCategory::ArrayToBytes,

--- a/zarrs_conformance/Cargo.toml
+++ b/zarrs_conformance/Cargo.toml
@@ -25,7 +25,6 @@ zarrs = { path = "../zarrs", features = [
     "gdeflate",
     "gzip",
     "pcodec",
-    "sharding",
     "transpose",
     "zfp",
     "zlib",


### PR DESCRIPTION
The `sharding` feature is soft deprecated.