### PR TITLE
refactor: add default implementations for ArrayOps methods

### DIFF
--- a/zarrs/src/array/array_ops/array_ops.rs
+++ b/zarrs/src/array/array_ops/array_ops.rs
@@ -38,6 +38,15 @@ pub trait ArrayOps {
     /// Get the storage transformers.
     fn storage_transformers(&self) -> &StorageTransformerChain;
 
+    /// Get the default codec options for no-options methods.
+    fn codec_options(&self) -> &CodecOptions;
+
+    /// Get the default array metadata options for no-options methods.
+    fn metadata_options(&self) -> &ArrayMetadataOptions;
+
+    /// Get the default metadata erase version for no-options methods.
+    fn metadata_erase_version(&self) -> MetadataEraseVersion;
+
     /// Get the dimension names.
     fn dimension_names(&self) -> &Option<Vec<DimensionName>>;
 

--- a/zarrs/src/array/array_ops/array_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_ops/array.rs
@@ -60,6 +60,18 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
         &self.storage_transformers
     }
 
+    pub fn codec_options(&self) -> &CodecOptions {
+        &self.codec_options
+    }
+
+    pub fn metadata_options(&self) -> &ArrayMetadataOptions {
+        &self.metadata_options
+    }
+
+    pub fn metadata_erase_version(&self) -> MetadataEraseVersion {
+        self.metadata_erase_version
+    }
+
     pub fn dimension_names(&self) -> &Option<Vec<DimensionName>> {
         &self.dimension_names
     }
@@ -210,7 +222,7 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
         let configuration = self
             .codecs
             .array_to_bytes_codec()
