### PR TITLE
refactor: use `camino::Utf8PathBuf` in `NodePath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Breaking**: Remove `retrieve_*` methods, these are handled by `ArrayCached` instead
   - **Breaking**: Change `ChunkCacheTypeDecoded` to an `Option`
   - Add `invalidate` methods
+- `NodePath` now uses `camino::Utf8PathBuf` internally instead of `std::path::PathBuf`
+  - Add `NodePath::as_utf8_path()` for direct access to `camino::Utf8Path`
 
 ### Removed
 - **Breaking**: Remove `ArrayShardedReadableExt`

--- a/zarrs/Cargo.toml
+++ b/zarrs/Cargo.toml
@@ -92,6 +92,7 @@ float8 = { version = "0.5.0", optional = true, features = ["bytemuck"] }
 microfloat = { version = "0.1.3", optional = true, features = ["bytemuck"] }
 simd-adler32 = { version = "0.3.7", optional = true }
 itoa = "1.0.15"
+camino = "1.1"
 log = "0.4.28"
 base64 = "0.22.1"
 zarrs_chunk_grid.workspace = true

--- a/zarrs/src/node/node_path.rs
+++ b/zarrs/src/node/node_path.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 use derive_more::Display;
 use thiserror::Error;
@@ -10,8 +10,8 @@ use zarrs_storage::{StorePrefix, StorePrefixError};
 ///
 /// See <https://zarr-specs.readthedocs.io/en/latest/v3/core/index.html#path>
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display)]
-#[display("{}", _0.to_string_lossy())]
-pub struct NodePath(PathBuf);
+#[display("{}", _0)]
+pub struct NodePath(Utf8PathBuf);
 
 /// An invalid node path.
 #[derive(Clone, Debug, Error)]
@@ -26,7 +26,7 @@ impl NodePath {
     /// Returns [`NodePathError`] if `path` is not valid according to [`NodePath::validate`()].
     pub fn new(path: &str) -> Result<Self, NodePathError> {
         if Self::validate(path) {
-            Ok(Self(PathBuf::from(path)))
+            Ok(Self(Utf8PathBuf::from(path)))
         } else {
             Err(NodePathError(path.to_string()))
         }
@@ -35,19 +35,24 @@ impl NodePath {
     /// The root node.
     #[must_use]
     pub fn root() -> Self {
-        Self(PathBuf::from("/"))
+        Self(Utf8PathBuf::from("/"))
     }
 
     /// Extracts a string slice containing the node path `String`.
-    #[allow(clippy::missing_panics_doc)]
     #[must_use]
     pub fn as_str(&self) -> &str {
-        self.0.to_str().unwrap()
+        self.0.as_str()
     }
 
     /// Extracts the path as a [`std::path::Path`].
     #[must_use]
     pub fn as_path(&self) -> &std::path::Path {
+        self.0.as_std_path()
+    }
+
+    /// Extracts the path as a [`camino::Utf8Path`].
+    #[must_use]
+    pub fn as_utf8_path(&self) -> &camino::Utf8Path {
         &self.0
     }
 
@@ -79,7 +84,7 @@ impl NodePath {
     /// Returns `true` if this is the root path.
     #[must_use]
     pub fn is_root(&self) -> bool {
-        self.0.as_os_str() == "/"
+        self.0.as_str() == "/"
     }
 
     /// Returns the parent path of this node, or `None` if this is the root path.


### PR DESCRIPTION
closes #355