### PR TITLE
refactor!: extend `ChunkCache` with `partial_decoder` and `retrieve_chunk[_bytes]_if_exists` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Soft deprecate the `sharding` feature flag
   - The sharding codec and associated utilities are now always available and no longer require opting in via the `sharding` feature
 - **Breaking**: `ArrayShardedExt::subchunk_grid` now returns a reference
-- **Breaking**: Add required `ChunkCache::partial_decoder` trait method
+- **Breaking**: Change `ChunkCacheTypeDecoded` to an `Option`
+- **Breaking**: Refactor `ChunkCache` trait:
+  - **Breaking**: Add required `partial_decoder` method
+  - **Breaking**: Add required `retrieve_chunk_bytes_if_exists` method
+  - Add `retrieve_chunk_if_exists`
+  - **Breaking**: Methods returning `ChunkCacheTypeDecoded` now return `Arc<ArrayBytes<'static>>`
 
 ### Removed
 - Remove deprecated `Array`, `ArrayShardedReadableExt`, `AsyncArrayShardedReadableExt`, and `ChunkCache` `_elements` / `_ndarray` method variants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Soft deprecate the `sharding` feature flag
   - The sharding codec and associated utilities are now always available and no longer require opting in via the `sharding` feature
 - **Breaking**: `ArrayShardedExt::subchunk_grid` now returns a reference
+- **Breaking**: Add required `ChunkCache::partial_decoder` trait method
 
 ### Removed
 - Remove deprecated `Array`, `ArrayShardedReadableExt`, `AsyncArrayShardedReadableExt`, and `ChunkCache` `_elements` / `_ndarray` method variants

--- a/zarrs/src/array/chunk_cache.rs
+++ b/zarrs/src/array/chunk_cache.rs
@@ -22,6 +22,7 @@
 //! `zarrs` consumers can create custom caches by implementing the [`ChunkCache`] trait.
 //!
 //! Chunk caches implement the [`ChunkCache`] trait which has cached versions of the equivalent [`Array`] methods:
+//!  - [`retrieve_chunk_if_exists`](ChunkCache::retrieve_chunk_if_exists)
 //!  - [`retrieve_chunk`](ChunkCache::retrieve_chunk)
 //!  - [`retrieve_chunks`](ChunkCache::retrieve_chunks)
 //!  - [`retrieve_chunk_subset`](ChunkCache::retrieve_chunk_subset)
@@ -65,7 +66,7 @@ pub use chunk_cache_lru::*;
 pub type ChunkCacheTypeEncoded = Option<Arc<ArrayBytesRaw<'static>>>;
 
 /// The chunk type of a decoded chunk cache.
-pub type ChunkCacheTypeDecoded = Arc<ArrayBytes<'static>>;
+pub type ChunkCacheTypeDecoded = Option<Arc<ArrayBytes<'static>>>;
 
 /// The chunk type of a partial decoder chunk cache.
 pub type ChunkCacheTypePartialDecoder = Arc<dyn ArrayPartialDecoderTraits>;