-            .configuration_v3(self.metadata_options.codec_metadata_options())?;
+            .configuration_v3(self.metadata_options().codec_metadata_options())?;
         if let Ok(ShardingCodecConfiguration::V1(sharding_configuration)) =
             ShardingCodecConfiguration::try_from_configuration(configuration)
         {

--- a/zarrs/src/array/array_ops/array_ops/array_cached.rs
+++ b/zarrs/src/array/array_ops/array_ops/array_cached.rs
@@ -47,6 +47,18 @@ impl<TStorage: ?Sized, C> ArrayOps for ArrayCached<TStorage, C> {
         self.array().storage_transformers()
     }
 
+    pub fn codec_options(&self) -> &CodecOptions {
+        self.array().codec_options()
+    }
+
+    pub fn metadata_options(&self) -> &ArrayMetadataOptions {
+        self.array().metadata_options()
+    }
+
+    pub fn metadata_erase_version(&self) -> MetadataEraseVersion {
+        self.array().metadata_erase_version()
+    }
+
     pub fn dimension_names(&self) -> &Option<Vec<DimensionName>> {
         self.array().dimension_names()
     }

--- a/zarrs/src/array/array_ops/array_read_ops.rs
+++ b/zarrs/src/array/array_ops/array_read_ops.rs
@@ -1,11 +1,17 @@
 use super::*;
-use zarrs_codec::{ArrayBytesDecodeIntoTarget, ArrayPartialDecoderTraits};
+use crate::array::ArrayBytes;
+use crate::array::array_sharded_ext::subchunk_shard_index_and_subset;
+use crate::iter_concurrent_limit;
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use zarrs_codec::{ArrayBytesDecodeIntoTarget, ArrayPartialDecoderTraits, CodecError};
+use zarrs_storage::MaybeSync;
 
 mod array;
 mod array_cached;
 
 /// Synchronous array read operations.
-pub trait ArrayReadOps: ArrayOps {
+pub trait ArrayReadOps: ArrayOps + MaybeSync {
     /// Read and decode the chunk at `chunk_indices` into its bytes or the fill value if it does not exist with default codec options.
     ///
     /// # Errors
@@ -16,7 +22,9 @@ pub trait ArrayReadOps: ArrayOps {
     ///
     /// # Panics
     /// Panics if the number of elements in the chunk exceeds `usize::MAX`.
-    fn retrieve_chunk<T: FromArrayBytes>(&self, chunk_indices: &[u64]) -> Result<T, ArrayError>;
+    fn retrieve_chunk<T: FromArrayBytes>(&self, chunk_indices: &[u64]) -> Result<T, ArrayError> {
+        self.retrieve_chunk_opt(chunk_indices, self.codec_options())
+    }
 
     /// Read and decode the chunk at `chunk_indices` with explicit codec options.
     /// Explicit options version of [`retrieve_chunk`](ArrayReadOps::retrieve_chunk).
@@ -25,7 +33,25 @@ pub trait ArrayReadOps: ArrayOps {
         &self,
         chunk_indices: &[u64],
         options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
+    ) -> Result<T, ArrayError> {
+        if let Some(chunk) = self.retrieve_chunk_if_exists_opt::<T>(chunk_indices, options)? {
+            Ok(chunk)
+        } else {
+            let chunk_shape = self.chunk_shape(chunk_indices)?;
+            let bytes = ArrayBytes::new_fill_value(
+                self.data_type(),
+                chunk_shape.iter().map(|&x| x.get()).product::<u64>(),
+                self.fill_value(),
+            )
+            .map_err(CodecError::from)
+            .map_err(ArrayError::from)?;
+            T::from_array_bytes(
+                bytes,
+                bytemuck::must_cast_slice(&chunk_shape),
+                self.data_type(),
+            )
+        }
+    }
 
     /// Read and decode the chunk at `chunk_indices` into a preallocated `output_target`.
     ///
@@ -58,7 +84,9 @@ pub trait ArrayReadOps: ArrayOps {
     fn retrieve_chunks<T: FromArrayBytes>(
         &self,
         chunks: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError>;
+    ) -> Result<T, ArrayError> {
+        self.retrieve_chunks_opt(chunks, self.codec_options())
+    }
 
     /// Read and decode the chunks in `chunks` with explicit codec options.
     /// Explicit options version of [`retrieve_chunks`](ArrayReadOps::retrieve_chunks).
@@ -67,7 +95,10 @@ pub trait ArrayReadOps: ArrayOps {
         &self,
         chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
+    ) -> Result<T, ArrayError> {
+        let array_subset = self.chunks_subset(chunks)?;
+        self.retrieve_array_subset_opt(&array_subset, options)
+    }
 
     /// Read and decode the `chunk_subset` of the chunk at `chunk_indices` into its bytes.
     ///
@@ -84,7 +115,9 @@ pub trait ArrayReadOps: ArrayOps {
         &self,
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError>;
+    ) -> Result<T, ArrayError> {
+        self.retrieve_chunk_subset_opt(chunk_indices, chunk_subset, self.codec_options())
+    }
 
     /// Read and decode a subset of the chunk at `chunk_indices` with explicit codec options.
     /// Explicit options version of [`retrieve_chunk_subset`](ArrayReadOps::retrieve_chunk_subset).
@@ -131,7 +164,9 @@ pub trait ArrayReadOps: ArrayOps {
     fn retrieve_array_subset<T: FromArrayBytes>(
         &self,
         array_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError>;
+    ) -> Result<T, ArrayError> {
+        self.retrieve_array_subset_opt(array_subset, self.codec_options())
+    }
 
     /// Read and decode the array subset with explicit codec options.
     /// Explicit options version of [`retrieve_array_subset`](ArrayReadOps::retrieve_array_subset).
@@ -155,7 +190,9 @@ pub trait ArrayReadOps: ArrayOps {
     fn retrieve_chunk_if_exists<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<T>, ArrayError>;
+    ) -> Result<Option<T>, ArrayError> {
+        self.retrieve_chunk_if_exists_opt(chunk_indices, self.codec_options())
+    }
 
     /// Read and decode the chunk at `chunk_indices` if it exists with explicit codec options.
     /// Explicit options version of [`retrieve_chunk_if_exists`](ArrayReadOps::retrieve_chunk_if_exists).
@@ -174,6 +211,19 @@ pub trait ArrayReadOps: ArrayOps {
     fn retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        self.retrieve_encoded_chunk_opt(chunk_indices, self.codec_options())
+    }
+
+    /// Retrieve the encoded bytes of a chunk with explicit codec options.
+    ///
+    /// # Errors
+    /// Returns an [`StorageError`] if there is an underlying store error.
+    #[allow(clippy::missing_panics_doc)]
+    fn retrieve_encoded_chunk_opt(
+        &self,
+        chunk_indices: &[u64],
+        options: &CodecOptions,
     ) -> Result<Option<Vec<u8>>, StorageError>;
 
     /// Retrieve the encoded bytes of the chunks in `chunks`.
@@ -185,8 +235,29 @@ pub trait ArrayReadOps: ArrayOps {
     fn retrieve_encoded_chunks(
         &self,
         chunks: &dyn ArraySubsetTraits,
+    ) -> Result<Vec<Option<Vec<u8>>>, StorageError> {
+        self.retrieve_encoded_chunks_opt(chunks, self.codec_options())
+    }
+
+    /// Retrieve the encoded bytes of the chunks in `chunks` with explicit codec options.
+    ///
+    /// The chunks are in order of the chunk indices returned by `chunks.indices().into_iter()`.
+    ///
+    /// # Errors
+    /// Returns a [`StorageError`] if there is an underlying store error.
+    fn retrieve_encoded_chunks_opt(
+        &self,
+        chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<Vec<Option<Vec<u8>>>, StorageError>;
+    ) -> Result<Vec<Option<Vec<u8>>>, StorageError> {
+        iter_concurrent_limit!(
+            options.concurrent_target(),
+            chunks.indices(),
+            map,
+            |chunk_indices| self.retrieve_encoded_chunk_opt(&chunk_indices, options)
+        )
+        .collect()
+    }
 
     /// Retrieve the encoded bytes of a subchunk.
     ///
@@ -212,7 +283,11 @@ pub trait ArrayReadOps: ArrayOps {
         &self,
         subchunk_indices: &[u64],
         options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
+    ) -> Result<T, ArrayError> {
+        let (chunk_indices, chunk_subset) =
+            subchunk_shard_index_and_subset(self, self.subchunk_grid(), subchunk_indices)?;
+        self.retrieve_chunk_subset_opt(&chunk_indices, &chunk_subset, options)
+    }
 
     /// Read and decode the subchunks at `subchunks` with explicit codec options.
     ///
@@ -225,7 +300,18 @@ pub trait ArrayReadOps: ArrayOps {
         &self,
         subchunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
+    ) -> Result<T, ArrayError> {
+        let array_subset = self
+            .subchunk_grid()
+            .chunks_subset(subchunks)?
+            .ok_or_else(|| {
+                ArrayError::InvalidArraySubset(
+                    subchunks.to_array_subset(),
+                    self.subchunk_grid_shape(),
+                )
+            })?;
+        self.retrieve_array_subset_opt(&array_subset, options)
+    }
 
     /// Read and decode the `array_subset` of array into a preallocated `output_target`.
     ///
@@ -244,7 +330,9 @@ pub trait ArrayReadOps: ArrayOps {
         &self,
         array_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-    ) -> Result<(), ArrayError>;
+    ) -> Result<(), ArrayError> {
+        self.retrieve_array_subset_into_opt(array_subset, output_target, self.codec_options())
+    }
 
     /// Read and decode an array subset into a preallocated target with explicit codec options.
     /// Explicit options version of [`retrieve_array_subset_into`](ArrayReadOps::retrieve_array_subset_into).
@@ -263,7 +351,9 @@ pub trait ArrayReadOps: ArrayOps {
     fn partial_decoder(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError>;
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
+        self.partial_decoder_opt(chunk_indices, self.codec_options())
+    }
 
     /// Initialises a partial decoder for the chunk at `chunk_indices` with explicit codec options.
     /// Explicit options version of [`partial_decoder`](ArrayReadOps::partial_decoder).

--- a/zarrs/src/array/array_ops/array_read_ops.rs
+++ b/zarrs/src/array/array_ops/array_read_ops.rs
@@ -9,6 +9,7 @@ use zarrs_storage::MaybeSync;
 
 mod array;
 mod array_cached;
+mod common;
 
 /// Synchronous array read operations.
 pub trait ArrayReadOps: ArrayOps + MaybeSync {

--- a/zarrs/src/array/array_ops/array_read_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/array.rs
@@ -3,8 +3,8 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use super::super::super::array_bytes_internal::{
-    build_nested_optional_target, extract_target_views, merge_chunks_vlen,
-    merge_chunks_vlen_optional, optional_nesting_depth,
+    build_nested_optional_target, merge_chunks_vlen, merge_chunks_vlen_optional,
+    optional_nesting_depth,
 };
 use super::super::super::concurrency::concurrency_chunks_and_codec;
 use super::super::super::{ArrayBytesFixedDisjointView, ArrayIndicesTinyVec};
@@ -19,8 +19,8 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use unsafe_cell_slice::UnsafeCellSlice;
 use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayBytesOptional, ArrayBytesVariableLength,
-    ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecError, InvalidNumberOfElementsError,
-    StoragePartialDecoder, copy_fill_value_into,
+    ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecError, StoragePartialDecoder,
+    copy_fill_value_into,
 };
 use zarrs_storage::StorageHandle;
 
@@ -446,78 +446,18 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
         output_target: ArrayBytesDecodeIntoTarget<'_>,
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        if array_subset.dimensionality() != self.dimensionality() {
-            return Err(ArrayError::InvalidArraySubset(
-                array_subset.to_array_subset(),
-                self.shape().to_vec(),
-            ));
-        }
-
-        if !self.data_type().is_fixed() {
-            return Err(ArrayError::CodecError(CodecError::Other(
-                "retrieve_array_subset_into does not support variable-length data types"
-                    .to_string(),
-            )));
-        }
-
-        if output_target.num_elements() != array_subset.num_elements() {
-            return Err(ArrayError::CodecError(
-                InvalidNumberOfElementsError::new(
-                    output_target.num_elements(),
-                    array_subset.num_elements(),
-                )
-                .into(),
-            ));
-        }
-
-        let chunks = self.chunks_in_array_subset(array_subset)?;
-        let Some(chunks) = chunks else {
-            return Err(ArrayError::InvalidArraySubset(
-                array_subset.to_array_subset(),
-                self.shape().to_vec(),
-            ));
-        };
-
-        let num_chunks = chunks.num_elements_usize();
-        match num_chunks {
-            0 => copy_fill_value_into(self.data_type(), self.fill_value(), output_target)
-                .map_err(ArrayError::CodecError),
-            1 => {
-                let chunk_indices = chunks.start();
-                let chunk_subset = self.chunk_subset(chunk_indices)?;
-                if chunk_subset == array_subset {
-                    self.retrieve_chunk_into(chunk_indices, output_target, options)
-                } else {
-                    let array_subset_in_chunk_subset =
-                        array_subset.relative_to(chunk_subset.start())?;
-                    self.retrieve_chunk_subset_into(
-                        chunk_indices,
-                        &array_subset_in_chunk_subset,
-                        output_target,
-                        options,
-                    )
-                }
-            }
-            _ => {
-                let chunk_shape = self.chunk_shape(chunks.start())?;
-                let codec_concurrency =
-                    self.recommended_codec_concurrency(&chunk_shape, self.data_type())?;
-                let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
-                    options.concurrent_target(),
-                    num_chunks,
-                    options,
-                    &codec_concurrency,
-                );
-
-                self.retrieve_multi_chunk_fixed_into(
-                    array_subset,
-                    &chunks,
-                    chunk_concurrent_limit,
-                    &output_target,
-                    &options,
-                )
-            }
-        }
+        super::common::retrieve_array_subset_into(
+            self,
+            array_subset,
+            output_target,
+            options,
+            |chunk_indices, output_target, options| {
+                self.retrieve_chunk_into(chunk_indices, output_target, options)
+            },
+            |chunk_indices, chunk_subset, output_target, options| {
+                self.retrieve_chunk_subset_into(chunk_indices, chunk_subset, output_target, options)
+            },
+        )
     }
 
     #[allow(clippy::missing_errors_doc)]
@@ -700,68 +640,6 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
             array_bytes = array_bytes.with_optional_mask(mask);
         }
         Ok(array_bytes)
-    }
-
-    fn retrieve_multi_chunk_fixed_into(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        chunks: &dyn ArraySubsetTraits,
-        chunk_concurrent_limit: usize,
-        output_target: &ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
-    ) -> Result<(), ArrayError> {
-        let (data_view_ref, mask_view_refs) = extract_target_views(output_target);
-        let parent_start = data_view_ref.subset().start().to_vec();
-
-        let retrieve_chunk = |chunk_indices: ArrayIndicesTinyVec| {
-            let chunk_subset = self.chunk_subset(&chunk_indices)?;
-            let chunk_subset_overlap = chunk_subset.overlap(array_subset)?;
-            let chunk_subset_in_array = chunk_subset_overlap.relative_to(&array_subset.start())?;
-
-            let chunk_start_in_view: Vec<u64> = chunk_subset_in_array
-                .start()
-                .iter()
-                .zip(&parent_start)
-                .map(|(&c, &p)| c + p)
-                .collect();
-            let chunk_subset_in_view = ArraySubset::new_with_start_shape(
-                chunk_start_in_view,
-                chunk_subset_in_array.shape().to_vec(),
-            )?;
-
-            let mut data_sub = unsafe {
-                // SAFETY: chunks represent disjoint array subsets
-                data_view_ref.subdivide(chunk_subset_in_view.clone())?
-            };
-
-            let mut mask_subs: Vec<ArrayBytesFixedDisjointView<'_>> = mask_view_refs
-                .iter()
-                .map(|mask_view| unsafe {
-                    // SAFETY: chunks represent disjoint array subsets
-                    mask_view.subdivide(chunk_subset_in_view.clone())
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let target = build_nested_optional_target(&mut data_sub, mask_subs.as_mut_slice());
-
-            self.retrieve_chunk_subset_into(
-                &chunk_indices,
-                &chunk_subset_overlap.relative_to(chunk_subset.start())?,
-                target,
-                options,
-            )?;
-            Ok::<_, ArrayError>(())
-        };
-
-        let indices = chunks.indices();
-        iter_concurrent_limit!(
-            chunk_concurrent_limit,
-            indices,
-            try_for_each,
-            retrieve_chunk
-        )?;
-
-        Ok(())
     }
 }
 

--- a/zarrs/src/array/array_ops/array_read_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/array.rs
@@ -11,9 +11,7 @@ use super::super::super::{ArrayBytesFixedDisjointView, ArrayIndicesTinyVec};
 use super::super::*;
 use super::ArrayReadOps;
 use crate::array::ArrayBytes;
-use crate::array::array_sharded_ext::{
-    subchunk_shard_index_and_chunk_index, subchunk_shard_index_and_subset,
-};
+use crate::array::array_sharded_ext::subchunk_shard_index_and_chunk_index;
 use crate::array::codec::array_to_bytes::sharding::{ShardingCodec, ShardingPartialDecoder};
 use crate::iter_concurrent_limit;
 #[cfg(not(target_arch = "wasm32"))]
@@ -29,37 +27,15 @@ use zarrs_storage::StorageHandle;
 #[inherent]
 impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<TStorage> {
     #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    pub fn retrieve_chunk<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-    ) -> Result<T, ArrayError> {
-        self.retrieve_chunk_opt(chunk_indices, &CodecOptions::default())
-    }
+    pub fn retrieve_chunk<T: FromArrayBytes>(&self, chunk_indices: &[u64])
+    -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunk_opt<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
         options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
-        if let Some(chunk) = self.retrieve_chunk_if_exists_opt::<T>(chunk_indices, options)? {
-            Ok(chunk)
-        } else {
-            let chunk_shape = self.chunk_shape(chunk_indices)?;
-            let bytes = ArrayBytes::new_fill_value(
-                self.data_type(),
-                chunk_shape.iter().map(|&x| x.get()).product::<u64>(),
-                self.fill_value(),
-            )
-            .map_err(CodecError::from)
-            .map_err(ArrayError::from)?;
-            T::from_array_bytes(
-                bytes,
-                bytemuck::must_cast_slice(&chunk_shape),
-                self.data_type(),
-            )
-        }
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunk_into(
@@ -101,35 +77,21 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
     pub fn retrieve_chunks<T: FromArrayBytes>(
         &self,
         chunks: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError> {
-        self.retrieve_chunks_opt(chunks, &CodecOptions::default())
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunks_opt<T: FromArrayBytes>(
         &self,
         chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
-        if chunks.dimensionality() != self.dimensionality() {
-            return Err(ArrayError::InvalidArraySubset(
-                chunks.to_array_subset(),
-                self.shape().to_vec(),
-            ));
-        }
-
-        let array_subset = self.chunks_subset(chunks)?;
-        self.retrieve_array_subset_opt(&array_subset, options)
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     pub fn retrieve_chunk_subset<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError> {
-        self.retrieve_chunk_subset_opt(chunk_indices, chunk_subset, &CodecOptions::default())
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunk_subset_opt<T: FromArrayBytes>(
@@ -224,9 +186,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
     pub fn retrieve_array_subset<T: FromArrayBytes>(
         &self,
         array_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError> {
-        self.retrieve_array_subset_opt(array_subset, &CodecOptions::default())
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     pub fn retrieve_array_subset_opt<T: FromArrayBytes>(
@@ -319,15 +279,21 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
     pub fn retrieve_chunk_if_exists<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<T>, ArrayError> {
-        self.retrieve_chunk_if_exists_opt(chunk_indices, &CodecOptions::default())
-    }
+    ) -> Result<Option<T>, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
+    ) -> Result<Option<Vec<u8>>, StorageError>;
+
+    #[allow(clippy::missing_errors_doc)]
+    pub fn retrieve_encoded_chunk_opt(
+        &self,
+        chunk_indices: &[u64],
+        options: &CodecOptions,
     ) -> Result<Option<Vec<u8>>, StorageError> {
+        let _ = options;
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
@@ -342,28 +308,14 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
     pub fn retrieve_encoded_chunks(
         &self,
         chunks: &dyn ArraySubsetTraits,
+    ) -> Result<Vec<Option<Vec<u8>>>, StorageError>;
+
+    #[allow(clippy::missing_errors_doc)]
+    pub fn retrieve_encoded_chunks_opt(
+        &self,
+        chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<Vec<Option<Vec<u8>>>, StorageError> {
-        let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
-        let storage_transformer = self
-            .storage_transformers()
-            .create_readable_transformer(storage_handle)?;
-
-        let retrieve_encoded_chunk = |chunk_indices: ArrayIndicesTinyVec| {
-            storage_transformer
-                .get(&self.chunk_key(&chunk_indices))
-                .map(|maybe_bytes| maybe_bytes.map(Into::into))
-        };
-
-        let indices = chunks.indices();
-        iter_concurrent_limit!(
-            options.concurrent_target(),
-            indices,
-            map,
-            retrieve_encoded_chunk
-        )
-        .collect()
-    }
+    ) -> Result<Vec<Option<Vec<u8>>>, StorageError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_encoded_subchunk(
@@ -407,7 +359,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
             sharding_codec.inner_codecs.clone(),
             &sharding_codec.index_codecs,
             sharding_codec.index_location,
-            &self.codec_options,
+            self.codec_options(),
             sharding_codec.options.clone(),
         )?;
 
@@ -421,46 +373,27 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
         &self,
         subchunk_indices: &[u64],
         options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
-        let (chunk_indices, chunk_subset) =
-            subchunk_shard_index_and_subset(self, self.subchunk_grid(), subchunk_indices)?;
-        self.retrieve_chunk_subset_opt(&chunk_indices, &chunk_subset, options)
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_subchunks_opt<T: FromArrayBytes>(
         &self,
         subchunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
-        let array_subset = self
-            .subchunk_grid()
-            .chunks_subset(subchunks)?
-            .ok_or_else(|| {
-                ArrayError::InvalidArraySubset(
-                    subchunks.to_array_subset(),
-                    self.subchunk_grid_shape(),
-                )
-            })?;
-        self.retrieve_array_subset_opt(&array_subset, options)
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     pub fn retrieve_array_subset_into(
         &self,
         array_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-    ) -> Result<(), ArrayError> {
-        self.retrieve_array_subset_into_opt(array_subset, output_target, &CodecOptions::default())
-    }
+    ) -> Result<(), ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn partial_decoder(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
-        self.partial_decoder_opt(chunk_indices, &CodecOptions::default())
-    }
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError>;
 
     /////////////////////////////////////////////////////////////////////////////
     // Advanced methods

--- a/zarrs/src/array/array_ops/array_read_ops/array_cached.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/array_cached.rs
@@ -459,8 +459,18 @@ where
         output_target: ArrayBytesDecodeIntoTarget<'_>,
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        self.array()
-            .retrieve_array_subset_into_opt(array_subset, output_target, options)
+        super::common::retrieve_array_subset_into(
+            self.array(),
+            array_subset,
+            output_target,
+            options,
+            |chunk_indices, output_target, options| {
+                self.retrieve_chunk_into(chunk_indices, output_target, options)
+            },
+            |chunk_indices, chunk_subset, output_target, options| {
+                self.retrieve_chunk_subset_into(chunk_indices, chunk_subset, output_target, options)
+            },
+        )
     }
 
     #[allow(clippy::missing_errors_doc)]

--- a/zarrs/src/array/array_ops/array_read_ops/array_cached.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/array_cached.rs
@@ -10,7 +10,6 @@ use super::ArrayReadOps;
 use crate::array::array_bytes_internal::{
     merge_chunks_vlen, merge_chunks_vlen_optional, optional_nesting_depth,
 };
-use crate::array::array_sharded_ext::subchunk_shard_index_and_subset;
 use crate::array::chunk_cache::{ChunkCacheType, fill_value_bytes, retrieve_chunk_bytes};
 use crate::array::concurrency::concurrency_chunks_and_codec;
 use crate::array::{ArrayBytes, ArrayBytesFixedDisjointView, ArrayIndicesTinyVec};
@@ -265,12 +264,8 @@ where
     C: ChunkCache,
 {
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunk<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-    ) -> Result<T, ArrayError> {
-        self.retrieve_chunk_opt(chunk_indices, &CodecOptions::default())
-    }
+    pub fn retrieve_chunk<T: FromArrayBytes>(&self, chunk_indices: &[u64])
+    -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunk_opt<T: FromArrayBytes>(
@@ -302,28 +297,21 @@ where
     pub fn retrieve_chunks<T: FromArrayBytes>(
         &self,
         chunks: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError> {
-        self.retrieve_chunks_opt(chunks, &CodecOptions::default())
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunks_opt<T: FromArrayBytes>(
         &self,
         chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
-        let array_subset = self.array().chunks_subset(chunks)?;
-        self.retrieve_array_subset_opt(&array_subset, options)
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunk_subset<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError> {
-        self.retrieve_chunk_subset_opt(chunk_indices, chunk_subset, &CodecOptions::default())
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunk_subset_opt<T: FromArrayBytes>(
@@ -364,9 +352,7 @@ where
     pub fn retrieve_array_subset<T: FromArrayBytes>(
         &self,
         array_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError> {
-        self.retrieve_array_subset_opt(array_subset, &CodecOptions::default())
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_array_subset_opt<T: FromArrayBytes>(
@@ -382,9 +368,7 @@ where
     pub fn retrieve_chunk_if_exists<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<T>, ArrayError> {
-        self.retrieve_chunk_if_exists_opt(chunk_indices, &CodecOptions::default())
-    }
+    ) -> Result<Option<T>, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunk_if_exists_opt<T: FromArrayBytes>(
@@ -414,18 +398,30 @@ where
     pub fn retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
+    ) -> Result<Option<Vec<u8>>, StorageError>;
+
+    #[allow(clippy::missing_errors_doc)]
+    pub fn retrieve_encoded_chunk_opt(
+        &self,
+        chunk_indices: &[u64],
+        options: &CodecOptions,
     ) -> Result<Option<Vec<u8>>, StorageError> {
-        self.array().retrieve_encoded_chunk(chunk_indices)
+        self.array()
+            .retrieve_encoded_chunk_opt(chunk_indices, options)
     }
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_encoded_chunks(
         &self,
         chunks: &dyn ArraySubsetTraits,
+    ) -> Result<Vec<Option<Vec<u8>>>, StorageError>;
+
+    #[allow(clippy::missing_errors_doc)]
+    pub fn retrieve_encoded_chunks_opt(
+        &self,
+        chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<Vec<Option<Vec<u8>>>, StorageError> {
-        self.array().retrieve_encoded_chunks(chunks, options)
-    }
+    ) -> Result<Vec<Option<Vec<u8>>>, StorageError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_encoded_subchunk(
@@ -440,42 +436,21 @@ where
         &self,
         subchunk_indices: &[u64],
         options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
-        let (chunk_indices, chunk_subset) = subchunk_shard_index_and_subset(
-            self.array(),
-            self.array().subchunk_grid(),
-            subchunk_indices,
-        )?;
-        self.retrieve_chunk_subset_opt(&chunk_indices, &chunk_subset, options)
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_subchunks_opt<T: FromArrayBytes>(
         &self,
         subchunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
-        let array_subset = self
-            .array()
-            .subchunk_grid()
-            .chunks_subset(subchunks)?
-            .ok_or_else(|| {
-                ArrayError::InvalidArraySubset(
-                    subchunks.to_array_subset(),
-                    self.array().subchunk_grid_shape(),
-                )
-            })?;
-        self.retrieve_array_subset_opt(&array_subset, options)
-    }
+    ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_array_subset_into(
         &self,
         array_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-    ) -> Result<(), ArrayError> {
-        self.retrieve_array_subset_into_opt(array_subset, output_target, &CodecOptions::default())
-    }
+    ) -> Result<(), ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_array_subset_into_opt(
@@ -492,9 +467,7 @@ where
     pub fn partial_decoder(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
-        self.partial_decoder_opt(chunk_indices, &CodecOptions::default())
-    }
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn partial_decoder_opt(

--- a/zarrs/src/array/array_ops/array_read_ops/common.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/common.rs
@@ -1,0 +1,181 @@
+use crate::array::{
+    Array, ArrayBytesFixedDisjointView, ArrayError, ArrayIndicesTinyVec, ArraySubset,
+    ArraySubsetTraits,
+};
+use crate::iter_concurrent_limit;
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use zarrs_codec::{
+    ArrayBytesDecodeIntoTarget, CodecError, CodecOptions, InvalidNumberOfElementsError,
+    copy_fill_value_into,
+};
+use zarrs_storage::{MaybeSend, MaybeSync, ReadableStorageTraits};
+
+use super::super::super::array_bytes_internal::{
+    build_nested_optional_target, extract_target_views,
+};
+use super::super::super::concurrency::concurrency_chunks_and_codec;
+
+pub(super) fn retrieve_array_subset_into<TStorage, RetrieveChunkInto, RetrieveChunkSubsetInto>(
+    array: &Array<TStorage>,
+    array_subset: &dyn ArraySubsetTraits,
+    output_target: ArrayBytesDecodeIntoTarget<'_>,
+    options: &CodecOptions,
+    retrieve_chunk_into: RetrieveChunkInto,
+    retrieve_chunk_subset_into: RetrieveChunkSubsetInto,
+) -> Result<(), ArrayError>
+where
+    TStorage: ?Sized + ReadableStorageTraits + 'static,
+    RetrieveChunkInto:
+        for<'a> Fn(&[u64], ArrayBytesDecodeIntoTarget<'a>, &CodecOptions) -> Result<(), ArrayError>,
+    RetrieveChunkSubsetInto: for<'a> Fn(
+            &[u64],
+            &dyn ArraySubsetTraits,
+            ArrayBytesDecodeIntoTarget<'a>,
+            &CodecOptions,
+        ) -> Result<(), ArrayError>
+        + MaybeSend
+        + MaybeSync,
+{
+    if array_subset.dimensionality() != array.dimensionality() {
+        return Err(ArrayError::InvalidArraySubset(
+            array_subset.to_array_subset(),
+            array.shape().to_vec(),
+        ));
+    }
+
+    if !array.data_type().is_fixed() {
+        return Err(ArrayError::CodecError(CodecError::Other(
+            "retrieve_array_subset_into does not support variable-length data types".to_string(),
+        )));
+    }
+
+    if output_target.num_elements() != array_subset.num_elements() {
+        return Err(ArrayError::CodecError(
+            InvalidNumberOfElementsError::new(
+                output_target.num_elements(),
+                array_subset.num_elements(),
+            )
+            .into(),
+        ));
+    }
+
+    let Some(chunks) = array.chunks_in_array_subset(array_subset)? else {
+        return Err(ArrayError::InvalidArraySubset(
+            array_subset.to_array_subset(),
+            array.shape().to_vec(),
+        ));
+    };
+
+    let num_chunks = chunks.num_elements_usize();
+    match num_chunks {
+        0 => copy_fill_value_into(array.data_type(), array.fill_value(), output_target)
+            .map_err(ArrayError::CodecError),
+        1 => {
+            let chunk_indices = chunks.start();
+            let chunk_subset = array.chunk_subset(chunk_indices)?;
+            if chunk_subset == array_subset {
+                retrieve_chunk_into(chunk_indices, output_target, options)
+            } else {
+                retrieve_chunk_subset_into(
+                    chunk_indices,
+                    &array_subset.relative_to(chunk_subset.start())?,
+                    output_target,
+                    options,
+                )
+            }
+        }
+        _ => {
+            let chunk_shape = array.chunk_shape(chunks.start())?;
+            let codec_concurrency =
+                array.recommended_codec_concurrency(&chunk_shape, array.data_type())?;
+            let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
+                options.concurrent_target(),
+                num_chunks,
+                options,
+                &codec_concurrency,
+            );
+            retrieve_multi_chunk_fixed_into(
+                array,
+                array_subset,
+                &chunks,
+                chunk_concurrent_limit,
+                &output_target,
+                &options,
+                &retrieve_chunk_subset_into,
+            )
+        }
+    }
+}
+
+fn retrieve_multi_chunk_fixed_into<TStorage, RetrieveChunkSubsetInto>(
+    array: &Array<TStorage>,
+    array_subset: &dyn ArraySubsetTraits,
+    chunks: &dyn ArraySubsetTraits,
+    chunk_concurrent_limit: usize,
+    output_target: &ArrayBytesDecodeIntoTarget<'_>,
+    options: &CodecOptions,
+    retrieve_chunk_subset_into: &RetrieveChunkSubsetInto,
+) -> Result<(), ArrayError>
+where
+    TStorage: ?Sized + ReadableStorageTraits + 'static,
+    RetrieveChunkSubsetInto: for<'a> Fn(
+            &[u64],
+            &dyn ArraySubsetTraits,
+            ArrayBytesDecodeIntoTarget<'a>,
+            &CodecOptions,
+        ) -> Result<(), ArrayError>
+        + MaybeSend
+        + MaybeSync,
+{
+    let (data_view_ref, mask_view_refs) = extract_target_views(output_target);
+    let parent_start = data_view_ref.subset().start().to_vec();
+
+    let retrieve_chunk = |chunk_indices: ArrayIndicesTinyVec| {
+        let chunk_subset = array.chunk_subset(&chunk_indices)?;
+        let chunk_subset_overlap = chunk_subset.overlap(array_subset)?;
+        let chunk_subset_in_array = chunk_subset_overlap.relative_to(&array_subset.start())?;
+
+        let chunk_start_in_view: Vec<u64> = chunk_subset_in_array
+            .start()
+            .iter()
+            .zip(&parent_start)
+            .map(|(&c, &p)| c + p)
+            .collect();
+        let chunk_subset_in_view = ArraySubset::new_with_start_shape(
+            chunk_start_in_view,
+            chunk_subset_in_array.shape().to_vec(),
+        )?;
+
+        let mut data_sub = unsafe {
+            // SAFETY: chunks represent disjoint array subsets.
+            data_view_ref.subdivide(chunk_subset_in_view.clone())?
+        };
+
+        let mut mask_subs: Vec<ArrayBytesFixedDisjointView<'_>> = mask_view_refs
+            .iter()
+            .map(|mask_view| unsafe {
+                // SAFETY: chunks represent disjoint array subsets.
+                mask_view.subdivide(chunk_subset_in_view.clone())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let target = build_nested_optional_target(&mut data_sub, mask_subs.as_mut_slice());
+        retrieve_chunk_subset_into(
+            &chunk_indices,
+            &chunk_subset_overlap.relative_to(chunk_subset.start())?,
+            target,
+            options,
+        )?;
+        Ok::<_, ArrayError>(())
+    };
+
+    iter_concurrent_limit!(
+        chunk_concurrent_limit,
+        chunks.indices(),
+        try_for_each,
+        retrieve_chunk
+    )?;
+
+    Ok(())
+}

--- a/zarrs/src/array/array_ops/array_update_ops.rs
+++ b/zarrs/src/array/array_ops/array_update_ops.rs
@@ -24,7 +24,14 @@ pub trait ArrayUpdateOps: ArrayReadOps + ArrayWriteOps {
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         chunk_subset_data: T,
-    ) -> Result<(), ArrayError>;
+    ) -> Result<(), ArrayError> {
+        self.store_chunk_subset_opt(
+            chunk_indices,
+            chunk_subset,
+            chunk_subset_data,
+            self.codec_options(),
+        )
+    }
 
     /// Explicit options version of [`store_chunk_subset`](ArrayUpdateOps::store_chunk_subset).
     fn store_chunk_subset_opt<'a, T: IntoArrayBytes<'a>>(
@@ -50,7 +57,9 @@ pub trait ArrayUpdateOps: ArrayReadOps + ArrayWriteOps {
         &self,
         array_subset: &dyn ArraySubsetTraits,
         subset_data: T,
-    ) -> Result<(), ArrayError>;
+    ) -> Result<(), ArrayError> {
+        self.store_array_subset_opt(array_subset, subset_data, self.codec_options())
+    }
 
     /// Explicit options version of [`store_array_subset`](ArrayUpdateOps::store_array_subset).
     fn store_array_subset_opt<'a, T: IntoArrayBytes<'a>>(

--- a/zarrs/src/array/array_ops/array_update_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_update_ops/array.rs
@@ -24,14 +24,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         chunk_subset_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_chunk_subset_opt(
-            chunk_indices,
-            chunk_subset,
-            chunk_subset_data,
-            &CodecOptions::default(),
-        )
-    }
+    ) -> Result<(), ArrayError>;
 
     #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     pub fn store_chunk_subset_opt<'a, T: IntoArrayBytes<'a>>(
@@ -103,9 +96,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
         &self,
         array_subset: &dyn ArraySubsetTraits,
         subset_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_array_subset_opt(array_subset, subset_data, &CodecOptions::default())
-    }
+    ) -> Result<(), ArrayError>;
 
     #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     #[allow(clippy::too_many_lines)]

--- a/zarrs/src/array/array_ops/array_update_ops/array_cached.rs
+++ b/zarrs/src/array/array_ops/array_update_ops/array_cached.rs
@@ -96,14 +96,7 @@ where
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         chunk_subset_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_chunk_subset_opt(
-            chunk_indices,
-            chunk_subset,
-            chunk_subset_data,
-            &CodecOptions::default(),
-        )
-    }
+    ) -> Result<(), ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn store_chunk_subset_opt<'a, T: IntoArrayBytes<'a>>(
@@ -128,9 +121,7 @@ where
         &self,
         array_subset: &dyn ArraySubsetTraits,
         subset_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_array_subset_opt(array_subset, subset_data, &CodecOptions::default())
-    }
+    ) -> Result<(), ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn store_array_subset_opt<'a, T: IntoArrayBytes<'a>>(

--- a/zarrs/src/array/array_ops/array_write_ops.rs
+++ b/zarrs/src/array/array_ops/array_write_ops.rs
@@ -11,7 +11,9 @@ pub trait ArrayWriteOps: ArrayOps {
     ///
     /// # Errors
     /// Returns [`StorageError`] if there is an underlying store error.
-    fn store_metadata(&self) -> Result<(), StorageError>;
+    fn store_metadata(&self) -> Result<(), StorageError> {
+        self.store_metadata_opt(self.metadata_options())
+    }
 
     /// Store metadata with non-default [`ArrayMetadataOptions`].
     ///
@@ -27,7 +29,9 @@ pub trait ArrayWriteOps: ArrayOps {
     ///
     /// # Errors
     /// Returns a [`StorageError`] if there is an underlying store error.
-    fn erase_metadata(&self) -> Result<(), StorageError>;
+    fn erase_metadata(&self) -> Result<(), StorageError> {
+        self.erase_metadata_opt(self.metadata_erase_version())
+    }
 
     /// Erase the metadata with non-default [`MetadataEraseVersion`] options.
     ///
@@ -52,7 +56,9 @@ pub trait ArrayWriteOps: ArrayOps {
         &self,
         chunk_indices: &[u64],
         chunk_data: T,
-    ) -> Result<(), ArrayError>;
+    ) -> Result<(), ArrayError> {
+        self.store_chunk_opt(chunk_indices, chunk_data, self.codec_options())
+    }
 
     /// Explicit options version of [`store_chunk`](ArrayWriteOps::store_chunk).
     fn store_chunk_opt<'a, T: IntoArrayBytes<'a>>(
@@ -77,7 +83,9 @@ pub trait ArrayWriteOps: ArrayOps {
         &self,
         chunks: &dyn ArraySubsetTraits,
         chunks_data: T,
-    ) -> Result<(), ArrayError>;
+    ) -> Result<(), ArrayError> {
+        self.store_chunks_opt(chunks, chunks_data, self.codec_options())
+    }
 
     /// Explicit options version of [`store_chunks`](ArrayWriteOps::store_chunks).
     fn store_chunks_opt<'a, T: IntoArrayBytes<'a>>(

--- a/zarrs/src/array/array_ops/array_write_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_write_ops/array.rs
@@ -15,9 +15,7 @@ use zarrs_storage::{Bytes, StorageHandle};
 
 #[inherent]
 impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array<TStorage> {
-    pub fn store_metadata(&self) -> Result<(), StorageError> {
-        self.store_metadata_opt(&self.metadata_options)
-    }
+    pub fn store_metadata(&self) -> Result<(), StorageError>;
 
     pub fn store_metadata_opt(&self, options: &ArrayMetadataOptions) -> Result<(), StorageError> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
@@ -60,9 +58,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
         }
     }
 
-    pub fn erase_metadata(&self) -> Result<(), StorageError> {
-        self.erase_metadata_opt(self.metadata_erase_version)
-    }
+    pub fn erase_metadata(&self) -> Result<(), StorageError>;
 
     pub fn erase_metadata_opt(&self, options: MetadataEraseVersion) -> Result<(), StorageError> {
         let storage_handle = StorageHandle::new(self.storage.clone());
@@ -91,9 +87,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
         &self,
         chunk_indices: &[u64],
         chunk_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_chunk_opt(chunk_indices, chunk_data, &CodecOptions::default())
-    }
+    ) -> Result<(), ArrayError>;
 
     pub fn store_chunk_opt<'a, T: IntoArrayBytes<'a>>(
         &self,
@@ -132,9 +126,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
         &self,
         chunks: &dyn ArraySubsetTraits,
         chunks_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_chunks_opt(chunks, chunks_data, &CodecOptions::default())
-    }
+    ) -> Result<(), ArrayError>;
 
     pub fn store_chunks_opt<'a, T: IntoArrayBytes<'a>>(
         &self,

--- a/zarrs/src/array/array_ops/array_write_ops/array_cached.rs
+++ b/zarrs/src/array/array_ops/array_write_ops/array_cached.rs
@@ -9,11 +9,7 @@ where
     TStorage: ?Sized + WritableStorageTraits + 'static,
     C: ChunkCache,
 {
-    pub fn store_metadata(&self) -> Result<(), StorageError> {
-        self.array().store_metadata()?;
-        self.cache().invalidate();
-        Ok(())
-    }
+    pub fn store_metadata(&self) -> Result<(), StorageError>;
 
     pub fn store_metadata_opt(&self, options: &ArrayMetadataOptions) -> Result<(), StorageError> {
         self.array().store_metadata_opt(options)?;
@@ -21,11 +17,7 @@ where
         Ok(())
     }
 
-    pub fn erase_metadata(&self) -> Result<(), StorageError> {
-        self.array().erase_metadata()?;
-        self.cache().invalidate();
-        Ok(())
-    }
+    pub fn erase_metadata(&self) -> Result<(), StorageError>;
 
     pub fn erase_metadata_opt(&self, options: MetadataEraseVersion) -> Result<(), StorageError> {
         self.array().erase_metadata_opt(options)?;
@@ -37,9 +29,7 @@ where
         &self,
         chunk_indices: &[u64],
         chunk_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_chunk_opt(chunk_indices, chunk_data, &CodecOptions::default())
-    }
+    ) -> Result<(), ArrayError>;
 
     pub fn store_chunk_opt<'a, T: IntoArrayBytes<'a>>(
         &self,
@@ -57,9 +47,7 @@ where
         &self,
         chunks: &dyn ArraySubsetTraits,
         chunks_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_chunks_opt(chunks, chunks_data, &CodecOptions::default())
-    }
+    ) -> Result<(), ArrayError>;
 
     pub fn store_chunks_opt<'a, T: IntoArrayBytes<'a>>(
         &self,

--- a/zarrs/src/array/array_ops/async_array_read_ops.rs
+++ b/zarrs/src/array/array_ops/async_array_read_ops.rs
@@ -37,7 +37,11 @@ pub trait AsyncArrayReadOps: ArrayOps {
         &self,
         chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
+    ) -> Result<T, ArrayError> {
+        let array_subset = self.chunks_subset(chunks)?;
+        self.async_retrieve_array_subset_opt(&array_subset, options)
+            .await
+    }
 
     /// Async variant of [`ArrayReadOps::retrieve_chunk_subset`].
     #[allow(clippy::missing_errors_doc)]
@@ -96,6 +100,17 @@ pub trait AsyncArrayReadOps: ArrayOps {
     async fn async_retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
+    ) -> Result<Option<Bytes>, StorageError> {
+        self.async_retrieve_encoded_chunk_opt(chunk_indices, self.codec_options())
+            .await
+    }
+
+    /// Async variant of [`ArrayReadOps::retrieve_encoded_chunk_opt`].
+    #[allow(clippy::missing_errors_doc)]
+    async fn async_retrieve_encoded_chunk_opt(
+        &self,
+        chunk_indices: &[u64],
+        options: &CodecOptions,
     ) -> Result<Option<Bytes>, StorageError>;
 
     /// Async variant of [`ArrayReadOps::retrieve_encoded_chunks`].
@@ -108,6 +123,16 @@ pub trait AsyncArrayReadOps: ArrayOps {
     /// Returns a [`StorageError`] if there is an underlying store error.
     #[allow(clippy::missing_errors_doc)]
     async fn async_retrieve_encoded_chunks(
+        &self,
+        chunks: &dyn ArraySubsetTraits,
+    ) -> Result<Vec<Option<Bytes>>, StorageError> {
+        self.async_retrieve_encoded_chunks_opt(chunks, self.codec_options())
+            .await
+    }
+
+    /// Async variant of [`ArrayReadOps::retrieve_encoded_chunks_opt`].
+    #[allow(clippy::missing_errors_doc)]
+    async fn async_retrieve_encoded_chunks_opt(
         &self,
         chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,

--- a/zarrs/src/array/array_ops/async_array_read_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_read_ops/array.rs
@@ -33,7 +33,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         chunk_indices: &[u64],
     ) -> Result<T, ArrayError> {
-        self.async_retrieve_chunk_opt(chunk_indices, &self.codec_options)
+        self.async_retrieve_chunk_opt(chunk_indices, self.codec_options())
             .await
     }
 
@@ -68,7 +68,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         chunks: &dyn ArraySubsetTraits,
     ) -> Result<T, ArrayError> {
-        self.async_retrieve_chunks_opt(chunks, &self.codec_options)
+        self.async_retrieve_chunks_opt(chunks, self.codec_options())
             .await
     }
 
@@ -76,25 +76,14 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
-        if chunks.dimensionality() != self.dimensionality() {
-            return Err(ArrayError::InvalidArraySubset(
-                chunks.to_array_subset(),
-                self.shape().to_vec(),
-            ));
-        }
-
-        let array_subset = self.chunks_subset(chunks)?;
-        self.async_retrieve_array_subset_opt(&array_subset, options)
-            .await
-    }
+    ) -> Result<T, ArrayError>;
 
     pub async fn async_retrieve_chunk_subset<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
     ) -> Result<T, ArrayError> {
-        self.async_retrieve_chunk_subset_opt(chunk_indices, chunk_subset, &self.codec_options)
+        self.async_retrieve_chunk_subset_opt(chunk_indices, chunk_subset, self.codec_options())
             .await
     }
 
@@ -151,7 +140,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         array_subset: &dyn ArraySubsetTraits,
     ) -> Result<T, ArrayError> {
-        self.async_retrieve_array_subset_opt(array_subset, &self.codec_options)
+        self.async_retrieve_array_subset_opt(array_subset, self.codec_options())
             .await
     }
 
@@ -243,14 +232,21 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         chunk_indices: &[u64],
     ) -> Result<Option<T>, ArrayError> {
-        self.async_retrieve_chunk_if_exists_opt(chunk_indices, &self.codec_options)
+        self.async_retrieve_chunk_if_exists_opt(chunk_indices, self.codec_options())
             .await
     }
 
     pub async fn async_retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
+    ) -> Result<Option<Bytes>, StorageError>;
+
+    pub async fn async_retrieve_encoded_chunk_opt(
+        &self,
+        chunk_indices: &[u64],
+        options: &CodecOptions,
     ) -> Result<Option<Bytes>, StorageError> {
+        let _ = options;
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
@@ -267,7 +263,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         array_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
     ) -> Result<(), ArrayError> {
-        self.async_retrieve_array_subset_into_opt(array_subset, output_target, &self.codec_options)
+        self.async_retrieve_array_subset_into_opt(array_subset, output_target, self.codec_options())
             .await
     }
 
@@ -275,7 +271,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         chunk_indices: &[u64],
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, ArrayError> {
-        self.async_partial_decoder_opt(chunk_indices, &self.codec_options)
+        self.async_partial_decoder_opt(chunk_indices, self.codec_options())
             .await
     }
 
@@ -326,6 +322,11 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
     }
 
     pub async fn async_retrieve_encoded_chunks(
+        &self,
+        chunks: &dyn ArraySubsetTraits,
+    ) -> Result<Vec<Option<Bytes>>, StorageError>;
+
+    pub async fn async_retrieve_encoded_chunks_opt(
         &self,
         chunks: &dyn ArraySubsetTraits,
         options: &CodecOptions,
@@ -394,7 +395,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
             sharding_codec.inner_codecs.clone(),
             &sharding_codec.index_codecs,
             sharding_codec.index_location,
-            &self.codec_options,
+            self.codec_options(),
             sharding_codec.options.clone(),
         )
         .await?;

--- a/zarrs/src/array/array_ops/async_array_update_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_update_ops/array.rs
@@ -27,7 +27,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
             chunk_indices,
             chunk_subset,
             chunk_subset_data,
-            &self.codec_options,
+            self.codec_options(),
         )
         .await
     }
@@ -103,7 +103,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
         array_subset: &dyn ArraySubsetTraits,
         subset_data: T,
     ) -> Result<(), ArrayError> {
-        self.async_store_array_subset_opt(array_subset, subset_data, &self.codec_options)
+        self.async_store_array_subset_opt(array_subset, subset_data, self.codec_options())
             .await
     }
 

--- a/zarrs/src/array/array_ops/async_array_write_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_write_ops/array.rs
@@ -17,7 +17,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
     for Array<TStorage>
 {
     pub async fn async_store_metadata(&self) -> Result<(), StorageError> {
-        self.async_store_metadata_opt(&self.metadata_options).await
+        self.async_store_metadata_opt(self.metadata_options()).await
     }
 
     pub async fn async_store_metadata_opt(
@@ -68,7 +68,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
     }
 
     pub async fn async_erase_metadata(&self) -> Result<(), StorageError> {
-        self.async_erase_metadata_opt(self.metadata_erase_version)
+        self.async_erase_metadata_opt(self.metadata_erase_version())
             .await
     }
 
@@ -115,7 +115,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
         chunk_indices: &[u64],
         chunk_data: T,
     ) -> Result<(), ArrayError> {
-        self.async_store_chunk_opt(chunk_indices, chunk_data, &CodecOptions::default())
+        self.async_store_chunk_opt(chunk_indices, chunk_data, self.codec_options())
             .await
     }
 
@@ -157,7 +157,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
         chunks: &dyn ArraySubsetTraits,
         chunks_data: T,
     ) -> Result<(), ArrayError> {
-        self.async_store_chunks_opt(chunks, chunks_data, &CodecOptions::default())
+        self.async_store_chunks_opt(chunks, chunks_data, self.codec_options())
             .await
     }
 

--- a/zarrs/src/array/array_sharded_ext.rs
+++ b/zarrs/src/array/array_sharded_ext.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
 
 use super::chunk_grid::{RectilinearChunkGrid, RegularBoundedChunkGrid, RegularChunkGrid};
-use super::{Array, ArrayError, ArrayShape, ArraySubset, ChunkGrid, ChunkShape, CodecChain};
+use super::{ArrayError, ArrayOps, ArrayShape, ArraySubset, ChunkGrid, ChunkShape, CodecChain};
 use crate::array::chunk_grid::ChunkEdgeLengths;
 use crate::array::chunk_grid::repeat::RepeatChunkGrid;
 use crate::array::codec::array_to_bytes::sharding::ShardingCodec;
@@ -177,8 +177,8 @@ struct SubchunkShardLocation {
     array_subset: ArraySubset,
 }
 
-fn subchunk_shard_location<TStorage: ?Sized>(
-    array: &Array<TStorage>,
+fn subchunk_shard_location<A: ArrayOps + ?Sized>(
+    array: &A,
     subchunk_grid: &ChunkGrid,
     subchunk_indices: &[u64],
 ) -> Result<SubchunkShardLocation, ArrayError> {
@@ -203,8 +203,8 @@ fn subchunk_shard_location<TStorage: ?Sized>(
     })
 }
 
-pub(super) fn subchunk_shard_index_and_subset<TStorage: ?Sized>(
-    array: &Array<TStorage>,
+pub(super) fn subchunk_shard_index_and_subset<A: ArrayOps + ?Sized>(
+    array: &A,
     subchunk_grid: &ChunkGrid,
     subchunk_indices: &[u64],
 ) -> Result<(Vec<u64>, ArraySubset), ArrayError> {
@@ -213,8 +213,8 @@ pub(super) fn subchunk_shard_index_and_subset<TStorage: ?Sized>(
     Ok((location.shard_indices, shard_subset))
 }
 
-pub(super) fn subchunk_shard_index_and_chunk_index<TStorage: ?Sized>(
-    array: &Array<TStorage>,
+pub(super) fn subchunk_shard_index_and_chunk_index<A: ArrayOps + ?Sized>(
+    array: &A,
     subchunk_grid: &ChunkGrid,
     subchunk_indices: &[u64],
 ) -> Result<(Vec<u64>, Vec<u64>), ArrayError> {
@@ -240,7 +240,7 @@ mod tests {
 
     use super::*;
     use crate::array::chunk_grid::{RectangularChunkGrid, RectilinearChunkGrid};
-    use crate::array::{ArrayBuilder, data_type};
+    use crate::array::{Array, ArrayBuilder, data_type};
     use zarrs_metadata_ext::chunk_grid::rectangular::RectangularChunkGridDimensionConfiguration;
     use zarrs_metadata_ext::chunk_grid::rectilinear::{ChunkEdgeLengths, RunLengthElement};
     use zarrs_plugin::ExtensionName;

--- a/zarrs/tests/array_ops.rs
+++ b/zarrs/tests/array_ops.rs
@@ -247,7 +247,7 @@ fn exercise_array_read_ops<A: ArrayReadOps + ArrayWriteOps>(array: &A) -> TestRe
     );
     assert!(array.retrieve_encoded_chunk(&[0, 0])?.is_some());
     assert_eq!(
-        array.retrieve_encoded_chunks(&chunks, &options)?.len(),
+        array.retrieve_encoded_chunks_opt(&chunks, &options)?.len(),
         chunks.num_elements_usize()
     );
     assert!(array.retrieve_encoded_subchunk(&[1, 1])?.is_some());

--- a/zarrs/tests/array_ops.rs
+++ b/zarrs/tests/array_ops.rs
@@ -497,6 +497,36 @@ fn array_cached_cache_hits_and_invalidation_cover_all_value_types() -> TestResul
     assert_cache_hits_and_invalidation(ChunkCachePartialDecoderLruChunkLimit::new(16), false)
 }
 
+fn assert_cache_hits_for_array_subset_into<C>(cache: C) -> TestResult
+where
+    C: ChunkCache + 'static,
+{
+    let (array, store) = fixture();
+    populate(array.as_ref())?;
+    let cached = ArrayCached::new(array, cache);
+    let subset = ArraySubset::new_with_ranges(&[1..4, 1..4]);
+
+    store.reset();
+    assert_eq!(
+        retrieve_into(&cached, &subset, None, true)?,
+        [7, 8, 9, 12, 13, 14, 17, 18, 19]
+    );
+    let reads_after_miss = store.reads();
+    assert!(reads_after_miss > 0);
+    assert_eq!(
+        retrieve_into(&cached, &subset, None, true)?,
+        [7, 8, 9, 12, 13, 14, 17, 18, 19]
+    );
+    assert_eq!(store.reads(), reads_after_miss);
+    Ok(())
+}
+
+#[test]
+fn array_cached_array_subset_into_uses_cache() -> TestResult {
+    assert_cache_hits_for_array_subset_into(ChunkCacheEncodedLruChunkLimit::new(16))?;
+    assert_cache_hits_for_array_subset_into(ChunkCacheDecodedLruChunkLimit::new(16))
+}
+
 // TODO: ChunkCacheType could be adjusted so that ChunkCacheEncoded could handle caching of encoded chunks, but seems low value
 #[test]
 fn array_cached_encoded_reads_bypass_cache() -> TestResult {

--- a/zarrs/tests/array_ops_async.rs
+++ b/zarrs/tests/array_ops_async.rs
@@ -163,7 +163,7 @@ async fn exercise_async_read_ops<A: AsyncArrayUpdateOps>(array: &A) -> TestResul
     assert!(array.async_retrieve_encoded_chunk(&[0, 0]).await?.is_some());
     assert_eq!(
         array
-            .async_retrieve_encoded_chunks(&chunks, &options)
+            .async_retrieve_encoded_chunks_opt(&chunks, &options)
             .await?
             .len(),
         chunks.num_elements_usize()


### PR DESCRIPTION
- Add `ArrayOps::{codec_options,metadata_options,metadata_erase_version}`
- Add `ArrayReadOps::{retrieve_encoded_chunk_opt,retrieve_encoded_chunks_opt}`
- Use cache in `ArrayCached::retrieve_array_subset_into_opt`