@@ -84,7 +85,7 @@ impl ChunkCacheType for ChunkCacheTypeEncoded {
 
 impl ChunkCacheType for ChunkCacheTypeDecoded {
     fn size(&self) -> usize {
-        ArrayBytes::size(self)
+        self.as_ref().map_or(0, |v| v.size())
     }
 }
 
@@ -109,13 +110,42 @@ pub trait ChunkCache: MaybeSend + MaybeSync {
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError>;
 
+    /// Cached variant of [`retrieve_chunk_if_exists_opt`](Array::retrieve_chunk_if_exists_opt) returning the cached bytes.
+    #[allow(clippy::missing_errors_doc)]
+    fn retrieve_chunk_bytes_if_exists(
+        &self,
+        chunk_indices: &[u64],
+        options: &CodecOptions,
+    ) -> Result<Option<Arc<ArrayBytes<'static>>>, ArrayError>;
+
     /// Cached variant of [`retrieve_chunk_opt`](Array::retrieve_chunk_opt) returning the cached bytes.
     #[allow(clippy::missing_errors_doc)]
     fn retrieve_chunk_bytes(
         &self,
         chunk_indices: &[u64],
         options: &CodecOptions,
-    ) -> Result<ChunkCacheTypeDecoded, ArrayError>;
+    ) -> Result<Arc<ArrayBytes<'static>>, ArrayError>;
+
+    /// Cached variant of [`retrieve_chunk_if_exists_opt`](Array::retrieve_chunk_if_exists_opt).
+    #[allow(clippy::missing_errors_doc)]
+    fn retrieve_chunk_if_exists<T: FromArrayBytes>(
+        &self,
+        chunk_indices: &[u64],
+        options: &CodecOptions,
+    ) -> Result<Option<T>, ArrayError>
+    where
+        Self: Sized,
+    {
+        let Some(bytes) = self.retrieve_chunk_bytes_if_exists(chunk_indices, options)? else {
+            return Ok(None);
+        };
+        let shape = self
+            .array()
+            .chunk_grid()
+            .chunk_shape_u64(chunk_indices)?
+            .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
+        T::from_array_bytes_arc(bytes, &shape, self.array().data_type()).map(Some)
+    }
 
     /// Cached variant of [`retrieve_chunk_opt`](Array::retrieve_chunk_opt).
     #[allow(clippy::missing_errors_doc)]
@@ -143,7 +173,7 @@ pub trait ChunkCache: MaybeSend + MaybeSync {
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<ChunkCacheTypeDecoded, ArrayError>;
+    ) -> Result<Arc<ArrayBytes<'static>>, ArrayError>;
 
     /// Cached variant of [`retrieve_chunk_subset_opt`](Array::retrieve_chunk_subset_opt).
     #[allow(clippy::missing_errors_doc)]
@@ -167,7 +197,7 @@ pub trait ChunkCache: MaybeSend + MaybeSync {
         &self,
         array_subset: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
+    ) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
         let array = self.array();
         if array_subset.dimensionality() != array.dimensionality() {
             return Err(ArrayError::InvalidArraySubset(
@@ -269,7 +299,7 @@ pub trait ChunkCache: MaybeSend + MaybeSync {
         &self,
         chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
+    ) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
         if chunks.dimensionality() != self.array().dimensionality() {
             return Err(IncompatibleDimensionalityError::new(
                 chunks.dimensionality(),
@@ -317,7 +347,7 @@ fn retrieve_multi_chunk_variable_impl<CC: ChunkCache + ?Sized>(
     chunks: &dyn ArraySubsetTraits,
     chunk_concurrent_limit: usize,
     options: &CodecOptions,
-) -> Result<ChunkCacheTypeDecoded, ArrayError> {
+) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
     let nesting_depth = optional_nesting_depth(array.data_type());
 
     // Retrieve chunks for variable-length data
@@ -378,7 +408,7 @@ fn retrieve_multi_chunk_fixed_impl<CC: ChunkCache + ?Sized>(
     chunks: &dyn ArraySubsetTraits,
     chunk_concurrent_limit: usize,
     options: &CodecOptions,
-) -> Result<ChunkCacheTypeDecoded, ArrayError> {
+) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
     // Allocate data buffer and optional mask buffer
     let data_type_size = array
         .data_type()

--- a/zarrs/src/array/chunk_cache.rs
+++ b/zarrs/src/array/chunk_cache.rs
@@ -99,6 +99,18 @@ pub trait ChunkCache: MaybeSend + MaybeSync {
     /// Return the array associated with the chunk cache.
     fn array(&self) -> Arc<Array<dyn ReadableStorageTraits>>;
 
+    /// Cached variant of [`partial_decoder`](Array::partial_decoder).
+    ///
+    /// If a partial decoder is cached, subsequent calls will use the `options` of the first call that cached the partial decoder, and the `options` argument of subsequent calls will be ignored.
+    #[allow(clippy::missing_errors_doc)]
+    fn partial_decoder(
+        &self,
+        chunk_indices: &[u64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
+        self.array().partial_decoder_opt(chunk_indices, options)
+    }
+
     /// Cached variant of [`retrieve_chunk_opt`](Array::retrieve_chunk_opt) returning the cached bytes.
     #[allow(clippy::missing_errors_doc)]
     fn retrieve_chunk_bytes(

--- a/zarrs/src/array/chunk_cache.rs
+++ b/zarrs/src/array/chunk_cache.rs
@@ -107,9 +107,7 @@ pub trait ChunkCache: MaybeSend + MaybeSync {
         &self,
         chunk_indices: &[u64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
-        self.array().partial_decoder_opt(chunk_indices, options)
-    }
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError>;
 
     /// Cached variant of [`retrieve_chunk_opt`](Array::retrieve_chunk_opt) returning the cached bytes.
     #[allow(clippy::missing_errors_doc)]

--- a/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::array::{
     Array, ArrayBytes, ArrayError, ArrayIndices, ArraySubset, ArraySubsetTraits, ChunkShape,
-    ChunkShapeTraits, DataType, Indexer,
+    ChunkShapeTraits, DataType, FillValue, Indexer,
 };
 use zarrs_codec::{ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecError};
 use zarrs_storage::{ReadableStorageTraits, StorageError};
@@ -38,14 +38,21 @@ struct CachedArrayBytesPartialDecoder {
     bytes: ChunkCacheTypeDecoded,
     shape: ChunkShape,
     data_type: DataType,
+    fill_value: FillValue,
 }
 
 impl CachedArrayBytesPartialDecoder {
-    fn new(bytes: ChunkCacheTypeDecoded, shape: ChunkShape, data_type: DataType) -> Self {
+    fn new(
+        bytes: ChunkCacheTypeDecoded,
+        shape: ChunkShape,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Self {
         Self {
             bytes,
             shape,
             data_type,
+            fill_value,
         }
     }
 }
@@ -56,7 +63,7 @@ impl ArrayPartialDecoderTraits for CachedArrayBytesPartialDecoder {
     }
 
     fn exists(&self) -> Result<bool, StorageError> {
-        Ok(true)
+        Ok(self.bytes.is_some())
     }
 
     fn size_held(&self) -> usize {
@@ -68,16 +75,40 @@ impl ArrayPartialDecoderTraits for CachedArrayBytesPartialDecoder {
         indexer: &dyn Indexer,
         _options: &zarrs_codec::CodecOptions,
     ) -> Result<ArrayBytes<'_>, CodecError> {
-        Ok(self.bytes.extract_array_subset(
-            indexer,
-            bytemuck::must_cast_slice(&self.shape),
-            &self.data_type,
-        )?)
+        if let Some(bytes) = &self.bytes {
+            Ok(bytes.extract_array_subset(
+                indexer,
+                bytemuck::must_cast_slice(&self.shape),
+                &self.data_type,
+            )?)
+        } else {
+            Ok(ArrayBytes::new_fill_value(
+                &self.data_type,
+                indexer.len(),
+                &self.fill_value,
+            )?)
+        }
     }
 
     fn supports_partial_decode(&self) -> bool {
         true
     }
+}
+
+fn fill_value_chunk(
+    array: &Array<dyn ReadableStorageTraits>,
+    chunk_indices: &[u64],
+) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
+    let chunk_shape = array.chunk_shape(chunk_indices)?;
+    Ok(Arc::new(
+        ArrayBytes::new_fill_value(
+            array.data_type(),
+            chunk_shape.num_elements_u64(),
+            array.fill_value(),
+        )
+        .map_err(CodecError::from)
+        .map_err(ArrayError::from)?,
+    ))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -198,12 +229,12 @@ macro_rules! impl_ChunkCacheLruEncoded {
             )?)
         }
 
-        fn retrieve_chunk_bytes(
+        fn retrieve_chunk_bytes_if_exists(
             &self,
             chunk_indices: &[u64],
             options: &zarrs_codec::CodecOptions,
-        ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
-            let chunk_encoded = self
+        ) -> Result<Option<Arc<ArrayBytes<'static>>>, ArrayError> {
+            let chunk_encoded: ChunkCacheTypeEncoded = self
                 .cache
                 .try_get_or_insert_with(chunk_indices.to_vec(), || {
                     Ok(self
@@ -232,18 +263,21 @@ macro_rules! impl_ChunkCacheLruEncoded {
                     )
                     .map_err(ArrayError::CodecError)?;
                 bytes.validate(chunk_shape.num_elements_u64(), self.array.data_type())?;
-                Ok(Arc::new(bytes.into_owned()))
+                Ok(Some(Arc::new(bytes.into_owned())))
             } else {
-                let chunk_shape = self.array.chunk_shape(chunk_indices)?;
-                Ok(Arc::new(
-                    ArrayBytes::new_fill_value(
-                        self.array.data_type(),
-                        chunk_shape.num_elements_u64(),
-                        self.array.fill_value(),
-                    )
-                    .map_err(CodecError::from)
-                    .map_err(ArrayError::from)?,
-                ))
+                Ok(None)
+            }
+        }
+
+        fn retrieve_chunk_bytes(
+            &self,
+            chunk_indices: &[u64],
+            options: &zarrs_codec::CodecOptions,
+        ) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
+            if let Some(bytes) = self.retrieve_chunk_bytes_if_exists(chunk_indices, options)? {
+                Ok(bytes)
+            } else {
+                fill_value_chunk(&self.array, chunk_indices)
             }
         }
 
@@ -252,7 +286,7 @@ macro_rules! impl_ChunkCacheLruEncoded {
             chunk_indices: &[u64],
             chunk_subset: &dyn ArraySubsetTraits,
             options: &zarrs_codec::CodecOptions,
-        ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
+        ) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
             let chunk_encoded: ChunkCacheTypeEncoded = self
                 .cache
                 .try_get_or_insert_with(chunk_indices.to_vec(), || {
@@ -305,26 +339,30 @@ macro_rules! impl_ChunkCacheLruDecoded {
             chunk_indices: &[u64],
             options: &zarrs_codec::CodecOptions,
         ) -> Result<ChunkCacheTypePartialDecoder, ArrayError> {
-            let bytes = self.retrieve_chunk_bytes(chunk_indices, options)?;
+            let bytes = self.retrieve_chunk_bytes_if_exists(chunk_indices, options)?;
             let chunk_shape = self.array.chunk_shape(chunk_indices)?;
             Ok(Arc::new(CachedArrayBytesPartialDecoder::new(
                 bytes,
                 chunk_shape,
                 self.array.data_type().clone(),
+                self.array.fill_value().clone(),
             )))
         }
 
-        fn retrieve_chunk_bytes(
+        fn retrieve_chunk_bytes_if_exists(
             &self,
             chunk_indices: &[u64],
             options: &zarrs_codec::CodecOptions,
-        ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
+        ) -> Result<Option<Arc<ArrayBytes<'static>>>, ArrayError> {
             self.cache
                 .try_get_or_insert_with(chunk_indices.to_vec(), || {
-                    Ok(Arc::new(
-                        self.array
-                            .retrieve_chunk_opt::<ArrayBytes<'static>>(chunk_indices, options)?,
-                    ))
+                    Ok(self
+                        .array
+                        .retrieve_chunk_if_exists_opt::<ArrayBytes<'static>>(
+                            chunk_indices,
+                            options,
+                        )?
+                        .map(Arc::new))
                 })
                 .map_err(|err| {
                     // moka returns an Arc'd error, unwrap it noting that ArrayError is not cloneable
@@ -332,6 +370,18 @@ macro_rules! impl_ChunkCacheLruDecoded {
                         ArrayError::StorageError(StorageError::from(err.to_string()))
                     })
                 })
+        }
+
+        fn retrieve_chunk_bytes(
+            &self,
+            chunk_indices: &[u64],
+            options: &zarrs_codec::CodecOptions,
+        ) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
+            if let Some(bytes) = self.retrieve_chunk_bytes_if_exists(chunk_indices, options)? {
+                Ok(bytes)
+            } else {
+                fill_value_chunk(&self.array, chunk_indices)
+            }
         }
 
         fn retrieve_chunk_subset_bytes(
@@ -339,14 +389,17 @@ macro_rules! impl_ChunkCacheLruDecoded {
             chunk_indices: &[u64],
             chunk_subset: &dyn ArraySubsetTraits,
             options: &zarrs_codec::CodecOptions,
-        ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
+        ) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
             let chunk = self
                 .cache
                 .try_get_or_insert_with(chunk_indices.to_vec(), || {
-                    Ok(Arc::new(
-                        self.array
-                            .retrieve_chunk_opt::<ArrayBytes<'static>>(chunk_indices, options)?,
-                    ))
+                    Ok(self
+                        .array
+                        .retrieve_chunk_if_exists_opt::<ArrayBytes<'static>>(
+                            chunk_indices,
+                            options,
+                        )?
+                        .map(Arc::new))
                 })
                 .map_err(|err| {
                     // moka returns an Arc'd error, unwrap it noting that ArrayError is not cloneable
@@ -354,15 +407,27 @@ macro_rules! impl_ChunkCacheLruDecoded {
                         ArrayError::StorageError(StorageError::from(err.to_string()))
                     })
                 })?;
-            let chunk_shape = self.array.chunk_shape(chunk_indices)?;
-            Ok(chunk
-                .extract_array_subset(
-                    chunk_subset,
-                    bytemuck::must_cast_slice(&chunk_shape),
-                    self.array.data_type(),
-                )?
-                .into_owned()
-                .into())
+            if let Some(chunk) = chunk {
+                let chunk_shape = self.array.chunk_shape(chunk_indices)?;
+                Ok(chunk
+                    .extract_array_subset(
+                        chunk_subset,
+                        bytemuck::must_cast_slice(&chunk_shape),
+                        self.array.data_type(),
+                    )?
+                    .into_owned()
+                    .into())
+            } else {
+                Ok(Arc::new(
+                    ArrayBytes::new_fill_value(
+                        self.array.data_type(),
+                        chunk_subset.num_elements(),
+                        self.array.fill_value(),
+                    )
+                    .map_err(CodecError::from)
+                    .map_err(ArrayError::from)?,
+                ))
+            }
         }
     };
 }
@@ -386,18 +451,37 @@ macro_rules! impl_ChunkCacheLruPartialDecoder {
                 })
         }
 
+        fn retrieve_chunk_bytes_if_exists(
+            &self,
+            chunk_indices: &[u64],
+            options: &zarrs_codec::CodecOptions,
+        ) -> Result<Option<Arc<ArrayBytes<'static>>>, ArrayError> {
+            let partial_decoder = self.partial_decoder(chunk_indices, options)?;
+            if partial_decoder.exists()? {
+                let chunk_shape = $crate::array::chunk_shape_to_array_shape(
+                    &self.array.chunk_shape(chunk_indices)?,
+                );
+                Ok(Some(
+                    partial_decoder
+                        .partial_decode(&ArraySubset::new_with_shape(chunk_shape), options)?
+                        .into_owned()
+                        .into(),
+                ))
+            } else {
+                Ok(None)
+            }
+        }
+
         fn retrieve_chunk_bytes(
             &self,
             chunk_indices: &[u64],
             options: &zarrs_codec::CodecOptions,
-        ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
-            let partial_decoder = self.partial_decoder(chunk_indices, options)?;
-            let chunk_shape =
-                $crate::array::chunk_shape_to_array_shape(&self.array.chunk_shape(chunk_indices)?);
-            Ok(partial_decoder
-                .partial_decode(&ArraySubset::new_with_shape(chunk_shape), options)?
-                .into_owned()
-                .into())
+        ) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
+            if let Some(bytes) = self.retrieve_chunk_bytes_if_exists(chunk_indices, options)? {
+                Ok(bytes)
+            } else {
+                fill_value_chunk(&self.array, chunk_indices)
+            }
         }
 
         fn retrieve_chunk_subset_bytes(
@@ -405,7 +489,7 @@ macro_rules! impl_ChunkCacheLruPartialDecoder {
             chunk_indices: &[u64],
             chunk_subset: &dyn ArraySubsetTraits,
             options: &zarrs_codec::CodecOptions,
-        ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
+        ) -> Result<Arc<ArrayBytes<'static>>, ArrayError> {
             let partial_decoder = self.partial_decoder(chunk_indices, options)?;
             Ok(partial_decoder
                 .partial_decode(chunk_subset, options)?
@@ -563,8 +647,8 @@ mod tests {
         let store: ReadableWritableStorage = Arc::new(MemoryStore::default());
         let store = Arc::new(PerformanceMetricsStorageAdapter::new(store));
         let array = ArrayBuilder::new(
-            vec![8, 8], // array shape
-            vec![4, 4], // regular chunk shape
+            vec![12, 8], // array shape
+            vec![4, 4],  // regular chunk shape
             data_type::uint8(),
             0u8,
         )
@@ -592,7 +676,7 @@ mod tests {
         thread_local: bool,
         size_limit: bool,
         partial_decoder: bool,
-        encoded: bool,
+        _encoded: bool,
     ) {
         assert_eq!(store.reads(), 0);
         assert!(cache.is_empty());
@@ -747,7 +831,7 @@ mod tests {
                 assert_eq!(store.reads(), 5);
             }
 
-            if size_limit && (encoded || partial_decoder) {
+            if size_limit {
                 assert_eq!(cache.len(), 2 + 1); // empty chunk is not included in size limit
             } else {
                 assert_eq!(cache.len(), 2);
@@ -956,6 +1040,114 @@ mod tests {
         let (store, array) = create_store_array_zstd();
         let cache = ChunkCachePartialDecoderLruSizeLimit::new(array, 1024);
         array_chunk_cache_zstd_partial_decoder_decoded_data_cached_impl(store, cache, true);
+    }
+
+    #[cfg(feature = "zstd")]
+    fn array_chunk_cache_retrieve_chunk_if_exists_zstd_impl<TChunkCache: ChunkCache>(
+        store: Arc<PerformanceMetricsStorageAdapter<dyn ReadableWritableStorageTraits>>,
+        cache: TChunkCache,
+    ) {
+        let options = CodecOptions::default();
+        let decoded_chunk: Arc<ArrayBytes<'static>> =
+            Arc::new(vec![0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27].into());
+
+        assert_eq!(store.reads(), 0);
+        assert!(cache.is_empty());
+
+        assert_eq!(
+            cache
+                .retrieve_chunk_bytes_if_exists(&[0, 0], &options)
+                .unwrap(),
+            Some(decoded_chunk)
+        );
+        assert_eq!(store.reads(), 1);
+
+        assert_eq!(
+            cache
+                .retrieve_chunk_if_exists::<Vec<u8>>(&[0, 0], &options)
+                .unwrap(),
+            Some(vec![
+                0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27,
+            ])
+        );
+        assert_eq!(store.reads(), 1);
+
+        assert!(
+            cache
+                .retrieve_chunk_bytes_if_exists(&[2, 1], &options)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(store.reads(), 2);
+
+        assert!(
+            cache
+                .retrieve_chunk_if_exists::<Vec<u8>>(&[2, 1], &options)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(store.reads(), 2);
+
+        assert_eq!(
+            cache.retrieve_chunk_bytes(&[2, 1], &options).unwrap(),
+            Arc::new(vec![0; 16].into())
+        );
+        assert_eq!(store.reads(), 2);
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_encoded_chunks_retrieve_chunk_if_exists_zstd() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCacheEncodedLruChunkLimit::new(array, 2);
+        array_chunk_cache_retrieve_chunk_if_exists_zstd_impl(store, cache);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_encoded_size_retrieve_chunk_if_exists_zstd() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCacheEncodedLruSizeLimit::new(array, 1024);
+        array_chunk_cache_retrieve_chunk_if_exists_zstd_impl(store, cache);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_decoded_chunks_retrieve_chunk_if_exists_zstd() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCacheDecodedLruChunkLimit::new(array, 2);
+        array_chunk_cache_retrieve_chunk_if_exists_zstd_impl(store, cache);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_decoded_size_retrieve_chunk_if_exists_zstd() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCacheDecodedLruSizeLimit::new(array, 1024);
+        array_chunk_cache_retrieve_chunk_if_exists_zstd_impl(store, cache);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_partial_decoder_chunks_retrieve_chunk_if_exists_zstd() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCachePartialDecoderLruChunkLimit::new(array, 2);
+        array_chunk_cache_retrieve_chunk_if_exists_zstd_impl(store, cache);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_partial_decoder_size_retrieve_chunk_if_exists_zstd() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCachePartialDecoderLruSizeLimit::new(array, 1024);
+        array_chunk_cache_retrieve_chunk_if_exists_zstd_impl(store, cache);
     }
 
     #[allow(clippy::type_complexity)]

--- a/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
@@ -457,6 +457,37 @@ mod tests {
         (store, array)
     }
 
+    #[cfg(feature = "zstd")]
+    #[allow(clippy::type_complexity)]
+    fn create_store_array_zstd() -> (
+        Arc<PerformanceMetricsStorageAdapter<dyn ReadableWritableStorageTraits>>,
+        Arc<Array<dyn ReadableStorageTraits>>,
+    ) {
+        let store: ReadableWritableStorage = Arc::new(MemoryStore::default());
+        let store = Arc::new(PerformanceMetricsStorageAdapter::new(store));
+        let array = ArrayBuilder::new(
+            vec![8, 8], // array shape
+            vec![4, 4], // regular chunk shape
+            data_type::uint8(),
+            0u8,
+        )
+        .bytes_to_bytes_codecs(vec![Arc::new(crate::array::codec::ZstdCodec::new(
+            5, false,
+        ))])
+        .build_arc(store.clone(), "/")
+        .unwrap();
+
+        let data: Vec<u8> = (0..8 * 8).map(|i| i as u8).collect();
+        array
+            .store_array_subset(&ArraySubset::new_with_shape(vec![8, 8]), &data)
+            .unwrap();
+        array.store_metadata().unwrap();
+
+        store.reset();
+        let array = Arc::new(array.readable());
+        (store, array)
+    }
+
     fn array_chunk_cache_impl<TChunkCache: ChunkCache>(
         store: Arc<PerformanceMetricsStorageAdapter<dyn ReadableWritableStorageTraits>>,
         cache: TChunkCache,
@@ -734,6 +765,43 @@ mod tests {
         let cache =
             ChunkCachePartialDecoderLruSizeLimitThreadLocal::new(array, 2 * chunk_size as u64);
         array_chunk_cache_impl(store, cache, true, true, true, false);
+    }
+
+    // zstd gets fully decoded and cached in a CodecChain, so expect no additional store reads after creating and caching a partial decoder.
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_partial_decoder_zstd_decoded_data_cached() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCachePartialDecoderLruChunkLimit::new(array, 2);
+        let options = CodecOptions::default();
+        let decoded_chunk_size = 4 * 4 * size_of::<u8>();
+
+        assert_eq!(store.reads(), 0);
+        assert!(cache.is_empty());
+
+        let partial_decoder = cache.partial_decoder(&[0, 0], &options).unwrap();
+        assert_eq!(store.reads(), 1);
+        assert_eq!(partial_decoder.size_held(), decoded_chunk_size);
+        assert_eq!(
+            partial_decoder
+                .partial_decode(&[0..2, 0..2], &options)
+                .unwrap(),
+            vec![0, 1, 8, 9].into()
+        );
+        assert_eq!(store.reads(), 1);
+
+        let cached_partial_decoder = cache.partial_decoder(&[0, 0], &options).unwrap();
+        assert!(Arc::ptr_eq(&partial_decoder, &cached_partial_decoder));
+        assert_eq!(cached_partial_decoder.size_held(), decoded_chunk_size);
+        assert_eq!(
+            cached_partial_decoder
+                .partial_decode(&[2..4, 2..4], &options)
+                .unwrap(),
+            vec![18, 19, 26, 27].into()
+        );
+        assert_eq!(store.reads(), 1);
+        assert_eq!(cache.len(), 1);
     }
 
     #[allow(clippy::type_complexity)]

--- a/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
@@ -1,14 +1,15 @@
 use std::borrow::Cow;
-use std::sync::{Arc, atomic};
+use std::sync::{Arc, Mutex, atomic};
 
 use super::{
     ChunkCache, ChunkCacheType, ChunkCacheTypeDecoded, ChunkCacheTypeEncoded,
     ChunkCacheTypePartialDecoder,
 };
 use crate::array::{
-    Array, ArrayBytes, ArrayError, ArrayIndices, ArraySubset, ArraySubsetTraits, ChunkShapeTraits,
+    Array, ArrayBytes, ArrayError, ArrayIndices, ArraySubset, ArraySubsetTraits, ChunkShape,
+    ChunkShapeTraits, DataType, Indexer,
 };
-use zarrs_codec::{ArrayToBytesCodecTraits, CodecError};
+use zarrs_codec::{ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecError};
 use zarrs_storage::{ReadableStorageTraits, StorageError};
 
 type ChunkIndices = ArrayIndices;
@@ -31,6 +32,52 @@ trait CacheChunkLimitTraits {
 
 trait CacheSizeLimitTraits {
     fn new_with_size_capacity(size_capacity: u64) -> Self;
+}
+
+struct CachedArrayBytesPartialDecoder {
+    bytes: ChunkCacheTypeDecoded,
+    shape: ChunkShape,
+    data_type: DataType,
+}
+
+impl CachedArrayBytesPartialDecoder {
+    fn new(bytes: ChunkCacheTypeDecoded, shape: ChunkShape, data_type: DataType) -> Self {
+        Self {
+            bytes,
+            shape,
+            data_type,
+        }
+    }
+}
+
+impl ArrayPartialDecoderTraits for CachedArrayBytesPartialDecoder {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn exists(&self) -> Result<bool, StorageError> {
+        Ok(true)
+    }
+
+    fn size_held(&self) -> usize {
+        self.bytes.size()
+    }
+
+    fn partial_decode(
+        &self,
+        indexer: &dyn Indexer,
+        _options: &zarrs_codec::CodecOptions,
+    ) -> Result<ArrayBytes<'_>, CodecError> {
+        Ok(self.bytes.extract_array_subset(
+            indexer,
+            bytemuck::must_cast_slice(&self.shape),
+            &self.data_type,
+        )?)
+    }
+
+    fn supports_partial_decode(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -115,6 +162,42 @@ macro_rules! impl_ChunkCacheLruCommon {
 
 macro_rules! impl_ChunkCacheLruEncoded {
     () => {
+        fn partial_decoder(
+            &self,
+            chunk_indices: &[u64],
+            options: &zarrs_codec::CodecOptions,
+        ) -> Result<ChunkCacheTypePartialDecoder, ArrayError> {
+            let chunk_encoded: ChunkCacheTypeEncoded = self
+                .cache
+                .try_get_or_insert_with(chunk_indices.to_vec(), || {
+                    Ok(self
+                        .array
+                        .retrieve_encoded_chunk(chunk_indices)?
+                        .map(|chunk| Arc::new(Cow::Owned(chunk))))
+                })
+                .map_err(|err| {
+                    // moka returns an Arc'd error, unwrap it noting that ArrayError is not cloneable
+                    Arc::try_unwrap(err).unwrap_or_else(|err| {
+                        ArrayError::StorageError(StorageError::from(err.to_string()))
+                    })
+                })?;
+
+            let input_handle: Arc<dyn zarrs_codec::BytesPartialDecoderTraits> =
+                if let Some(chunk_encoded) = chunk_encoded {
+                    chunk_encoded
+                } else {
+                    Arc::new(Mutex::new(None))
+                };
+            let chunk_shape = self.array.chunk_shape(chunk_indices)?;
+            Ok(self.array.codecs().clone().partial_decoder(
+                input_handle,
+                &chunk_shape,
+                self.array.data_type(),
+                self.array.fill_value(),
+                options,
+            )?)
+        }
+
         fn retrieve_chunk_bytes(
             &self,
             chunk_indices: &[u64],
@@ -217,6 +300,20 @@ macro_rules! impl_ChunkCacheLruEncoded {
 
 macro_rules! impl_ChunkCacheLruDecoded {
     () => {
+        fn partial_decoder(
+            &self,
+            chunk_indices: &[u64],
+            options: &zarrs_codec::CodecOptions,
+        ) -> Result<ChunkCacheTypePartialDecoder, ArrayError> {
+            let bytes = self.retrieve_chunk_bytes(chunk_indices, options)?;
+            let chunk_shape = self.array.chunk_shape(chunk_indices)?;
+            Ok(Arc::new(CachedArrayBytesPartialDecoder::new(
+                bytes,
+                chunk_shape,
+                self.array.data_type().clone(),
+            )))
+        }
+
         fn retrieve_chunk_bytes(
             &self,
             chunk_indices: &[u64],
@@ -767,13 +864,12 @@ mod tests {
         array_chunk_cache_impl(store, cache, true, true, true, false);
     }
 
-    // zstd gets fully decoded and cached in a CodecChain, so expect no additional store reads after creating and caching a partial decoder.
-    #[test]
     #[cfg(feature = "zstd")]
-    #[cfg_attr(miri, ignore)]
-    fn array_chunk_cache_partial_decoder_zstd_decoded_data_cached() {
-        let (store, array) = create_store_array_zstd();
-        let cache = ChunkCachePartialDecoderLruChunkLimit::new(array, 2);
+    fn array_chunk_cache_zstd_partial_decoder_decoded_data_cached_impl<TChunkCache: ChunkCache>(
+        store: Arc<PerformanceMetricsStorageAdapter<dyn ReadableWritableStorageTraits>>,
+        cache: TChunkCache,
+        expect_same_partial_decoder: bool,
+    ) {
         let options = CodecOptions::default();
         let decoded_chunk_size = 4 * 4 * size_of::<u8>();
 
@@ -792,7 +888,10 @@ mod tests {
         assert_eq!(store.reads(), 1);
 
         let cached_partial_decoder = cache.partial_decoder(&[0, 0], &options).unwrap();
-        assert!(Arc::ptr_eq(&partial_decoder, &cached_partial_decoder));
+        assert_eq!(
+            Arc::ptr_eq(&partial_decoder, &cached_partial_decoder),
+            expect_same_partial_decoder
+        );
         assert_eq!(cached_partial_decoder.size_held(), decoded_chunk_size);
         assert_eq!(
             cached_partial_decoder
@@ -802,6 +901,61 @@ mod tests {
         );
         assert_eq!(store.reads(), 1);
         assert_eq!(cache.len(), 1);
+    }
+
+    // zstd gets fully decoded and cached in a CodecChain, so expect no additional store reads after creating a partial decoder.
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_encoded_chunks_zstd_partial_decoder_decoded_data_cached() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCacheEncodedLruChunkLimit::new(array, 2);
+        array_chunk_cache_zstd_partial_decoder_decoded_data_cached_impl(store, cache, false);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_encoded_size_zstd_partial_decoder_decoded_data_cached() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCacheEncodedLruSizeLimit::new(array, 1024);
+        array_chunk_cache_zstd_partial_decoder_decoded_data_cached_impl(store, cache, false);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_decoded_chunks_zstd_partial_decoder_decoded_data_cached() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCacheDecodedLruChunkLimit::new(array, 2);
+        array_chunk_cache_zstd_partial_decoder_decoded_data_cached_impl(store, cache, false);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_decoded_size_zstd_partial_decoder_decoded_data_cached() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCacheDecodedLruSizeLimit::new(array, 1024);
+        array_chunk_cache_zstd_partial_decoder_decoded_data_cached_impl(store, cache, false);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_partial_decoder_chunks_zstd_decoded_data_cached() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCachePartialDecoderLruChunkLimit::new(array, 2);
+        array_chunk_cache_zstd_partial_decoder_decoded_data_cached_impl(store, cache, true);
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(miri, ignore)]
+    fn array_chunk_cache_partial_decoder_size_zstd_decoded_data_cached() {
+        let (store, array) = create_store_array_zstd();
+        let cache = ChunkCachePartialDecoderLruSizeLimit::new(array, 1024);
+        array_chunk_cache_zstd_partial_decoder_decoded_data_cached_impl(store, cache, true);
     }
 
     #[allow(clippy::type_complexity)]

--- a/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
@@ -272,22 +272,29 @@ macro_rules! impl_ChunkCacheLruDecoded {
 
 macro_rules! impl_ChunkCacheLruPartialDecoder {
     () => {
-        fn retrieve_chunk_bytes(
+        fn partial_decoder(
             &self,
             chunk_indices: &[u64],
             options: &zarrs_codec::CodecOptions,
-        ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
-            let partial_decoder = self
-                .cache
+        ) -> Result<ChunkCacheTypePartialDecoder, ArrayError> {
+            self.cache
                 .try_get_or_insert_with(chunk_indices.to_vec(), || {
-                    self.array.partial_decoder(chunk_indices)
+                    self.array.partial_decoder_opt(chunk_indices, options)
                 })
                 .map_err(|err| {
                     // moka returns an Arc'd error, unwrap it noting that ArrayError is not cloneable
                     Arc::try_unwrap(err).unwrap_or_else(|err| {
                         ArrayError::StorageError(StorageError::from(err.to_string()))
                     })
-                })?;
+                })
+        }
+
+        fn retrieve_chunk_bytes(
+            &self,
+            chunk_indices: &[u64],
+            options: &zarrs_codec::CodecOptions,
+        ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
+            let partial_decoder = self.partial_decoder(chunk_indices, options)?;
             let chunk_shape =
                 $crate::array::chunk_shape_to_array_shape(&self.array.chunk_shape(chunk_indices)?);
             Ok(partial_decoder
@@ -302,17 +309,7 @@ macro_rules! impl_ChunkCacheLruPartialDecoder {
             chunk_subset: &dyn ArraySubsetTraits,
             options: &zarrs_codec::CodecOptions,
         ) -> Result<ChunkCacheTypeDecoded, ArrayError> {
-            let partial_decoder = self
-                .cache
-                .try_get_or_insert_with(chunk_indices.to_vec(), || {
-                    self.array.partial_decoder(chunk_indices)
-                })
-                .map_err(|err| {
-                    // moka returns an Arc'd error, unwrap it noting that ArrayError is not cloneable
-                    Arc::try_unwrap(err).unwrap_or_else(|err| {
-                        ArrayError::StorageError(StorageError::from(err.to_string()))
-                    })
-                })?;
+            let partial_decoder = self.partial_decoder(chunk_indices, options)?;
             Ok(partial_decoder
                 .partial_decode(chunk_subset, options)?
                 .into_owned()

--- a/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
@@ -111,6 +111,23 @@ fn fill_value_chunk(
     ))
 }
 
+fn validate_chunk_indices(
+    array: &Array<dyn ReadableStorageTraits>,
+    chunk_indices: &[u64],
+) -> Result<ChunkShape, ArrayError> {
+    if chunk_indices.len() != array.dimensionality()
+        || chunk_indices
+            .iter()
+            .zip(array.chunk_grid_shape())
+            .any(|(&index, &size)| index >= size)
+    {
+        return Err(ArrayError::InvalidChunkGridIndicesError(
+            chunk_indices.to_vec(),
+        ));
+    }
+    array.chunk_shape(chunk_indices)
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[path = "chunk_cache_lru_moka.rs"]
 mod platform;
@@ -219,7 +236,7 @@ macro_rules! impl_ChunkCacheLruEncoded {
                 } else {
                     Arc::new(Mutex::new(None))
                 };
-            let chunk_shape = self.array.chunk_shape(chunk_indices)?;
+            let chunk_shape = validate_chunk_indices(&self.array, chunk_indices)?;
             Ok(self.array.codecs().clone().partial_decoder(
                 input_handle,
                 &chunk_shape,
@@ -234,6 +251,7 @@ macro_rules! impl_ChunkCacheLruEncoded {
             chunk_indices: &[u64],
             options: &zarrs_codec::CodecOptions,
         ) -> Result<Option<Arc<ArrayBytes<'static>>>, ArrayError> {
+            let chunk_shape = validate_chunk_indices(&self.array, chunk_indices)?;
             let chunk_encoded: ChunkCacheTypeEncoded = self
                 .cache
                 .try_get_or_insert_with(chunk_indices.to_vec(), || {
@@ -250,7 +268,6 @@ macro_rules! impl_ChunkCacheLruEncoded {
                 })?;
 
             if let Some(chunk_encoded) = chunk_encoded.as_ref() {
-                let chunk_shape = self.array.chunk_shape(chunk_indices)?;
                 let bytes = self
                     .array
                     .codecs()
@@ -354,6 +371,7 @@ macro_rules! impl_ChunkCacheLruDecoded {
             chunk_indices: &[u64],
             options: &zarrs_codec::CodecOptions,
         ) -> Result<Option<Arc<ArrayBytes<'static>>>, ArrayError> {
+            validate_chunk_indices(&self.array, chunk_indices)?;
             self.cache
                 .try_get_or_insert_with(chunk_indices.to_vec(), || {
                     Ok(self
@@ -456,11 +474,12 @@ macro_rules! impl_ChunkCacheLruPartialDecoder {
             chunk_indices: &[u64],
             options: &zarrs_codec::CodecOptions,
         ) -> Result<Option<Arc<ArrayBytes<'static>>>, ArrayError> {
+            let chunk_shape = $crate::array::chunk_shape_to_array_shape(&validate_chunk_indices(
+                &self.array,
+                chunk_indices,
+            )?);
             let partial_decoder = self.partial_decoder(chunk_indices, options)?;
             if partial_decoder.exists()? {
-                let chunk_shape = $crate::array::chunk_shape_to_array_shape(
-                    &self.array.chunk_shape(chunk_indices)?,
-                );
                 Ok(Some(
                     partial_decoder
                         .partial_decode(&ArraySubset::new_with_shape(chunk_shape), options)?
@@ -1093,6 +1112,26 @@ mod tests {
             Arc::new(vec![0; 16].into())
         );
         assert_eq!(store.reads(), 2);
+
+        let reads = store.reads();
+        let err = cache
+            .retrieve_chunk_bytes_if_exists(&[3, 0], &options)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ArrayError::InvalidChunkGridIndicesError(indices) if indices == vec![3, 0]
+        ));
+        assert_eq!(store.reads(), reads);
+
+        let err = cache
+            .retrieve_chunk_bytes_if_exists(&[0], &options)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ArrayError::InvalidChunkGridIndicesError(indices) if indices == vec![0]
+        ));
+        assert_eq!(store.reads(), reads);
+
         assert_eq!(cache.len(), 2);
     }
 


### PR DESCRIPTION
Split out from https://github.com/zarrs/zarrs/tree/refactor/array_traits