### PR TITLE
refactor: bound array->array and array->bytes codecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `invalidate` methods
 - `NodePath` now uses `camino::Utf8PathBuf` internally instead of `std::path::PathBuf`
   - Add `NodePath::as_utf8_path()` for direct access to `camino::Utf8Path`
+- **Breaking**: change `ArrayCreateError::CodecError` to contain a `CodecCreateError` rather than a `PluginCreateError`
 
 ### Removed
 - **Breaking**: Remove `ArrayShardedReadableExt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/zarrs/zarrs/compare/zarrs-v0.23.13...HEAD)
 
 ### Added
-- Add `CodecChainBound` and `ArrayOps::codecs_bound` for context-bound codec runtime operations
 - Implement `Default` for `MetadataRetrieveVersion`
 - Add `GroupOpenOptions` and `Group::new_with_metadata_opt`
 - Implement `Copy` for `GroupMetadataOptions`
@@ -18,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `ArrayOps::partial_decode_granularity` replacing `ArrayShardedExt::effective_subchunk_shape`
   - Add `ArrayReadOps::{retrieve_encoded_subchunk,retrieve_subchunk_opt,retrieve_subchunks_opt}`
   - These are implemented as inherent traits on `Array` and `ArrayCached`
+- Add `CodecChainBound` and `ArrayOps::codecs_bound` for data type and fill value context-bound codec runtime operations
 
 ### Changed
-- **Breaking**: Make array codec-specific reconfiguration APIs fallible and rebuild the bound codec chain after reconfiguration
 - Bind array codec chains eagerly during array construction and use the bound chain for runtime and representation queries
 - **Breaking**: bump `zarrs_chunk_grid` to 0.6.0
 - **Breaking**: Bump `zarrs_codec` to 0.3.0
@@ -39,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `invalidate` methods
 - `NodePath` now uses `camino::Utf8PathBuf` internally instead of `std::path::PathBuf`
   - Add `NodePath::as_utf8_path()` for direct access to `camino::Utf8Path`
+- **Breaking**: Make array codec-specific reconfiguration APIs fallible
 - **Breaking**: change `ArrayCreateError::CodecError` to contain a `CodecCreateError` rather than a `PluginCreateError`
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The partial decode granularity potentially being incorrect with multiple array-to-array codecs
+- Fixed `vlen` index endianness handling to use actual index data type rather than `uint64`
 
 ## [0.23.13](https://github.com/zarrs/zarrs/releases/tag/zarrs-v0.23.13) - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - **Breaking**: Remove `ArrayShardedReadableExt`
 - **Breaking**: Remove `ArrayShardedExt::effective_subchunk_shape`
+- **Breaking**: Remove `CodecError::UnsupportedDataTypeCodec`
 - Remove deprecated `_elements` / `_ndarray` method variants present on `Array` and array extension traits/`ChunkCache`
   - Use the generic `store_*` and `retrieve_*` methods with `Vec<T>` or `ndarray::Array<T, D>` instead
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/zarrs/zarrs/compare/zarrs-v0.23.13...HEAD)
 
 ### Added
+- Add `CodecChainBound` and `ArrayOps::codecs_bound` for context-bound codec runtime operations
 - Implement `Default` for `MetadataRetrieveVersion`
 - Add `GroupOpenOptions` and `Group::new_with_metadata_opt`
 - Implement `Copy` for `GroupMetadataOptions`
@@ -19,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - These are implemented as inherent traits on `Array` and `ArrayCached`
 
 ### Changed
+- **Breaking**: Make array codec-specific reconfiguration APIs fallible and rebuild the bound codec chain after reconfiguration
+- Bind array codec chains eagerly during array construction and use the bound chain for runtime and representation queries
 - **Breaking**: bump `zarrs_chunk_grid` to 0.6.0
 - **Breaking**: Bump `zarrs_codec` to 0.3.0
   - Improves the API for computing partial decoding granularity

--- a/zarrs/benches/codecs.rs
+++ b/zarrs/benches/codecs.rs
@@ -10,7 +10,7 @@ use criterion::{
 use zarrs::array::codec::bytes_to_bytes::blosc::{BloscCompressor, BloscShuffleMode};
 use zarrs::array::codec::{BloscCodec, BytesCodec};
 use zarrs::array::{BytesRepresentation, Element, Endianness, data_type};
-use zarrs_codec::{ArrayToBytesCodecTraits, BytesToBytesCodecTraits, CodecOptions};
+use zarrs_codec::{BytesToBytesCodecTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
 use zarrs_data_type::FillValue;
 
 fn codec_bytes(c: &mut Criterion) {

--- a/zarrs/benches/codecs.rs
+++ b/zarrs/benches/codecs.rs
@@ -25,6 +25,9 @@ fn codec_bytes(c: &mut Criterion) {
     let codec = BytesCodec::new(Some(Endianness::Big));
 
     let fill_value = FillValue::from(0u16);
+    let codec = codec
+        .with_context(data_type::uint16(), fill_value.clone())
+        .unwrap();
     for size in [32, 64, 128, 256, 512].iter() {
         let num_elements = size * size * size;
         let shape = [num_elements.try_into().unwrap(); 1];
@@ -35,13 +38,7 @@ fn codec_bytes(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("encode_decode", num_elements), |b| {
             b.iter(|| {
                 codec
-                    .encode(
-                        bytes.clone(),
-                        &shape,
-                        &data_type::uint16(),
-                        &fill_value,
-                        &CodecOptions::default(),
-                    )
+                    .encode(bytes.clone(), &shape, &CodecOptions::default())
                     .unwrap()
             });
         });

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -769,7 +769,6 @@ impl<TStorage: ?Sized> Array<TStorage> {
     fn recommended_codec_concurrency(
         &self,
         chunk_shape: &[NonZeroU64],
-        _data_type: &DataType,
     ) -> Result<RecommendedConcurrency, ArrayError> {
         Ok(self.codecs_bound().recommended_concurrency(chunk_shape)?)
     }

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -479,6 +479,19 @@ impl<TStorage: ?Sized> Array<TStorage> {
         let data_type = DataType::from_metadata(&v3.data_type)
             .map_err(ArrayCreateError::DataTypeCreateError)?;
 
+        // Create fill value from V3 metadata
+        let fill_value = data_type.fill_value_v3(&v3.fill_value).map_err(|_| {
+            ArrayCreateError::InvalidFillValueMetadata {
+                data_type_name: v3.data_type.name().to_string(),
+                fill_value_metadata: v3.fill_value.clone(),
+            }
+        })?;
+
+        // Create bound codecs
+        let codecs_bound = codecs
+            .clone()
+            .with_context(data_type.clone(), fill_value.clone())?;
+
         // Create chunk grid
         let chunk_grid = ChunkGrid::from_metadata(&v3.chunk_grid, &v3.shape)
             .map_err(ArrayCreateError::ChunkGridCreateError)?;
@@ -488,18 +501,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
                 v3.shape.len(),
             ));
         }
-        let subchunk_grid = array_sharded_ext::create_subchunk_grid(&chunk_grid, &codecs);
-
-        // Create fill value from V3 metadata
-        let fill_value = data_type.fill_value_v3(&v3.fill_value).map_err(|_| {
-            ArrayCreateError::InvalidFillValueMetadata {
-                data_type_name: v3.data_type.name().to_string(),
-                fill_value_metadata: v3.fill_value.clone(),
-            }
-        })?;
-        let codecs_bound = codecs
-            .clone()
-            .with_context(data_type.clone(), fill_value.clone())?;
+        let subchunk_grid = array_sharded_ext::create_subchunk_grid(&chunk_grid, &codecs_bound);
 
         // Create storage transformers
         let storage_transformers =
@@ -604,7 +606,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
         let codecs_bound = codecs
             .clone()
             .with_context(data_type.clone(), fill_value.clone())?;
-        let subchunk_grid = array_sharded_ext::create_subchunk_grid(&chunk_grid, &codecs);
+        let subchunk_grid = array_sharded_ext::create_subchunk_grid(&chunk_grid, &codecs_bound);
 
         // Create chunk key encoding from V2 dimension separator
         let chunk_key_encoding =
@@ -720,7 +722,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
         self.chunk_grid = ChunkGrid::from_metadata(&chunk_grid_metadata, &array_shape)
             .map_err(ArrayCreateError::ChunkGridCreateError)?;
         self.subchunk_grid =
-            array_sharded_ext::create_subchunk_grid(&self.chunk_grid, self.codecs.as_ref());
+            array_sharded_ext::create_subchunk_grid(&self.chunk_grid, &self.codecs_bound);
 
         // Update metadata based on version
         match &mut self.metadata {

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -69,10 +69,10 @@ pub use zarrs_codec::{
     ArrayBytesVariableLength, ArrayCodecTraits, ArrayPartialDecoderTraits,
     ArrayPartialEncoderTraits, ArrayToArrayCodecTraits, ArrayToBytesCodecTraits,
     BytesPartialDecoderTraits, BytesPartialEncoderTraits, BytesRepresentation,
-    BytesToBytesCodecTraits, Codec, CodecError, CodecMetadataOptions, CodecOptions,
-    CodecSpecificOptions, CodecTraits, CodecTraitsV2, CodecTraitsV3, RecommendedConcurrency,
-    StoragePartialDecoder, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
-    copy_fill_value_into, update_array_bytes,
+    BytesToBytesCodecTraits, Codec, CodecCreateError, CodecError, CodecMetadataOptions,
+    CodecOptions, CodecSpecificOptions, CodecTraits, CodecTraitsV2, CodecTraitsV3,
+    RecommendedConcurrency, StoragePartialDecoder, UnboundArrayToArrayCodecTraits,
+    UnboundArrayToBytesCodecTraits, copy_fill_value_into, update_array_bytes,
 };
 #[cfg(feature = "async")]
 pub use zarrs_codec::{
@@ -657,7 +657,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
     /// This replaces the array's codec chain with the reconfigured version.
     ///
     /// # Errors
-    /// Returns a [`CodecError`] if a codec cannot be reconfigured or rebound.
+    /// Returns a [`CodecCreateError`] if a codec cannot be reconfigured or rebound.
     ///
     /// # Example
     /// ```rust,no_run
@@ -675,7 +675,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
     pub fn with_codec_specific_options(
         mut self,
         opts: &CodecSpecificOptions,
-    ) -> Result<Self, CodecError> {
+    ) -> Result<Self, CodecCreateError> {
         self.codecs =
             Arc::new(Arc::unwrap_or_clone(self.codecs).with_codec_specific_options(opts)?);
         self.codecs_bound = self

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -1117,7 +1117,7 @@ fn create_codec_chain_from_v2(
         #[cfg(not(feature = "blosc"))]
         {
             let codec = Codec::from_metadata(compressor)
-                .map_err(|e: PluginCreateError| ArrayMetadataV2ToV3Error::Other(e.to_string()))?;
+                .map_err(|e| ArrayMetadataV2ToV3Error::Other(e.to_string()))?;
 
             match codec {
                 Codec::ArrayToArray(c) => {

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -71,7 +71,8 @@ pub use zarrs_codec::{
     BytesPartialDecoderTraits, BytesPartialEncoderTraits, BytesRepresentation,
     BytesToBytesCodecTraits, Codec, CodecError, CodecMetadataOptions, CodecOptions,
     CodecSpecificOptions, CodecTraits, CodecTraitsV2, CodecTraitsV3, RecommendedConcurrency,
-    StoragePartialDecoder, copy_fill_value_into, update_array_bytes,
+    StoragePartialDecoder, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
+    copy_fill_value_into, update_array_bytes,
 };
 #[cfg(feature = "async")]
 pub use zarrs_codec::{
@@ -100,7 +101,7 @@ pub use self::array_ops::{ArrayMutOps, ArrayOps, ArrayReadOps, ArrayUpdateOps, A
 #[cfg(feature = "async")]
 pub use self::array_ops::{AsyncArrayReadOps, AsyncArrayUpdateOps, AsyncArrayWriteOps};
 use self::chunk_grid::RegularChunkGrid;
-pub use self::codec::CodecChain;
+pub use self::codec::{CodecChain, CodecChainBound};
 pub use self::element::{Element, ElementError, ElementOwned};
 pub use self::from_array_bytes::FromArrayBytes;
 pub use self::into_array_bytes::IntoArrayBytes;
@@ -358,10 +359,10 @@ pub fn chunk_shape_to_array_shape(chunk_shape: &[std::num::NonZeroU64]) -> Array
 /// The key traits for each extension type are:
 /// - Data types ([`zarrs_data_type`]): [`DataTypeTraits`], [`DataTypeTraitsV2`], [`DataTypeTraitsV3`]
 /// - Codecs ([`zarrs_codec`]): [`CodecTraits`], [`CodecTraitsV2`], [`CodecTraitsV3`])
-///   - Array-to-array codecs: [`ArrayCodecTraits`] + [`ArrayToArrayCodecTraits`]
+///   - Array-to-array codecs: [`UnboundArrayToArrayCodecTraits`] and bound [`ArrayToArrayCodecTraits`]
 ///     - [`ArrayPartialEncoderTraits`], [`AsyncArrayPartialEncoderTraits`]
 ///     - [`ArrayPartialDecoderTraits`], [`AsyncArrayPartialDecoderTraits`]
-///   - Array-to-bytes codecs: [`ArrayCodecTraits`] + [`ArrayToBytesCodecTraits`]
+///   - Array-to-bytes codecs: [`UnboundArrayToBytesCodecTraits`] and bound [`ArrayToBytesCodecTraits`]
 ///     - [`BytesPartialEncoderTraits`], [`AsyncBytesPartialEncoderTraits`]
 ///     - [`BytesPartialDecoderTraits`], [`AsyncBytesPartialDecoderTraits`]
 ///   - Bytes-to-bytes codecs: [`BytesToBytesCodecTraits`]
@@ -395,6 +396,8 @@ pub struct Array<TStorage: ?Sized> {
     fill_value: FillValue,
     /// Specifies a list of codecs to be used for encoding and decoding chunks.
     codecs: Arc<CodecChain>,
+    /// The codec chain bound to this array's data type and fill value.
+    codecs_bound: Arc<CodecChainBound>,
     /// An optional list of storage transformers.
     storage_transformers: StorageTransformerChain,
     /// An optional list of dimension names.
@@ -419,6 +422,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
             chunk_key_encoding: self.chunk_key_encoding.clone(),
             fill_value: self.fill_value.clone(),
             codecs: self.codecs.clone(),
+            codecs_bound: self.codecs_bound.clone(),
             storage_transformers: self.storage_transformers.clone(),
             dimension_names: self.dimension_names.clone(),
             metadata: self.metadata.clone(),
@@ -493,6 +497,9 @@ impl<TStorage: ?Sized> Array<TStorage> {
                 fill_value_metadata: v3.fill_value.clone(),
             }
         })?;
+        let codecs_bound = codecs
+            .clone()
+            .with_context(data_type.clone(), fill_value.clone())?;
 
         // Create storage transformers
         let storage_transformers =
@@ -531,6 +538,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
             chunk_key_encoding,
             fill_value,
             codecs,
+            codecs_bound,
             storage_transformers,
             dimension_names: v3.dimension_names.clone(),
             metadata: ArrayMetadata::V3(v3),
@@ -593,6 +601,9 @@ impl<TStorage: ?Sized> Array<TStorage> {
             )
             .map_err(|e| ArrayCreateError::UnsupportedZarrV2Array(e.to_string()))?,
         );
+        let codecs_bound = codecs
+            .clone()
+            .with_context(data_type.clone(), fill_value.clone())?;
         let subchunk_grid = array_sharded_ext::create_subchunk_grid(&chunk_grid, &codecs);
 
         // Create chunk key encoding from V2 dimension separator
@@ -620,6 +631,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
             chunk_key_encoding,
             fill_value,
             codecs,
+            codecs_bound,
             storage_transformers,
             dimension_names: None,
             codec_options,
@@ -642,6 +654,9 @@ impl<TStorage: ?Sized> Array<TStorage> {
     /// reconfigured instance. Codecs that do not recognise any option are left unchanged.
     /// This replaces the array's codec chain with the reconfigured version.
     ///
+    /// # Errors
+    /// Returns a [`CodecError`] if a codec cannot be reconfigured or rebound.
+    ///
     /// # Example
     /// ```rust,no_run
     /// # use std::sync::Arc;
@@ -655,10 +670,17 @@ impl<TStorage: ?Sized> Array<TStorage> {
     /// let array = array.with_codec_specific_options(&opts);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    #[must_use]
-    pub fn with_codec_specific_options(mut self, opts: &CodecSpecificOptions) -> Self {
-        self.codecs = Arc::new(Arc::unwrap_or_clone(self.codecs).with_codec_specific_options(opts));
-        self
+    pub fn with_codec_specific_options(
+        mut self,
+        opts: &CodecSpecificOptions,
+    ) -> Result<Self, CodecError> {
+        self.codecs =
+            Arc::new(Arc::unwrap_or_clone(self.codecs).with_codec_specific_options(opts)?);
+        self.codecs_bound = self
+            .codecs
+            .clone()
+            .with_context(self.data_type.clone(), self.fill_value.clone())?;
+        Ok(self)
     }
 
     /// Set the metadata options.
@@ -745,11 +767,9 @@ impl<TStorage: ?Sized> Array<TStorage> {
     fn recommended_codec_concurrency(
         &self,
         chunk_shape: &[NonZeroU64],
-        data_type: &DataType,
+        _data_type: &DataType,
     ) -> Result<RecommendedConcurrency, ArrayError> {
-        Ok(self
-            .codecs()
-            .recommended_concurrency(chunk_shape, data_type)?)
+        Ok(self.codecs_bound().recommended_concurrency(chunk_shape)?)
     }
 
     /// Convert the array to Zarr V3.
@@ -769,6 +789,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
                     chunk_key_encoding: self.chunk_key_encoding,
                     fill_value: self.fill_value,
                     codecs: self.codecs,
+                    codecs_bound: self.codecs_bound,
                     storage_transformers: self.storage_transformers,
                     dimension_names: self.dimension_names,
                     metadata,
@@ -1001,8 +1022,8 @@ fn create_codec_chain_from_v2(
 ) -> Result<CodecChain, crate::convert::ArrayMetadataV2ToV3Error> {
     use crate::convert::ArrayMetadataV2ToV3Error;
 
-    let mut array_to_array: Vec<Arc<dyn ArrayToArrayCodecTraits>> = vec![];
-    let mut array_to_bytes: Option<Arc<dyn ArrayToBytesCodecTraits>> = None;
+    let mut array_to_array: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>> = vec![];
+    let mut array_to_bytes: Option<Arc<dyn UnboundArrayToBytesCodecTraits>> = None;
     let mut bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>> = vec![];
 
     // Insert transpose for F-order arrays

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -1051,7 +1051,7 @@ fn create_codec_chain_from_v2(
     if let Some(filters) = filters {
         for filter in filters {
             let codec = Codec::from_metadata(filter)
-                .map_err(|e: PluginCreateError| ArrayMetadataV2ToV3Error::Other(e.to_string()))?;
+                .map_err(|e| ArrayMetadataV2ToV3Error::Other(e.to_string()))?;
 
             match codec {
                 Codec::ArrayToArray(c) => {
@@ -1097,7 +1097,7 @@ fn create_codec_chain_from_v2(
             bytes_to_bytes.push(Arc::new(blosc));
         } else {
             let codec = Codec::from_metadata(compressor)
-                .map_err(|e: PluginCreateError| ArrayMetadataV2ToV3Error::Other(e.to_string()))?;
+                .map_err(|e| ArrayMetadataV2ToV3Error::Other(e.to_string()))?;
 
             match codec {
                 Codec::ArrayToArray(c) => {

--- a/zarrs/src/array/array_errors.rs
+++ b/zarrs/src/array/array_errors.rs
@@ -50,6 +50,9 @@ pub enum ArrayCreateError {
     /// Error creating codecs.
     #[error(transparent)]
     CodecsCreateError(PluginCreateError),
+    /// Error binding codecs to the array data type and fill value.
+    #[error(transparent)]
+    CodecError(#[from] CodecError),
     /// Storage transformer creation error.
     #[error(transparent)]
     StorageTransformersCreateError(PluginCreateError),

--- a/zarrs/src/array/array_errors.rs
+++ b/zarrs/src/array/array_errors.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 use thiserror::Error;
-use zarrs_codec::CodecError;
+use zarrs_codec::{CodecCreateError, CodecError};
 use zarrs_data_type::FillValue;
 use zarrs_metadata::FillValueMetadata;
 
@@ -47,12 +47,9 @@ pub enum ArrayCreateError {
         /// The fill value metadata.
         fill_value_metadata: FillValueMetadata,
     },
-    /// Error creating codecs.
+    /// Error creating, reconfiguring, or binding codecs.
     #[error(transparent)]
-    CodecsCreateError(PluginCreateError),
-    /// Error binding codecs to the array data type and fill value.
-    #[error(transparent)]
-    CodecError(#[from] CodecError),
+    CodecsCreateError(#[from] CodecCreateError),
     /// Storage transformer creation error.
     #[error(transparent)]
     StorageTransformersCreateError(PluginCreateError),

--- a/zarrs/src/array/array_ops.rs
+++ b/zarrs/src/array/array_ops.rs
@@ -4,8 +4,8 @@ use super::chunk_cache::ChunkCache;
 use super::{
     Array, ArrayBuilder, ArrayCached, ArrayCreateError, ArrayError, ArrayIndices, ArrayMetadata,
     ArrayMetadataOptions, ArrayShape, ArraySubset, ArraySubsetTraits, ArrayToBytesCodecTraits,
-    ChunkGrid, ChunkKeyEncoding, ChunkShape, CodecChain, CodecChainBound, CodecError, CodecOptions,
-    CodecSpecificOptions, DataType, DimensionName, FillValue, FromArrayBytes,
+    ChunkGrid, ChunkKeyEncoding, ChunkShape, CodecChain, CodecChainBound, CodecCreateError,
+    CodecOptions, CodecSpecificOptions, DataType, DimensionName, FillValue, FromArrayBytes,
     IncompatibleDimensionalityError, IntoArrayBytes, NodePath, StorageTransformerChain,
 };
 use crate::config::MetadataEraseVersion;

--- a/zarrs/src/array/array_ops.rs
+++ b/zarrs/src/array/array_ops.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use super::chunk_cache::ChunkCache;
 use super::{
     Array, ArrayBuilder, ArrayCached, ArrayCreateError, ArrayError, ArrayIndices, ArrayMetadata,
-    ArrayMetadataOptions, ArrayShape, ArraySubset, ArraySubsetTraits, ChunkGrid, ChunkKeyEncoding,
-    ChunkShape, CodecChain, CodecOptions, CodecSpecificOptions, DataType, DimensionName, FillValue,
-    FromArrayBytes, IncompatibleDimensionalityError, IntoArrayBytes, NodePath,
-    StorageTransformerChain,
+    ArrayMetadataOptions, ArrayShape, ArraySubset, ArraySubsetTraits, ArrayToBytesCodecTraits,
+    ChunkGrid, ChunkKeyEncoding, ChunkShape, CodecChain, CodecChainBound, CodecError, CodecOptions,
+    CodecSpecificOptions, DataType, DimensionName, FillValue, FromArrayBytes,
+    IncompatibleDimensionalityError, IntoArrayBytes, NodePath, StorageTransformerChain,
 };
 use crate::config::MetadataEraseVersion;
 #[cfg(feature = "async")]

--- a/zarrs/src/array/array_ops/array_mut_ops.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops.rs
@@ -12,7 +12,7 @@ pub trait ArrayMutOps: ArrayOps {
     /// Refer to [`with_codec_specific_options`](Array::with_codec_specific_options) for details.
     ///
     /// # Errors
-    /// Returns a [`CodecError`] if a codec cannot be reconfigured or rebound.
+    /// Returns a [`CodecCreateError`] if a codec cannot be reconfigured or rebound.
     ///
     /// # Example
     /// ```rust,no_run
@@ -30,7 +30,7 @@ pub trait ArrayMutOps: ArrayOps {
     fn set_codec_specific_options(
         &mut self,
         opts: &CodecSpecificOptions,
-    ) -> Result<&mut Self, CodecError>;
+    ) -> Result<&mut Self, CodecCreateError>;
 
     /// Set the metadata options.
     fn set_metadata_options(&mut self, metadata_options: ArrayMetadataOptions) -> &mut Self;

--- a/zarrs/src/array/array_ops/array_mut_ops.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops.rs
@@ -11,6 +11,9 @@ pub trait ArrayMutOps: ArrayOps {
     ///
     /// Refer to [`with_codec_specific_options`](Array::with_codec_specific_options) for details.
     ///
+    /// # Errors
+    /// Returns a [`CodecError`] if a codec cannot be reconfigured or rebound.
+    ///
     /// # Example
     /// ```rust,no_run
     /// # use std::sync::Arc;
@@ -24,7 +27,10 @@ pub trait ArrayMutOps: ArrayOps {
     /// array.set_codec_specific_options(&opts);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    fn set_codec_specific_options(&mut self, opts: &CodecSpecificOptions) -> &mut Self;
+    fn set_codec_specific_options(
+        &mut self,
+        opts: &CodecSpecificOptions,
+    ) -> Result<&mut Self, CodecError>;
 
     /// Set the metadata options.
     fn set_metadata_options(&mut self, metadata_options: ArrayMetadataOptions) -> &mut Self;

--- a/zarrs/src/array/array_ops/array_mut_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops/array.rs
@@ -13,11 +13,11 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
     /// Reconfigure and rebind the codec chain.
     ///
     /// # Errors
-    /// Returns a [`CodecError`] if a codec cannot be reconfigured or rebound.
+    /// Returns a [`CodecCreateError`] if a codec cannot be reconfigured or rebound.
     pub fn set_codec_specific_options(
         &mut self,
         opts: &CodecSpecificOptions,
-    ) -> Result<&mut Self, CodecError> {
+    ) -> Result<&mut Self, CodecCreateError> {
         let codecs = Arc::new((*self.codecs).clone().with_codec_specific_options(opts)?);
         let codecs_bound = codecs
             .clone()

--- a/zarrs/src/array/array_ops/array_mut_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops/array.rs
@@ -18,11 +18,10 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
         &mut self,
         opts: &CodecSpecificOptions,
     ) -> Result<&mut Self, CodecCreateError> {
-        let codecs = Arc::new((*self.codecs).clone().with_codec_specific_options(opts)?);
-        let codecs_bound = codecs
-            .clone()
+        self.codecs = Arc::new((*self.codecs).clone().with_codec_specific_options(opts)?);
+        let codecs_bound = self
+            .codecs
             .with_context(self.data_type.clone(), self.fill_value.clone())?;
-        self.codecs = codecs;
         self.codecs_bound = codecs_bound;
         Ok(self)
     }

--- a/zarrs/src/array/array_ops/array_mut_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops/array.rs
@@ -18,10 +18,11 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
         &mut self,
         opts: &CodecSpecificOptions,
     ) -> Result<&mut Self, CodecCreateError> {
-        self.codecs = Arc::new((*self.codecs).clone().with_codec_specific_options(opts)?);
-        let codecs_bound = self
-            .codecs
+        let codecs = Arc::new((*self.codecs).clone().with_codec_specific_options(opts)?);
+        let codecs_bound = codecs
+            .clone()
             .with_context(self.data_type.clone(), self.fill_value.clone())?;
+        self.codecs = codecs;
         self.codecs_bound = codecs_bound;
         Ok(self)
     }

--- a/zarrs/src/array/array_ops/array_mut_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops/array.rs
@@ -10,9 +10,21 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
         self
     }
 
-    pub fn set_codec_specific_options(&mut self, opts: &CodecSpecificOptions) -> &mut Self {
-        self.codecs = Arc::new((*self.codecs).clone().with_codec_specific_options(opts));
-        self
+    /// Reconfigure and rebind the codec chain.
+    ///
+    /// # Errors
+    /// Returns a [`CodecError`] if a codec cannot be reconfigured or rebound.
+    pub fn set_codec_specific_options(
+        &mut self,
+        opts: &CodecSpecificOptions,
+    ) -> Result<&mut Self, CodecError> {
+        let codecs = Arc::new((*self.codecs).clone().with_codec_specific_options(opts)?);
+        let codecs_bound = codecs
+            .clone()
+            .with_context(self.data_type.clone(), self.fill_value.clone())?;
+        self.codecs = codecs;
+        self.codecs_bound = codecs_bound;
+        Ok(self)
     }
 
     pub fn set_metadata_options(&mut self, metadata_options: ArrayMetadataOptions) -> &mut Self {

--- a/zarrs/src/array/array_ops/array_mut_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops/array.rs
@@ -37,7 +37,7 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
             .map_err(ArrayCreateError::ChunkGridCreateError)?;
         self.subchunk_grid = crate::array::array_sharded_ext::create_subchunk_grid(
             &self.chunk_grid,
-            self.codecs.as_ref(),
+            self.codecs_bound.as_ref(),
         );
         match &mut self.metadata {
             ArrayMetadata::V3(metadata) => {

--- a/zarrs/src/array/array_ops/array_ops.rs
+++ b/zarrs/src/array/array_ops/array_ops.rs
@@ -29,6 +29,9 @@ pub trait ArrayOps {
     /// Get the codecs.
     fn codecs(&self) -> Arc<CodecChain>;
 
+    /// Get the codecs bound to the array data type and fill value.
+    fn codecs_bound(&self) -> Arc<CodecChainBound>;
+
     /// Get the chunk grid.
     fn chunk_grid(&self) -> &ChunkGrid;
 

--- a/zarrs/src/array/array_ops/array_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_ops/array.rs
@@ -10,7 +10,6 @@ use crate::array::codec::ShardingCodecConfiguration;
 use crate::config::MetadataConvertVersion;
 use crate::convert::array_metadata_v2_to_v3;
 use crate::node::data_key;
-use zarrs_codec::ArrayToBytesCodecTraits;
 use zarrs_metadata::ConfigurationSerialize;
 use zarrs_metadata::v2::DataTypeMetadataV2;
 use zarrs_metadata::v3::MetadataV3;
@@ -46,6 +45,10 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
 
     pub fn codecs(&self) -> Arc<CodecChain> {
         self.codecs.clone()
+    }
+
+    pub fn codecs_bound(&self) -> Arc<CodecChainBound> {
+        self.codecs_bound.clone()
     }
 
     pub fn chunk_grid(&self) -> &ChunkGrid {
@@ -265,7 +268,9 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
         chunk_indices: &[u64],
     ) -> Result<ChunkShape, ArrayError> {
         let chunk_shape = self.chunk_shape(chunk_indices)?;
-        Ok(self.codecs().partial_decode_granularity(&chunk_shape)?)
+        Ok(self
+            .codecs_bound()
+            .partial_decode_granularity(&chunk_shape)?)
     }
 
     pub fn subset_all(&self) -> ArraySubset {

--- a/zarrs/src/array/array_ops/array_ops/array_cached.rs
+++ b/zarrs/src/array/array_ops/array_ops/array_cached.rs
@@ -35,6 +35,10 @@ impl<TStorage: ?Sized, C> ArrayOps for ArrayCached<TStorage, C> {
         self.array().codecs()
     }
 
+    pub fn codecs_bound(&self) -> Arc<CodecChainBound> {
+        self.array().codecs_bound()
+    }
+
     pub fn chunk_grid(&self) -> &ChunkGrid {
         self.array().chunk_grid()
     }

--- a/zarrs/src/array/array_ops/array_read_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/array.rs
@@ -12,7 +12,7 @@ use super::super::*;
 use super::ArrayReadOps;
 use crate::array::ArrayBytes;
 use crate::array::array_sharded_ext::subchunk_shard_index_and_chunk_index;
-use crate::array::codec::array_to_bytes::sharding::{ShardingCodec, ShardingPartialDecoder};
+use crate::array::codec::array_to_bytes::sharding::{ShardingCodecBound, ShardingPartialDecoder};
 use crate::iter_concurrent_limit;
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -306,11 +306,11 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
         &self,
         subchunk_indices: &[u64],
     ) -> Result<Option<Vec<u8>>, ArrayError> {
-        let codecs = self.codecs();
+        let codecs = self.codecs_bound();
         let Some(sharding_codec) = codecs
             .array_to_bytes_codec()
             .as_any()
-            .downcast_ref::<ShardingCodec>()
+            .downcast_ref::<ShardingCodecBound>()
         else {
             return Err(ArrayError::UnsupportedMethod(
                 "the array is not exclusively sharded".to_string(),
@@ -336,8 +336,6 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
 
         let partial_decoder = ShardingPartialDecoder::new(
             input_handle,
-            self.data_type().clone(),
-            self.fill_value().clone(),
             self.chunk_shape(&shard_indices)?,
             sharding_codec.subchunk_shape.clone(),
             sharding_codec.inner_codecs.clone(),

--- a/zarrs/src/array/array_ops/array_read_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/array.rs
@@ -227,8 +227,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
                 let chunk_shape = self.chunk_shape(chunks.start())?;
 
                 // Calculate chunk/codec concurrency
-                let codec_concurrency =
-                    self.recommended_codec_concurrency(&chunk_shape, self.data_type())?;
+                let codec_concurrency = self.recommended_codec_concurrency(&chunk_shape)?;
                 let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
                     options.concurrent_target(),
                     num_chunks,

--- a/zarrs/src/array/array_ops/array_read_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/array.rs
@@ -57,12 +57,10 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
             .get(&self.chunk_key(chunk_indices))
             .map_err(ArrayError::StorageError)?;
         if let Some(chunk_encoded) = chunk_encoded {
-            self.codecs()
+            self.codecs_bound()
                 .decode_into(
                     Cow::Owned(chunk_encoded.into()),
                     &self.chunk_shape(chunk_indices)?,
-                    self.data_type(),
-                    self.fill_value(),
                     output_target,
                     options,
                 )
@@ -124,15 +122,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
                 self.chunk_key(chunk_indices),
             ));
 
-            self.codecs
-                .clone()
-                .partial_decoder(
-                    input_handle,
-                    &chunk_shape,
-                    self.data_type(),
-                    self.fill_value(),
-                    options,
-                )?
+            self.codecs_bound()
+                .partial_decoder(input_handle, &chunk_shape, options)?
                 .partial_decode(chunk_subset, options)?
                 .into_owned()
         };
@@ -168,15 +159,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
                 storage_transformer,
                 self.chunk_key(chunk_indices),
             ));
-            self.codecs
-                .clone()
-                .partial_decoder(
-                    input_handle,
-                    &chunk_shape,
-                    self.data_type(),
-                    self.fill_value(),
-                    options,
-                )?
+            self.codecs_bound()
+                .partial_decoder(input_handle, &chunk_shape, options)?
                 .partial_decode_into(chunk_subset, output_target, options)?;
             Ok(())
         }
@@ -420,14 +404,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
         if let Some(chunk_encoded) = chunk_encoded {
             let chunk_shape = self.chunk_shape(chunk_indices)?;
             let bytes = self
-                .codecs()
-                .decode(
-                    Cow::Owned(chunk_encoded.into()),
-                    &chunk_shape,
-                    self.data_type(),
-                    self.fill_value(),
-                    options,
-                )
+                .codecs_bound()
+                .decode(Cow::Owned(chunk_encoded.into()), &chunk_shape, options)
                 .map_err(ArrayError::CodecError)?;
             Ok(Some(T::from_array_bytes(
                 bytes.into_owned(),
@@ -474,11 +452,9 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
             storage_transformer,
             self.chunk_key(chunk_indices),
         ));
-        Ok(self.codecs.clone().partial_decoder(
+        Ok(self.codecs_bound().partial_decoder(
             input_handle,
             &self.chunk_shape(chunk_indices)?,
-            self.data_type(),
-            self.fill_value(),
             options,
         )?)
     }

--- a/zarrs/src/array/array_ops/array_read_ops/array_cached.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/array_cached.rs
@@ -61,8 +61,7 @@ where
             }
         }
         num_chunks => {
-            let codec_concurrency =
-                array.recommended_codec_concurrency(&chunk_shape0, array.data_type())?;
+            let codec_concurrency = array.recommended_codec_concurrency(&chunk_shape0)?;
             let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
                 options.concurrent_target(),
                 num_chunks,

--- a/zarrs/src/array/array_ops/array_read_ops/common.rs
+++ b/zarrs/src/array/array_ops/array_read_ops/common.rs
@@ -87,8 +87,7 @@ where
         }
         _ => {
             let chunk_shape = array.chunk_shape(chunks.start())?;
-            let codec_concurrency =
-                array.recommended_codec_concurrency(&chunk_shape, array.data_type())?;
+            let codec_concurrency = array.recommended_codec_concurrency(&chunk_shape)?;
             let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
                 options.concurrent_target(),
                 num_chunks,

--- a/zarrs/src/array/array_ops/array_update_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_update_ops/array.rs
@@ -144,8 +144,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
             subset_bytes.validate(array_subset.num_elements(), self.data_type())?;
             // Calculate chunk/codec concurrency
             let chunk_shape = self.chunk_shape(&vec![0; self.dimensionality()])?;
-            let codec_concurrency =
-                self.recommended_codec_concurrency(&chunk_shape, self.data_type())?;
+            let codec_concurrency = self.recommended_codec_concurrency(&chunk_shape)?;
             let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
                 options.concurrent_target(),
                 num_chunks,

--- a/zarrs/src/array/array_ops/array_update_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_update_ops/array.rs
@@ -185,11 +185,9 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
     ) -> Result<bool, ArrayError> {
         let chunk_bytes = self.retrieve_encoded_chunk(chunk_indices)?;
         if let Some(chunk_bytes) = chunk_bytes {
-            if let Some(compacted_bytes) = self.codecs.compact(
+            if let Some(compacted_bytes) = self.codecs_bound.compact(
                 chunk_bytes.into(),
                 &self.chunk_shape(chunk_indices)?,
-                self.data_type(),
-                self.fill_value(),
                 options,
             )? {
                 // SAFETY: The compacted bytes are already encoded
@@ -232,11 +230,9 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
             self.chunk_key(chunk_indices),
         ));
 
-        Ok(self.codecs.clone().partial_encoder(
+        Ok(self.codecs_bound().partial_encoder(
             input_output_handle,
             &self.chunk_shape(chunk_indices)?,
-            self.data_type(),
-            self.fill_value(),
             options,
         )?)
     }

--- a/zarrs/src/array/array_ops/array_write_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_write_ops/array.rs
@@ -145,8 +145,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
 
                 // Calculate chunk/codec concurrency
                 let chunk_shape = self.chunk_shape(&vec![0; self.dimensionality()])?;
-                let codec_concurrency =
-                    self.recommended_codec_concurrency(&chunk_shape, self.data_type())?;
+                let codec_concurrency = self.recommended_codec_concurrency(&chunk_shape)?;
                 let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
                     options.concurrent_target(),
                     num_chunks,

--- a/zarrs/src/array/array_ops/array_write_ops/array.rs
+++ b/zarrs/src/array/array_ops/array_write_ops/array.rs
@@ -107,14 +107,8 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
             self.erase_chunk(chunk_indices)?;
         } else {
             let chunk_encoded = self
-                .codecs()
-                .encode(
-                    chunk_bytes,
-                    &chunk_shape,
-                    self.data_type(),
-                    self.fill_value(),
-                    options,
-                )
+                .codecs_bound()
+                .encode(chunk_bytes, &chunk_shape, options)
                 .map_err(ArrayError::CodecError)?;
             let chunk_encoded = Bytes::from(chunk_encoded.into_owned());
             unsafe { self.store_encoded_chunk(chunk_indices, chunk_encoded) }?;

--- a/zarrs/src/array/array_ops/async_array_read_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_read_ops/array.rs
@@ -190,8 +190,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
             }
             _ => {
                 let chunk_shape = self.chunk_shape(chunks.start())?;
-                let codec_concurrency =
-                    self.recommended_codec_concurrency(&chunk_shape, self.data_type())?;
+                let codec_concurrency = self.recommended_codec_concurrency(&chunk_shape)?;
                 let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
                     options.concurrent_target(),
                     num_chunks,
@@ -484,8 +483,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
             }
             _ => {
                 let chunk_shape = self.chunk_shape(chunks.start())?;
-                let codec_concurrency =
-                    self.recommended_codec_concurrency(&chunk_shape, self.data_type())?;
+                let codec_concurrency = self.recommended_codec_concurrency(&chunk_shape)?;
                 let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
                     options.concurrent_target(),
                     num_chunks,

--- a/zarrs/src/array/array_ops/async_array_read_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_read_ops/array.rs
@@ -16,7 +16,9 @@ use super::AsyncArrayReadOps;
 use crate::array::array_sharded_ext::{
     subchunk_shard_index_and_chunk_index, subchunk_shard_index_and_subset,
 };
-use crate::array::codec::array_to_bytes::sharding::{AsyncShardingPartialDecoder, ShardingCodec};
+use crate::array::codec::array_to_bytes::sharding::{
+    AsyncShardingPartialDecoder, ShardingCodecBound,
+};
 use crate::array::{ArrayBytes, ArraySubset, ChunkShapeTraits};
 use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayToBytesCodecTraits, AsyncArrayPartialDecoderTraits,
@@ -345,11 +347,11 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         subchunk_indices: &[u64],
     ) -> Result<Option<Vec<u8>>, ArrayError> {
-        let codecs = self.codecs();
+        let codecs = self.codecs_bound();
         let Some(sharding_codec) = codecs
             .array_to_bytes_codec()
             .as_any()
-            .downcast_ref::<ShardingCodec>()
+            .downcast_ref::<ShardingCodecBound>()
         else {
             return Err(ArrayError::UnsupportedMethod(
                 "the array is not exclusively sharded".to_string(),
@@ -375,8 +377,6 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         ));
         let partial_decoder = AsyncShardingPartialDecoder::new(
             input_handle,
-            self.data_type().clone(),
-            self.fill_value().clone(),
             self.chunk_shape(&shard_indices)?,
             sharding_codec.subchunk_shape.clone(),
             sharding_codec.inner_codecs.clone(),

--- a/zarrs/src/array/array_ops/async_array_read_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_read_ops/array.rs
@@ -118,15 +118,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
                 self.chunk_key(chunk_indices),
             ));
             let bytes = self
-                .codecs
-                .clone()
-                .async_partial_decoder(
-                    input_handle,
-                    &chunk_shape,
-                    self.data_type(),
-                    self.fill_value(),
-                    options,
-                )
+                .codecs_bound()
+                .async_partial_decoder(input_handle, &chunk_shape, options)
                 .await?
                 .partial_decode(chunk_subset, options)
                 .await?
@@ -301,14 +294,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         if let Some(chunk_encoded) = chunk_encoded {
             let chunk_shape = self.chunk_shape(chunk_indices)?;
             let bytes = self
-                .codecs()
-                .decode(
-                    Cow::Owned(chunk_encoded.into()),
-                    &chunk_shape,
-                    self.data_type(),
-                    self.fill_value(),
-                    options,
-                )
+                .codecs_bound()
+                .decode(Cow::Owned(chunk_encoded.into()), &chunk_shape, options)
                 .map_err(ArrayError::CodecError)?;
             bytes.validate(chunk_shape.num_elements_u64(), self.data_type())?;
             Ok(Some(T::from_array_bytes(
@@ -533,15 +520,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
             self.chunk_key(chunk_indices),
         ));
         Ok(self
-            .codecs
-            .clone()
-            .async_partial_decoder(
-                input_handle,
-                &self.chunk_shape(chunk_indices)?,
-                self.data_type(),
-                self.fill_value(),
-                options,
-            )
+            .codecs_bound()
+            .async_partial_decoder(input_handle, &self.chunk_shape(chunk_indices)?, options)
             .await?)
     }
 }
@@ -569,12 +549,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             .map_err(ArrayError::StorageError)?;
         if let Some(chunk_encoded) = chunk_encoded {
             let chunk_shape = self.chunk_shape(chunk_indices)?;
-            self.codecs()
+            self.codecs_bound()
                 .decode_into(
                     Cow::Owned(chunk_encoded.into()),
                     &chunk_shape,
-                    self.data_type(),
-                    self.fill_value(),
                     output_target,
                     options,
                 )
@@ -855,15 +833,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
                 self.chunk_key(chunk_indices),
             ));
 
-            self.codecs
-                .clone()
-                .async_partial_decoder(
-                    input_handle,
-                    &chunk_shape,
-                    self.data_type(),
-                    self.fill_value(),
-                    options,
-                )
+            self.codecs_bound()
+                .async_partial_decoder(input_handle, &chunk_shape, options)
                 .await?
                 .partial_decode_into(chunk_subset, output_target, options)
                 .await?;

--- a/zarrs/src/array/array_ops/async_array_update_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_update_ops/array.rs
@@ -207,13 +207,10 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
         if let Some(chunk_bytes) = chunk_bytes {
             let chunk_bytes: Vec<u8> = chunk_bytes.into();
             let chunk_shape = self.chunk_shape(chunk_indices)?;
-            if let Some(compacted_bytes) = self.codecs.compact(
-                chunk_bytes.into(),
-                &chunk_shape,
-                self.data_type(),
-                self.fill_value(),
-                options,
-            )? {
+            if let Some(compacted_bytes) =
+                self.codecs_bound
+                    .compact(chunk_bytes.into(), &chunk_shape, options)?
+            {
                 unsafe {
                     self.async_store_encoded_chunk(
                         chunk_indices,
@@ -257,15 +254,8 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
         ));
 
         Ok(self
-            .codecs
-            .clone()
-            .async_partial_encoder(
-                input_output_handle,
-                &chunk_shape,
-                self.data_type(),
-                self.fill_value(),
-                options,
-            )
+            .codecs_bound()
+            .async_partial_encoder(input_output_handle, &chunk_shape, options)
             .await?)
     }
 }

--- a/zarrs/src/array/array_ops/async_array_update_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_update_ops/array.rs
@@ -154,8 +154,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
 
             // Calculate chunk/codec concurrency
             let chunk_shape = self.chunk_shape(&vec![0; self.dimensionality()])?;
-            let codec_concurrency =
-                self.recommended_codec_concurrency(&chunk_shape, self.data_type())?;
+            let codec_concurrency = self.recommended_codec_concurrency(&chunk_shape)?;
             let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
                 options.concurrent_target(),
                 num_chunks,

--- a/zarrs/src/array/array_ops/async_array_write_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_write_ops/array.rs
@@ -179,8 +179,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
 
                 // Calculate chunk/codec concurrency
                 let chunk_shape = self.chunk_shape(&vec![0; self.dimensionality()])?;
-                let codec_concurrency =
-                    self.recommended_codec_concurrency(&chunk_shape, self.data_type())?;
+                let codec_concurrency = self.recommended_codec_concurrency(&chunk_shape)?;
                 let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
                     options.concurrent_target(),
                     num_chunks,

--- a/zarrs/src/array/array_ops/async_array_write_ops/array.rs
+++ b/zarrs/src/array/array_ops/async_array_write_ops/array.rs
@@ -137,14 +137,8 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
             self.async_erase_chunk(chunk_indices).await?;
         } else {
             let chunk_encoded = self
-                .codecs()
-                .encode(
-                    chunk_bytes,
-                    &chunk_shape,
-                    self.data_type(),
-                    self.fill_value(),
-                    options,
-                )
+                .codecs_bound()
+                .encode(chunk_bytes, &chunk_shape, options)
                 .map_err(ArrayError::CodecError)?;
             let chunk_encoded = Bytes::from(chunk_encoded.into_owned());
             unsafe { self.async_store_encoded_chunk(chunk_indices, chunk_encoded) }.await?;

--- a/zarrs/src/array/array_sharded_ext.rs
+++ b/zarrs/src/array/array_sharded_ext.rs
@@ -1,11 +1,11 @@
 use std::num::NonZeroU64;
 
 use super::chunk_grid::{RectilinearChunkGrid, RegularBoundedChunkGrid, RegularChunkGrid};
-use super::{ArrayError, ArrayOps, ArrayShape, ArraySubset, ChunkGrid, ChunkShape, CodecChain};
+use super::{ArrayError, ArrayOps, ArrayShape, ArraySubset, ChunkGrid, ChunkShape, CodecChainBound};
 use crate::array::chunk_grid::ChunkEdgeLengths;
 use crate::array::chunk_grid::repeat::RepeatChunkGrid;
-use crate::array::codec::array_to_bytes::sharding::ShardingCodec;
-use zarrs_codec::UnboundArrayToBytesCodecTraits;
+use crate::array::codec::array_to_bytes::sharding::ShardingCodecBound;
+use zarrs_codec::ArrayToBytesCodecTraits;
 use zarrs_metadata_ext::chunk_grid::rectilinear::RunLengthElement;
 use zarrs_plugin::ExtensionAliasesV3;
 
@@ -116,16 +116,17 @@ fn repeated_subchunk_grid_for_regular_shards(
 
 pub(crate) fn create_subchunk_grid(
     chunk_grid: &ChunkGrid,
-    codecs: &CodecChain,
+    codecs: &CodecChainBound,
 ) -> Option<ChunkGrid> {
-    if !codecs.array_to_bytes_codec().as_any().is::<ShardingCodec>() {
-        return None;
-    }
+    let sharding_codec = codecs
+        .array_to_bytes_codec()
+        .as_any()
+        .downcast_ref::<ShardingCodecBound>()?;
 
     let dimensionality = chunk_grid.dimensionality();
     let origin_chunk = vec![0; dimensionality];
     let decoded_chunk_shape = chunk_grid.chunk_shape(&origin_chunk).ok().flatten()?;
-    let subchunk_shape = codecs
+    let subchunk_shape = sharding_codec
         .partial_decode_granularity(&decoded_chunk_shape)
         .ok()?;
     if subchunk_shape == decoded_chunk_shape {

--- a/zarrs/src/array/array_sharded_ext.rs
+++ b/zarrs/src/array/array_sharded_ext.rs
@@ -5,7 +5,7 @@ use super::{ArrayError, ArrayOps, ArrayShape, ArraySubset, ChunkGrid, ChunkShape
 use crate::array::chunk_grid::ChunkEdgeLengths;
 use crate::array::chunk_grid::repeat::RepeatChunkGrid;
 use crate::array::codec::array_to_bytes::sharding::ShardingCodec;
-use zarrs_codec::ArrayToBytesCodecTraits;
+use zarrs_codec::UnboundArrayToBytesCodecTraits;
 use zarrs_metadata_ext::chunk_grid::rectilinear::RunLengthElement;
 use zarrs_plugin::ExtensionAliasesV3;
 

--- a/zarrs/src/array/array_sharded_ext.rs
+++ b/zarrs/src/array/array_sharded_ext.rs
@@ -1,7 +1,9 @@
 use std::num::NonZeroU64;
 
 use super::chunk_grid::{RectilinearChunkGrid, RegularBoundedChunkGrid, RegularChunkGrid};
-use super::{ArrayError, ArrayOps, ArrayShape, ArraySubset, ChunkGrid, ChunkShape, CodecChainBound};
+use super::{
+    ArrayError, ArrayOps, ArrayShape, ArraySubset, ChunkGrid, ChunkShape, CodecChainBound,
+};
 use crate::array::chunk_grid::ChunkEdgeLengths;
 use crate::array::chunk_grid::repeat::RepeatChunkGrid;
 use crate::array::codec::array_to_bytes::sharding::ShardingCodecBound;

--- a/zarrs/src/array/builder.rs
+++ b/zarrs/src/array/builder.rs
@@ -17,8 +17,8 @@ use crate::config::global_config;
 use crate::node::NodePath;
 use zarrs_chunk_key_encoding::ChunkKeyEncoding;
 use zarrs_codec::{
-    ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, BytesToBytesCodecTraits, CodecOptions,
-    CodecSpecificOptions,
+    BytesToBytesCodecTraits, CodecOptions, CodecSpecificOptions, UnboundArrayToArrayCodecTraits,
+    UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::v3::{AdditionalFieldsV3, MetadataV3};
 use zarrs_metadata::{ChunkKeySeparator, IntoDimensionName};
@@ -107,9 +107,9 @@ pub struct ArrayBuilder {
     /// Fill value.
     fill_value: ArrayBuilderFillValue,
     /// The array-to-array codecs.
-    array_to_array_codecs: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
+    array_to_array_codecs: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>>,
     /// The array-to-bytes codec.
-    array_to_bytes_codec: Option<Arc<dyn ArrayToBytesCodecTraits>>,
+    array_to_bytes_codec: Option<Arc<dyn UnboundArrayToBytesCodecTraits>>,
     /// The bytes-to-bytes codecs. If [`None`], chooses a default based on the data type.
     bytes_to_bytes_codecs: Vec<Arc<dyn BytesToBytesCodecTraits>>,
     /// Storage transformer chain.
@@ -313,7 +313,7 @@ impl ArrayBuilder {
     /// If left unmodified, the array will have no array-to-array codecs.
     pub fn array_to_array_codecs(
         &mut self,
-        array_to_array_codecs: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
+        array_to_array_codecs: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>>,
     ) -> &mut Self {
         self.array_to_array_codecs = array_to_array_codecs;
         self
@@ -324,7 +324,7 @@ impl ArrayBuilder {
     /// If left unmodified, the array will default to using the `bytes` codec with native endian encoding.
     pub fn array_to_bytes_codec(
         &mut self,
-        array_to_bytes_codec: Arc<dyn ArrayToBytesCodecTraits>,
+        array_to_bytes_codec: Arc<dyn UnboundArrayToBytesCodecTraits>,
     ) -> &mut Self {
         self.array_to_bytes_codec = Some(array_to_bytes_codec);
         self
@@ -588,7 +588,7 @@ impl ArrayBuilder {
             Array::new_with_codec_chain(storage, path, array_metadata_v3, codec_chain)?
                 .with_metadata_options(self.metadata_options)
                 .with_codec_options(self.codec_options)
-                .with_codec_specific_options(&self.codec_specific_options),
+                .with_codec_specific_options(&self.codec_specific_options)?,
         )
     }
 

--- a/zarrs/src/array/builder.rs
+++ b/zarrs/src/array/builder.rs
@@ -616,6 +616,7 @@ mod tests {
     use super::*;
     use crate::array::chunk_grid::RegularChunkGrid;
     use crate::array::chunk_key_encoding::V2ChunkKeyEncoding;
+    use crate::array::codec::ShardingCodecBound;
     use crate::array::data_type;
     use zarrs_metadata::FillValueMetadata;
     use zarrs_metadata::v3::MetadataV3;
@@ -912,7 +913,7 @@ mod tests {
     fn array_builder_codec_specific_options_impl(
         write_order: crate::array::codec::array_to_bytes::sharding::SubchunkWriteOrder,
     ) {
-        use crate::array::codec::array_to_bytes::sharding::{ShardingCodec, ShardingCodecOptions};
+        use crate::array::codec::array_to_bytes::sharding::ShardingCodecOptions;
         use zarrs_codec::CodecSpecificOptions;
 
         let storage = Arc::new(MemoryStore::new());
@@ -925,11 +926,11 @@ mod tests {
         );
         let array = builder.build(storage, "/").unwrap();
 
-        let codecs = array.codecs();
+        let codecs = array.codecs_bound();
         let sharding = codecs
             .array_to_bytes_codec()
             .as_any()
-            .downcast_ref::<ShardingCodec>()
+            .downcast_ref::<ShardingCodecBound>()
             .expect("expected ShardingCodec");
         assert!(
             matches!(sharding.options.subchunk_write_order(), o if std::mem::discriminant(&o) == std::mem::discriminant(&write_order)),
@@ -956,7 +957,7 @@ mod tests {
     ) {
         use crate::array::ArraySubset;
         use crate::array::codec::ZstdCodec;
-        use crate::array::codec::array_to_bytes::sharding::{ShardingCodec, ShardingCodecBuilder};
+        use crate::array::codec::array_to_bytes::sharding::ShardingCodecBuilder;
 
         const SHAPE: [u64; 2] = [4, 4];
         const SHARD_SHAPE: [u64; 2] = [2, 2];
@@ -983,11 +984,11 @@ mod tests {
         .unwrap();
 
         // Verify the option was preserved through build()
-        let codecs = array.codecs();
+        let codecs = array.codecs_bound();
         let sharding = codecs
             .array_to_bytes_codec()
             .as_any()
-            .downcast_ref::<ShardingCodec>()
+            .downcast_ref::<ShardingCodecBound>()
             .expect("expected ShardingCodec");
         assert!(
             matches!(sharding.options.subchunk_write_order(), o if std::mem::discriminant(&o) == std::mem::discriminant(&write_order)),

--- a/zarrs/src/array/chunk_cache/chunk_cache_type/encoded.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_type/encoded.rs
@@ -36,13 +36,9 @@ impl ChunkCacheType for ChunkCacheTypeEncoded {
             None => Arc::new(Mutex::new(None)),
         };
         let chunk_shape = validate_chunk_indices(array, chunk_indices)?;
-        Ok(array.codecs().partial_decoder(
-            input,
-            &chunk_shape,
-            array.data_type(),
-            array.fill_value(),
-            options,
-        )?)
+        Ok(array
+            .codecs_bound()
+            .partial_decoder(input, &chunk_shape, options)?)
     }
 
     fn retrieve_chunk_bytes_if_exists<TStorage, C>(
@@ -67,14 +63,8 @@ impl ChunkCacheType for ChunkCacheTypeEncoded {
             .as_ref()
             .map(|encoded| {
                 let bytes = array
-                    .codecs()
-                    .decode(
-                        Cow::Borrowed(encoded),
-                        &chunk_shape,
-                        array.data_type(),
-                        array.fill_value(),
-                        options,
-                    )
+                    .codecs_bound()
+                    .decode(Cow::Borrowed(encoded), &chunk_shape, options)
                     .map_err(ArrayError::CodecError)?;
                 bytes.validate(chunk_shape.num_elements_u64(), array.data_type())?;
                 Ok(Arc::new(bytes.into_owned()))

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -28,7 +28,7 @@ pub use array_to_array::squeeze::*;
 pub use array_to_array::transpose::*;
 // Array to bytes
 pub use array_to_bytes::bytes::*;
-pub use array_to_bytes::codec_chain::CodecChain;
+pub use array_to_bytes::codec_chain::{CodecChain, CodecChainBound};
 pub use array_to_bytes::optional::*;
 pub use array_to_bytes::packbits::*;
 #[cfg(feature = "pcodec")]
@@ -87,7 +87,7 @@ pub use zarrs_codec as api;
 #[must_use]
 pub fn default_array_to_bytes_codec(
     data_type: &zarrs_data_type::DataType,
-) -> Arc<dyn zarrs_codec::ArrayToBytesCodecTraits> {
+) -> Arc<dyn zarrs_codec::UnboundArrayToBytesCodecTraits> {
     // Special handling for optional types
     if let Some(opt) = data_type.as_optional() {
         // Create mask codec chain using PackBitsCodec

--- a/zarrs/src/array/codec/array_to_array/bitround.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround.rs
@@ -46,7 +46,6 @@ use zarrs_codec::{Codec, CodecPluginV3, CodecTraitsV3};
 pub use zarrs_metadata_ext::codec::bitround::{
     BitroundCodecConfiguration, BitroundCodecConfigurationV1,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(BitroundCodec,
     v3: "bitround", ["numcodecs.bitround", "https://codec.zarrs.dev/array_to_bytes/bitround"]
@@ -58,7 +57,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for BitroundCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: BitroundCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(BitroundCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToArray(codec))
@@ -134,6 +133,21 @@ mod tests {
             decoded.into_fixed().unwrap().into_owned(),
         );
         assert_eq!(decoded_elements, &[0.0f32, 1.25f32, -8.0f32, 98304.0f32]);
+    }
+
+    #[test]
+    fn codec_bitround_encoded_fill_value_is_rounded() {
+        const JSON: &str = r#"{ "keepbits": 3 }"#;
+        let data_type = data_type::float32();
+        let fill_value = FillValue::from(1.234_567_9f32);
+
+        let codec_configuration: BitroundCodecConfiguration = serde_json::from_str(JSON).unwrap();
+        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type, fill_value.clone())
+            .unwrap();
+
+        assert_eq!(codec.fill_value(), &fill_value);
+        assert_eq!(codec.encoded_fill_value(), &FillValue::from(1.25f32));
     }
 
     #[test]

--- a/zarrs/src/array/codec/array_to_array/bitround.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround.rs
@@ -92,9 +92,7 @@ mod tests {
     use super::*;
     use crate::array::codec::BytesCodec;
     use crate::array::{ArrayBytes, ArraySubset, data_type};
-    use zarrs_codec::{
-        CodecOptions,
-    };
+    use zarrs_codec::CodecOptions;
 
     #[test]
     fn codec_bitround_float() {

--- a/zarrs/src/array/codec/array_to_array/bitround.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround.rs
@@ -92,7 +92,9 @@ mod tests {
     use super::*;
     use crate::array::codec::BytesCodec;
     use crate::array::{ArrayBytes, ArraySubset, data_type};
-    use zarrs_codec::CodecOptions;
+    use zarrs_codec::{
+        CodecOptions, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
+    };
 
     #[test]
     fn codec_bitround_float() {
@@ -118,25 +120,15 @@ mod tests {
         let bytes = ArrayBytes::from(bytes);
 
         let codec_configuration: BitroundCodecConfiguration = serde_json::from_str(JSON).unwrap();
-        let codec = BitroundCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &shape, &CodecOptions::default())
             .unwrap();
         let decoded_elements = crate::array::transmute_from_bytes_vec::<f32>(
             decoded.into_fixed().unwrap().into_owned(),
@@ -155,25 +147,15 @@ mod tests {
         let bytes = ArrayBytes::from(bytes);
 
         let codec_configuration: BitroundCodecConfiguration = serde_json::from_str(JSON).unwrap();
-        let codec = BitroundCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &shape, &CodecOptions::default())
             .unwrap();
         let decoded_elements = crate::array::transmute_from_bytes_vec::<u32>(
             decoded.into_fixed().unwrap().into_owned(),
@@ -198,25 +180,15 @@ mod tests {
         let bytes = ArrayBytes::from(bytes);
 
         let codec_configuration: BitroundCodecConfiguration = serde_json::from_str(JSON).unwrap();
-        let codec = BitroundCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &shape, &CodecOptions::default())
             .unwrap();
         let decoded_elements = crate::array::transmute_from_bytes_vec::<u32>(
             decoded.into_fixed().unwrap().into_owned(),
@@ -232,43 +204,33 @@ mod tests {
     fn codec_bitround_partial_decode() {
         const JSON: &str = r#"{ "keepbits": 2 }"#;
         let codec_configuration: BitroundCodecConfiguration = serde_json::from_str(JSON).unwrap();
-        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration).unwrap());
 
         let elements: Vec<f32> = (0..32).map(|i| i as f32).collect();
         let shape = vec![(elements.len() as u64).try_into().unwrap()];
         let data_type = data_type::float32();
         let fill_value = FillValue::from(0.0f32);
         let bytes: ArrayBytes = crate::array::transmute_to_bytes_vec(elements).into();
+        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap()
             .into_owned();
         let input_handle = Arc::new(encoded.into_fixed().unwrap());
         let bytes_codec = Arc::new(BytesCodec::default());
-        let input_handle = bytes_codec
-            .partial_decoder(
-                input_handle,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
+        let bytes_codec = bytes_codec
+            .with_context(
+                codec.encoded_data_type().clone(),
+                codec.encoded_fill_value().clone(),
             )
             .unwrap();
+        let input_handle = bytes_codec
+            .partial_decoder(input_handle, &shape, &CodecOptions::default())
+            .unwrap();
         let partial_decoder = codec
-            .partial_decoder(
-                input_handle.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle.clone(), &shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // bitround partial decoder does not hold bytes
         let decoded_regions = [
@@ -295,7 +257,6 @@ mod tests {
 
         const JSON: &str = r#"{ "keepbits": 2 }"#;
         let codec_configuration: BitroundCodecConfiguration = serde_json::from_str(JSON).unwrap();
-        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration).unwrap());
 
         let elements: Vec<f32> = (0..32).map(|i| i as f32).collect();
         let shape = vec![(elements.len() as u64).try_into().unwrap()];
@@ -303,36 +264,27 @@ mod tests {
         let fill_value = FillValue::from(0.0f32);
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes = ArrayBytes::from(bytes);
+        let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap();
         let input_handle = Arc::new(encoded.into_fixed().unwrap());
         let bytes_codec = Arc::new(BytesCodec::default());
-        let input_handle = bytes_codec
-            .async_partial_decoder(
-                input_handle,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
+        let bytes_codec = bytes_codec
+            .with_context(
+                codec.encoded_data_type().clone(),
+                codec.encoded_fill_value().clone(),
             )
+            .unwrap();
+        let input_handle = bytes_codec
+            .async_partial_decoder(input_handle, &shape, &CodecOptions::default())
             .await
             .unwrap();
         let partial_decoder = codec
-            .async_partial_decoder(
-                input_handle,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .async_partial_decoder(input_handle, &shape, &CodecOptions::default())
             .await
             .unwrap();
         let decoded_regions = [

--- a/zarrs/src/array/codec/array_to_array/bitround.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround.rs
@@ -92,7 +92,9 @@ mod tests {
     use super::*;
     use crate::array::codec::BytesCodec;
     use crate::array::{ArrayBytes, ArraySubset, data_type};
-    use zarrs_codec::{ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, CodecOptions};
+    use zarrs_codec::{
+        CodecOptions, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
+    };
 
     #[test]
     fn codec_bitround_float() {

--- a/zarrs/src/array/codec/array_to_array/bitround.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround.rs
@@ -93,7 +93,7 @@ mod tests {
     use crate::array::codec::BytesCodec;
     use crate::array::{ArrayBytes, ArraySubset, data_type};
     use zarrs_codec::{
-        CodecOptions, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
+        CodecOptions,
     };
 
     #[test]

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -6,12 +6,13 @@ use super::{
     BitroundCodecConfiguration, BitroundCodecConfigurationV1, BitroundDataTypeExt,
     bitround_codec_partial, round_bytes,
 };
-use crate::array::{DataType, FillValue};
+use crate::array::{ChunkShape, DataType, FillValue};
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
+    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
@@ -24,7 +25,7 @@ pub struct BitroundCodec {
 }
 
 /// A `bitround` codec implementation.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 struct BitroundCodecBound {
     keepbits: u32,
     data_type: DataType,
@@ -98,7 +99,7 @@ impl UnboundArrayToArrayCodecTraits for BitroundCodec {
     }
 
     fn with_context(
-        self: Arc<Self>,
+        &self,
         data_type: DataType,
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
@@ -141,16 +142,34 @@ impl ArrayToArrayCodecTraits for BitroundCodecBound {
         self as Arc<dyn ArrayToArrayCodecTraits>
     }
 
+    fn encoded_data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn encoded_fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn encoded_shape(&self, decoded_shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError> {
+        Ok(decoded_shape.to_vec())
+    }
+
+    fn partial_decode_granularity(
+        &self,
+        _decoded_shape: &[NonZeroU64],
+        encoded_granularity: &[NonZeroU64],
+    ) -> Result<ChunkShape, CodecError> {
+        Ok(encoded_granularity.to_vec())
+    }
+
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         let mut bytes = bytes.into_fixed()?;
-        round_bytes(bytes.to_mut(), data_type, self.keepbits)?;
+        round_bytes(bytes.to_mut(), &self.data_type, self.keepbits)?;
         Ok(ArrayBytes::from(bytes))
     }
 
@@ -158,8 +177,6 @@ impl ArrayToArrayCodecTraits for BitroundCodecBound {
         &self,
         bytes: ArrayBytes<'a>,
         _shape: &[NonZeroU64],
-        _data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         Ok(bytes)
@@ -169,13 +186,11 @@ impl ArrayToArrayCodecTraits for BitroundCodecBound {
         self: Arc<Self>,
         input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(bitround_codec_partial::BitroundCodecPartial::new(
             input_handle,
-            data_type,
+            &self.data_type,
             self.keepbits,
         )?))
     }
@@ -184,13 +199,11 @@ impl ArrayToArrayCodecTraits for BitroundCodecBound {
         self: Arc<Self>,
         input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(bitround_codec_partial::BitroundCodecPartial::new(
             input_output_handle,
-            data_type,
+            &self.data_type,
             self.keepbits,
         )?))
     }
@@ -200,13 +213,11 @@ impl ArrayToArrayCodecTraits for BitroundCodecBound {
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(bitround_codec_partial::BitroundCodecPartial::new(
             input_handle,
-            data_type,
+            &self.data_type,
             self.keepbits,
         )?))
     }
@@ -216,19 +227,12 @@ impl ArrayToArrayCodecTraits for BitroundCodecBound {
         self: Arc<Self>,
         input_output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(bitround_codec_partial::BitroundCodecPartial::new(
             input_output_handle,
-            data_type,
+            &self.data_type,
             self.keepbits,
         )?))
-    }
-
-    fn encoded_data_type(&self, decoded_data_type: &DataType) -> Result<DataType, CodecError> {
-        decoded_data_type.codec_bitround()?;
-        Ok(decoded_data_type.clone())
     }
 }

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -10,8 +10,8 @@ use crate::array::{ChunkShape, DataType, FillValue};
 use std::num::NonZeroU64;
 use zarrs_codec::{
     ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayToArrayCodecTraits, CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
     UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
@@ -98,7 +98,7 @@ impl UnboundArrayToArrayCodecTraits for BitroundCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecCreateError> {
         data_type.codec_bitround()?;
         Ok(Arc::new(BitroundCodecBound {
             keepbits: self.keepbits,

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -9,9 +9,9 @@ use super::{
 use crate::array::{DataType, FillValue};
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
@@ -21,6 +21,14 @@ use zarrs_metadata::Configuration;
 #[derive(Clone, Debug, Default)]
 pub struct BitroundCodec {
     keepbits: u32,
+}
+
+/// A `bitround` codec implementation.
+#[derive(Clone, Debug, Default)]
+struct BitroundCodecBound {
+    keepbits: u32,
+    data_type: DataType,
+    fill_value: FillValue,
 }
 
 impl BitroundCodec {
@@ -84,11 +92,39 @@ impl CodecTraits for BitroundCodec {
     }
 }
 
-impl ArrayCodecTraits for BitroundCodec {
+impl UnboundArrayToArrayCodecTraits for BitroundCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToArrayCodecTraits> {
+        self as Arc<dyn UnboundArrayToArrayCodecTraits>
+    }
+
+    fn with_context(
+        self: Arc<Self>,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+        data_type.codec_bitround()?;
+        Ok(Arc::new(BitroundCodecBound {
+            keepbits: self.keepbits,
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for BitroundCodecBound {
+    /// Return the decoded data type bound to this codec.
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    /// Return the decoded fill value bound to this codec.
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
     fn recommended_concurrency(
         &self,
         _shape: &[NonZeroU64],
-        _data_type: &DataType,
     ) -> Result<RecommendedConcurrency, CodecError> {
         // TODO: bitround is well suited to multithread, when is it optimal to kick in?
         Ok(RecommendedConcurrency::new_maximum(1))
@@ -100,7 +136,7 @@ impl ArrayCodecTraits for BitroundCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToArrayCodecTraits for BitroundCodec {
+impl ArrayToArrayCodecTraits for BitroundCodecBound {
     fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
         self as Arc<dyn ArrayToArrayCodecTraits>
     }

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -30,6 +30,7 @@ struct BitroundCodecBound {
     keepbits: u32,
     data_type: DataType,
     fill_value: FillValue,
+    encoded_fill_value: FillValue,
 }
 
 impl BitroundCodec {
@@ -89,6 +90,19 @@ impl CodecTraits for BitroundCodec {
     }
 }
 
+fn encode_fill_value(
+    fill_value: &FillValue,
+    data_type: &DataType,
+    keepbits: u32,
+) -> Result<FillValue, CodecCreateError> {
+    let mut fill_value_bytes = ArrayBytes::new_fill_value(data_type, 1, fill_value)?
+        .into_fixed()
+        .map_err(CodecCreateError::other)?
+        .into_owned();
+    round_bytes(&mut fill_value_bytes, data_type, keepbits).map_err(CodecCreateError::other)?;
+    Ok(FillValue::new(fill_value_bytes))
+}
+
 impl UnboundArrayToArrayCodecTraits for BitroundCodec {
     fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToArrayCodecTraits> {
         self as Arc<dyn UnboundArrayToArrayCodecTraits>
@@ -100,10 +114,12 @@ impl UnboundArrayToArrayCodecTraits for BitroundCodec {
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecCreateError> {
         data_type.codec_bitround()?;
+        let encoded_fill_value = encode_fill_value(&fill_value, &data_type, self.keepbits)?;
         Ok(Arc::new(BitroundCodecBound {
             keepbits: self.keepbits,
             data_type,
             fill_value,
+            encoded_fill_value,
         }))
     }
 }
@@ -147,7 +163,7 @@ impl ArrayToArrayCodecTraits for BitroundCodecBound {
     }
 
     fn encoded_fill_value(&self) -> &FillValue {
-        &self.fill_value
+        &self.encoded_fill_value
     }
 
     fn encoded_shape(&self, decoded_shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError> {

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -60,10 +60,6 @@ impl BitroundCodec {
 }
 
 impl CodecTraits for BitroundCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec.rs
@@ -113,6 +113,10 @@ impl UnboundArrayToArrayCodecTraits for BitroundCodec {
 }
 
 impl ArrayCodecTraits for BitroundCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     /// Return the decoded data type bound to this codec.
     fn data_type(&self) -> &DataType {
         &self.data_type

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
@@ -44,7 +44,6 @@ use zarrs_codec::{Codec, CodecPluginV2, CodecPluginV3, CodecTraitsV2, CodecTrait
 pub use zarrs_metadata_ext::codec::fixedscaleoffset::{
     FixedScaleOffsetCodecConfiguration, FixedScaleOffsetCodecConfigurationNumcodecs,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(FixedScaleOffsetCodec,
     v3: "numcodecs.fixedscaleoffset", [],
@@ -60,7 +59,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for FixedScaleOffsetCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: FixedScaleOffsetCodecConfiguration =
             metadata.to_typed_configuration()?;
         let codec = Arc::new(FixedScaleOffsetCodec::new_with_configuration(
@@ -71,7 +70,7 @@ impl CodecTraitsV3 for FixedScaleOffsetCodec {
 }
 
 impl CodecTraitsV2 for FixedScaleOffsetCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: FixedScaleOffsetCodecConfiguration =
             metadata.to_typed_configuration()?;
         let codec = Arc::new(FixedScaleOffsetCodec::new_with_configuration(

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
@@ -96,7 +96,7 @@ mod tests {
 
     use crate::array::codec::array_to_array::fixedscaleoffset::FixedScaleOffsetCodec;
     use crate::array::{ArrayBytes, data_type};
-    use zarrs_codec::{ArrayToArrayCodecTraits, CodecOptions};
+    use zarrs_codec::{CodecOptions, UnboundArrayToArrayCodecTraits};
     use zarrs_metadata_ext::codec::fixedscaleoffset::FixedScaleOffsetCodecConfiguration;
 
     #[test]

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
@@ -145,4 +145,20 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn codec_fixedscaleoffset_encoded_fill_value() {
+        const JSON: &str = r#"{ "offset": 1000, "scale": 10, "dtype": "f8", "astype": "u1" }"#;
+        let data_type = data_type::float64();
+        let fill_value = FillValue::from(1000.3f64);
+
+        let codec_configuration: FixedScaleOffsetCodecConfiguration =
+            serde_json::from_str(JSON).unwrap();
+        let codec =
+            Arc::new(FixedScaleOffsetCodec::new_with_configuration(&codec_configuration).unwrap())
+                .with_context(data_type, fill_value)
+                .unwrap();
+
+        assert_eq!(codec.encoded_fill_value(), &FillValue::from(3u8));
+    }
 }

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
@@ -91,6 +91,7 @@ pub use zarrs_data_type::codec_traits::fixedscaleoffset::{
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroU64;
+    use std::sync::Arc;
 
     use zarrs_data_type::FillValue;
 
@@ -123,25 +124,16 @@ mod tests {
 
         let codec_configuration: FixedScaleOffsetCodecConfiguration =
             serde_json::from_str(JSON).unwrap();
-        let codec = FixedScaleOffsetCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec =
+            Arc::new(FixedScaleOffsetCodec::new_with_configuration(&codec_configuration).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())
+                .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &shape, &CodecOptions::default())
             .unwrap();
         let decoded_elements = crate::array::transmute_from_bytes_vec::<f64>(
             decoded.into_fixed().unwrap().into_owned(),

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
@@ -10,9 +10,9 @@ use crate::array::{DataType, FillValue};
 use crate::convert::data_type_metadata_v2_to_v3;
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
-    UnboundArrayToArrayCodecTraits,
+    ArrayBytes, ArrayCodecTraits, ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions,
+    CodecOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
+    RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata::v2::DataTypeMetadataV2;
@@ -26,6 +26,15 @@ pub struct FixedScaleOffsetCodec {
     astype_str: Option<String>,
     dtype: DataType,
     astype: Option<DataType>,
+}
+
+/// A `fixedscaleoffset` codec implementation bound to a data type and fill value.
+#[derive(Clone, Debug)]
+struct FixedScaleOffsetCodecBound {
+    codec: Arc<FixedScaleOffsetCodec>,
+    data_type: DataType,
+    fill_value: FillValue,
+    encoded_data_type: DataType,
 }
 
 fn add_byteoder_to_dtype(dtype: &str) -> String {
@@ -129,16 +138,6 @@ impl CodecTraits for FixedScaleOffsetCodec {
         PartialEncoderCapability {
             partial_encode: false, // TODO
         }
-    }
-}
-
-impl ArrayCodecTraits for FixedScaleOffsetCodec {
-    fn recommended_concurrency(
-        &self,
-        _shape: &[NonZeroU64],
-        _data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        Ok(RecommendedConcurrency::new_maximum(1))
     }
 }
 
@@ -411,27 +410,75 @@ impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
         self as Arc<dyn UnboundArrayToArrayCodecTraits>
     }
 
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+        get_element_type(&data_type)?;
+        if self.dtype != data_type {
+            return Err(CodecError::UnsupportedDataType(
+                data_type,
+                FixedScaleOffsetCodec::aliases_v3().default_name.to_string(),
+            ));
+        }
+        let encoded_data_type = self.astype.clone().unwrap_or_else(|| self.dtype.clone());
+        Ok(Arc::new(FixedScaleOffsetCodecBound {
+            codec: self,
+            data_type,
+            fill_value,
+            encoded_data_type,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for FixedScaleOffsetCodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn recommended_concurrency(
+        &self,
+        _shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        Ok(RecommendedConcurrency::new_maximum(1))
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToArrayCodecTraits for FixedScaleOffsetCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
+        self as Arc<dyn ArrayToArrayCodecTraits>
+    }
+
+    fn encoded_data_type(&self) -> &DataType {
+        &self.encoded_data_type
+    }
+
+    fn encoded_fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        if self.dtype != *data_type {
-            return Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                FixedScaleOffsetCodec::aliases_v3().default_name.to_string(),
-            ));
-        }
-
         do_encode(
             bytes,
-            data_type,
-            self.offset,
-            self.scale,
-            self.astype.as_ref(),
+            &self.data_type,
+            self.codec.offset,
+            self.codec.scale,
+            self.codec.astype.as_ref(),
         )
     }
 
@@ -439,35 +486,20 @@ impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
         &self,
         bytes: ArrayBytes<'a>,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        if self.dtype != *data_type {
-            return Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                FixedScaleOffsetCodec::aliases_v3().default_name.to_string(),
-            ));
-        }
-
         let bytes = bytes.into_fixed()?.into_owned();
-        let mut bytes = if let Some(astype) = &self.astype {
-            cast_array(&bytes, astype, data_type)?
+        let mut bytes = if let Some(astype) = &self.codec.astype {
+            cast_array(&bytes, astype, &self.data_type)?
         } else {
             bytes
         };
-        unscale_array(&mut bytes, data_type, self.offset, self.scale)?;
+        unscale_array(
+            &mut bytes,
+            &self.data_type,
+            self.codec.offset,
+            self.codec.scale,
+        )?;
         Ok(bytes.into())
-    }
-
-    fn encoded_data_type(&self, decoded_data_type: &DataType) -> Result<DataType, CodecError> {
-        // Check if the data type is supported by checking the trait
-        get_element_type(decoded_data_type)?;
-
-        if let Some(astype) = &self.astype {
-            Ok(astype.clone())
-        } else {
-            Ok(decoded_data_type.clone())
-        }
     }
 }

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
@@ -31,7 +31,9 @@ pub struct FixedScaleOffsetCodec {
 /// A `fixedscaleoffset` codec implementation bound to a data type and fill value.
 #[derive(Clone, Debug)]
 struct FixedScaleOffsetCodecBound {
-    codec: Arc<FixedScaleOffsetCodec>,
+    offset: f32,
+    scale: f32,
+    astype: Option<DataType>,
     data_type: DataType,
     fill_value: FillValue,
     encoded_data_type: DataType,
@@ -424,7 +426,9 @@ impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
         }
         let encoded_data_type = self.astype.clone().unwrap_or_else(|| self.dtype.clone());
         Ok(Arc::new(FixedScaleOffsetCodecBound {
-            codec: self,
+            offset: self.offset,
+            scale: self.scale,
+            astype: self.astype.clone(),
             data_type,
             fill_value,
             encoded_data_type,
@@ -433,6 +437,10 @@ impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
 }
 
 impl ArrayCodecTraits for FixedScaleOffsetCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }
@@ -476,9 +484,9 @@ impl ArrayToArrayCodecTraits for FixedScaleOffsetCodecBound {
         do_encode(
             bytes,
             &self.data_type,
-            self.codec.offset,
-            self.codec.scale,
-            self.codec.astype.as_ref(),
+            self.offset,
+            self.scale,
+            self.astype.as_ref(),
         )
     }
 
@@ -489,17 +497,12 @@ impl ArrayToArrayCodecTraits for FixedScaleOffsetCodecBound {
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         let bytes = bytes.into_fixed()?.into_owned();
-        let mut bytes = if let Some(astype) = &self.codec.astype {
+        let mut bytes = if let Some(astype) = &self.astype {
             cast_array(&bytes, astype, &self.data_type)?
         } else {
             bytes
         };
-        unscale_array(
-            &mut bytes,
-            &self.data_type,
-            self.codec.offset,
-            self.codec.scale,
-        )?;
+        unscale_array(&mut bytes, &self.data_type, self.offset, self.scale)?;
         Ok(bytes.into())
     }
 }

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
@@ -34,6 +34,8 @@ struct FixedScaleOffsetCodecBound {
     offset: f32,
     scale: f32,
     astype: Option<DataType>,
+    element_type: FixedScaleOffsetElementType,
+    encoded_element_type: FixedScaleOffsetElementType,
     data_type: DataType,
     fill_value: FillValue,
     encoded_data_type: DataType,
@@ -155,11 +157,10 @@ fn get_element_type(
 )]
 fn scale_array(
     bytes: &mut [u8],
-    data_type: &DataType,
+    element_type: FixedScaleOffsetElementType,
     offset: f32,
     scale: f32,
-) -> Result<(), zarrs_data_type::DataTypeCodecError> {
-    let element_type = get_element_type(data_type)?;
+) -> Result<(), CodecError> {
     let float_type = element_type.intermediate_float();
 
     macro_rules! scale_impl {
@@ -186,10 +187,9 @@ fn scale_array(
         (FixedScaleOffsetElementType::F64, FixedScaleOffsetFloatType::F64) => scale_impl!(f64, f64),
         _ => {
             // FIXME: make this unreachable?
-            return Err(zarrs_data_type::DataTypeCodecError::UnsupportedDataType {
-                data_type: data_type.clone(),
-                codec_name: "fixedscaleoffset",
-            });
+            return Err(CodecError::Other(
+                "fixedscaleoffset element type has unsupported intermediate float type".to_string(),
+            ));
         }
     }
     Ok(())
@@ -203,11 +203,10 @@ fn scale_array(
 )]
 fn unscale_array(
     bytes: &mut [u8],
-    data_type: &DataType,
+    element_type: FixedScaleOffsetElementType,
     offset: f32,
     scale: f32,
-) -> Result<(), zarrs_data_type::DataTypeCodecError> {
-    let element_type = get_element_type(data_type)?;
+) -> Result<(), CodecError> {
     let float_type = element_type.intermediate_float();
 
     macro_rules! unscale_impl {
@@ -249,10 +248,9 @@ fn unscale_array(
         }
         _ => {
             // FIXME: Make this unreachable?
-            return Err(zarrs_data_type::DataTypeCodecError::UnsupportedDataType {
-                data_type: data_type.clone(),
-                codec_name: "fixedscaleoffset",
-            });
+            return Err(CodecError::Other(
+                "fixedscaleoffset element type has unsupported intermediate float type".to_string(),
+            ));
         }
     }
     Ok(())
@@ -267,12 +265,9 @@ fn unscale_array(
 )]
 fn cast_array(
     bytes: &[u8],
-    data_type: &DataType,
-    as_type: &DataType,
-) -> Result<Vec<u8>, zarrs_data_type::DataTypeCodecError> {
-    let from_type = get_element_type(data_type)?;
-    let to_type = get_element_type(as_type)?;
-
+    from_type: FixedScaleOffsetElementType,
+    to_type: FixedScaleOffsetElementType,
+) -> Vec<u8> {
     // First cast to f32
     let elements: Vec<f32> = match from_type {
         FixedScaleOffsetElementType::I8 => bytes
@@ -380,20 +375,21 @@ fn cast_array(
             .collect(),
     };
 
-    Ok(result)
+    result
 }
 
 fn do_encode<'a>(
     bytes: ArrayBytes<'a>,
-    data_type: &DataType,
+    element_type: FixedScaleOffsetElementType,
     offset: f32,
     scale: f32,
-    astype: Option<&DataType>,
+    encoded_element_type: FixedScaleOffsetElementType,
+    astype: bool,
 ) -> Result<ArrayBytes<'a>, CodecError> {
     let mut bytes = bytes.into_fixed()?.into_owned();
-    scale_array(&mut bytes, data_type, offset, scale)?;
-    if let Some(astype) = astype {
-        Ok(cast_array(&bytes, data_type, astype)?.into())
+    scale_array(&mut bytes, element_type, offset, scale)?;
+    if astype {
+        Ok(cast_array(&bytes, element_type, encoded_element_type).into())
     } else {
         Ok(bytes.into())
     }
@@ -402,12 +398,21 @@ fn do_encode<'a>(
 fn encode_fill_value(
     fill_value: &FillValue,
     data_type: &DataType,
+    element_type: FixedScaleOffsetElementType,
     offset: f32,
     scale: f32,
-    astype: Option<&DataType>,
+    encoded_element_type: FixedScaleOffsetElementType,
+    astype: bool,
 ) -> Result<FillValue, CodecError> {
     let fill_value_bytes = ArrayBytes::new_fill_value(data_type, 1, fill_value)?;
-    let encoded_fill_value = do_encode(fill_value_bytes, data_type, offset, scale, astype)?;
+    let encoded_fill_value = do_encode(
+        fill_value_bytes,
+        element_type,
+        offset,
+        scale,
+        encoded_element_type,
+        astype,
+    )?;
     Ok(FillValue::new(
         encoded_fill_value.into_fixed()?.into_owned(),
     ))
@@ -428,7 +433,7 @@ impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
         data_type: DataType,
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
-        get_element_type(&data_type)?;
+        let element_type = get_element_type(&data_type)?;
         if self.dtype != data_type {
             return Err(CodecError::UnsupportedDataType(
                 data_type,
@@ -436,17 +441,23 @@ impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
             ));
         }
         let encoded_data_type = self.astype.clone().unwrap_or_else(|| self.dtype.clone());
+        let encoded_element_type = get_element_type(&encoded_data_type)?;
+        let astype = self.astype.is_some();
         let encoded_fill_value = encode_fill_value(
             &fill_value,
             &data_type,
+            element_type,
             self.offset,
             self.scale,
-            self.astype.as_ref(),
+            encoded_element_type,
+            astype,
         )?;
         Ok(Arc::new(FixedScaleOffsetCodecBound {
             offset: self.offset,
             scale: self.scale,
             astype: self.astype.clone(),
+            element_type,
+            encoded_element_type,
             data_type,
             fill_value,
             encoded_data_type,
@@ -502,10 +513,11 @@ impl ArrayToArrayCodecTraits for FixedScaleOffsetCodecBound {
     ) -> Result<ArrayBytes<'a>, CodecError> {
         do_encode(
             bytes,
-            &self.data_type,
+            self.element_type,
             self.offset,
             self.scale,
-            self.astype.as_ref(),
+            self.encoded_element_type,
+            self.astype.is_some(),
         )
     }
 
@@ -516,12 +528,12 @@ impl ArrayToArrayCodecTraits for FixedScaleOffsetCodecBound {
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         let bytes = bytes.into_fixed()?.into_owned();
-        let mut bytes = if let Some(astype) = &self.astype {
-            cast_array(&bytes, astype, &self.data_type)?
+        let mut bytes = if self.astype.is_some() {
+            cast_array(&bytes, self.encoded_element_type, self.element_type)
         } else {
             bytes
         };
-        unscale_array(&mut bytes, &self.data_type, self.offset, self.scale)?;
+        unscale_array(&mut bytes, self.element_type, self.offset, self.scale)?;
         Ok(bytes.into())
     }
 }

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
@@ -10,9 +10,9 @@ use crate::array::{DataType, FillValue};
 use crate::convert::data_type_metadata_v2_to_v3;
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayCodecTraits, ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions,
-    CodecOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
-    RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
+    ArrayBytes, ArrayCodecTraits, ArrayToArrayCodecTraits, CodecCreateError, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata::v2::DataTypeMetadataV2;
@@ -403,7 +403,7 @@ fn encode_fill_value(
     scale: f32,
     encoded_element_type: FixedScaleOffsetElementType,
     astype: bool,
-) -> Result<FillValue, CodecError> {
+) -> Result<FillValue, CodecCreateError> {
     let fill_value_bytes = ArrayBytes::new_fill_value(data_type, 1, fill_value)?;
     let encoded_fill_value = do_encode(
         fill_value_bytes,
@@ -412,9 +412,13 @@ fn encode_fill_value(
         scale,
         encoded_element_type,
         astype,
-    )?;
+    )
+    .map_err(CodecCreateError::other)?;
     Ok(FillValue::new(
-        encoded_fill_value.into_fixed()?.into_owned(),
+        encoded_fill_value
+            .into_fixed()
+            .map_err(CodecCreateError::other)?
+            .into_owned(),
     ))
 }
 
@@ -432,10 +436,10 @@ impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecCreateError> {
         let element_type = get_element_type(&data_type)?;
         if self.dtype != data_type {
-            return Err(CodecError::UnsupportedDataType(
+            return Err(CodecCreateError::UnsupportedDataType(
                 data_type,
                 FixedScaleOffsetCodec::aliases_v3().default_name.to_string(),
             ));

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
@@ -108,10 +108,6 @@ impl FixedScaleOffsetCodec {
 }
 
 impl CodecTraits for FixedScaleOffsetCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
@@ -10,9 +10,9 @@ use crate::array::{DataType, FillValue};
 use crate::convert::data_type_metadata_v2_to_v3;
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayCodecTraits, ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions,
-    CodecOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
-    RecommendedConcurrency,
+    ArrayBytes, ArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToArrayCodecTraits,
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata::v2::DataTypeMetadataV2;
@@ -406,9 +406,9 @@ fn do_encode<'a>(
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToArrayCodecTraits for FixedScaleOffsetCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
-        self as Arc<dyn ArrayToArrayCodecTraits>
+impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToArrayCodecTraits> {
+        self as Arc<dyn UnboundArrayToArrayCodecTraits>
     }
 
     fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset/fixedscaleoffset_codec.rs
@@ -37,6 +37,7 @@ struct FixedScaleOffsetCodecBound {
     data_type: DataType,
     fill_value: FillValue,
     encoded_data_type: DataType,
+    encoded_fill_value: FillValue,
 }
 
 fn add_byteoder_to_dtype(dtype: &str) -> String {
@@ -398,6 +399,20 @@ fn do_encode<'a>(
     }
 }
 
+fn encode_fill_value(
+    fill_value: &FillValue,
+    data_type: &DataType,
+    offset: f32,
+    scale: f32,
+    astype: Option<&DataType>,
+) -> Result<FillValue, CodecError> {
+    let fill_value_bytes = ArrayBytes::new_fill_value(data_type, 1, fill_value)?;
+    let encoded_fill_value = do_encode(fill_value_bytes, data_type, offset, scale, astype)?;
+    Ok(FillValue::new(
+        encoded_fill_value.into_fixed()?.into_owned(),
+    ))
+}
+
 #[cfg_attr(
     all(feature = "async", not(target_arch = "wasm32")),
     async_trait::async_trait
@@ -421,6 +436,13 @@ impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
             ));
         }
         let encoded_data_type = self.astype.clone().unwrap_or_else(|| self.dtype.clone());
+        let encoded_fill_value = encode_fill_value(
+            &fill_value,
+            &data_type,
+            self.offset,
+            self.scale,
+            self.astype.as_ref(),
+        )?;
         Ok(Arc::new(FixedScaleOffsetCodecBound {
             offset: self.offset,
             scale: self.scale,
@@ -428,6 +450,7 @@ impl UnboundArrayToArrayCodecTraits for FixedScaleOffsetCodec {
             data_type,
             fill_value,
             encoded_data_type,
+            encoded_fill_value,
         }))
     }
 }
@@ -468,7 +491,7 @@ impl ArrayToArrayCodecTraits for FixedScaleOffsetCodecBound {
     }
 
     fn encoded_fill_value(&self) -> &FillValue {
-        &self.fill_value
+        &self.encoded_fill_value
     }
 
     fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_array/reshape.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape.rs
@@ -175,23 +175,12 @@ mod tests {
         let bytes: ArrayBytes = bytes.into();
 
         let configuration: ReshapeCodecConfiguration = serde_json::from_str(json)?;
-        let codec = ReshapeCodec::new_with_configuration(&configuration)?;
+        let codec = Arc::new(ReshapeCodec::new_with_configuration(&configuration)?)
+            .with_context(data_type.clone(), fill_value.clone())?;
         assert_eq!(codec.encoded_shape(&shape)?, output_shape);
 
-        let encoded = codec.encode(
-            bytes.clone(),
-            &shape,
-            &data_type,
-            &fill_value,
-            &CodecOptions::default(),
-        )?;
-        let decoded = codec.decode(
-            encoded,
-            &shape,
-            &data_type,
-            &fill_value,
-            &CodecOptions::default(),
-        )?;
+        let encoded = codec.encode(bytes.clone(), &shape, &CodecOptions::default())?;
+        let decoded = codec.decode(encoded, &shape, &CodecOptions::default())?;
         assert_eq!(bytes, decoded);
         Ok(())
     }
@@ -365,10 +354,12 @@ mod tests {
 
     #[test]
     fn codec_reshape_partial_decode_granularity() {
-        let codec = ReshapeCodec::new(ReshapeShape(vec![
+        let codec = Arc::new(ReshapeCodec::new(ReshapeShape(vec![
             ReshapeDim::InputDims(vec![0]),
             ReshapeDim::InputDims(vec![1]),
-        ]));
+        ])))
+        .with_context(data_type::uint8(), FillValue::from(0u8))
+        .unwrap();
         assert_eq!(
             codec
                 .partial_decode_granularity(&[nz(4), nz(6)], &[nz(2), nz(3)])
@@ -376,7 +367,11 @@ mod tests {
             vec![nz(2), nz(3)]
         );
 
-        let codec = ReshapeCodec::new(ReshapeShape(vec![ReshapeDim::InputDims(vec![0, 1])]));
+        let codec = Arc::new(ReshapeCodec::new(ReshapeShape(vec![
+            ReshapeDim::InputDims(vec![0, 1]),
+        ])))
+        .with_context(data_type::uint8(), FillValue::from(0u8))
+        .unwrap();
         assert_eq!(
             codec
                 .partial_decode_granularity(&[nz(2), nz(20)], &[nz(5)])
@@ -396,11 +391,13 @@ mod tests {
             vec![nz(2), nz(20)]
         );
 
-        let codec = ReshapeCodec::new(ReshapeShape(vec![
+        let codec = Arc::new(ReshapeCodec::new(ReshapeShape(vec![
             ReshapeDim::Size(nz(2)),
             ReshapeDim::Size(nz(3)),
             ReshapeDim::Size(nz(2)),
-        ]));
+        ])))
+        .with_context(data_type::uint8(), FillValue::from(0u8))
+        .unwrap();
         assert_eq!(
             codec
                 .partial_decode_granularity(&[nz(12)], &[nz(1), nz(1), nz(2)])
@@ -414,10 +411,12 @@ mod tests {
             vec![nz(6)]
         );
 
-        let codec = ReshapeCodec::new(ReshapeShape(vec![
+        let codec = Arc::new(ReshapeCodec::new(ReshapeShape(vec![
             ReshapeDim::InputDims(vec![2]),
             ReshapeDim::InputDims(vec![0, 1]),
-        ]));
+        ])))
+        .with_context(data_type::uint8(), FillValue::from(0u8))
+        .unwrap();
         assert_eq!(
             codec
                 .partial_decode_granularity(&[nz(2), nz(3), nz(4)], &[nz(1), nz(6)])
@@ -446,37 +445,25 @@ mod tests {
         let fill_value = FillValue::from(0u16);
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
+        let codec = codec
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
         let encoded = codec
-            .encode(
-                bytes,
-                shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes, shape, &CodecOptions::default())
             .unwrap();
         let input_handle = Arc::new(encoded.into_fixed().unwrap());
         let bytes_codec = Arc::new(BytesCodec::default());
-        let (encoded_shape, encoded_data_type, encoded_fill_value) = codec
-            .encoded_representation(shape, &data_type, &fill_value)
+        let encoded_shape = codec.encoded_shape(shape).unwrap();
+        let encoded_data_type = codec.encoded_data_type().clone();
+        let encoded_fill_value = codec.encoded_fill_value().clone();
+        let bytes_codec = bytes_codec
+            .with_context(encoded_data_type.clone(), encoded_fill_value.clone())
             .unwrap();
         let input_handle = bytes_codec
-            .partial_decoder(
-                input_handle,
-                &encoded_shape,
-                &encoded_data_type,
-                &encoded_fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle, &encoded_shape, &CodecOptions::default())
             .unwrap();
         codec
-            .partial_decoder(
-                input_handle,
-                shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle, shape, &CodecOptions::default())
             .unwrap()
     }
 
@@ -502,50 +489,32 @@ mod tests {
         let fill_value = FillValue::from(0u16);
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
+        let codec = codec
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
         let encoded = codec
-            .encode(
-                bytes,
-                shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes, shape, &CodecOptions::default())
             .unwrap();
 
         let bytes_codec = Arc::new(BytesCodec::default());
-        let (encoded_shape, encoded_data_type, encoded_fill_value) = codec
-            .encoded_representation(shape, &data_type, &fill_value)
+        let encoded_shape = codec.encoded_shape(shape).unwrap();
+        let encoded_data_type = codec.encoded_data_type().clone();
+        let encoded_fill_value = codec.encoded_fill_value().clone();
+        let bytes_codec = bytes_codec
+            .with_context(encoded_data_type.clone(), encoded_fill_value.clone())
             .unwrap();
         let encoded_chunk = bytes_codec
-            .encode(
-                encoded,
-                &encoded_shape,
-                &encoded_data_type,
-                &encoded_fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(encoded, &encoded_shape, &CodecOptions::default())
             .unwrap()
             .into_owned();
         let output = Arc::new(Mutex::new(Some(encoded_chunk)));
         let input_output_handle = bytes_codec
             .clone()
-            .partial_encoder(
-                output.clone(),
-                &encoded_shape,
-                &encoded_data_type,
-                &encoded_fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_encoder(output.clone(), &encoded_shape, &CodecOptions::default())
             .unwrap();
         let partial_encoder = codec
             .clone()
-            .partial_encoder(
-                input_output_handle,
-                shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_encoder(input_output_handle, shape, &CodecOptions::default())
             .unwrap();
         assert!(partial_encoder.supports_partial_encode());
 
@@ -556,22 +525,10 @@ mod tests {
 
         let output = output.lock().unwrap().clone().unwrap();
         let decoded_encoded = bytes_codec
-            .decode(
-                output.into(),
-                &encoded_shape,
-                &encoded_data_type,
-                &encoded_fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(output.into(), &encoded_shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                decoded_encoded,
-                shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(decoded_encoded, shape, &CodecOptions::default())
             .unwrap();
         crate::array::convert_from_bytes_slice::<u16>(&decoded.into_fixed().unwrap()).to_vec()
     }

--- a/zarrs/src/array/codec/array_to_array/reshape.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape.rs
@@ -45,7 +45,6 @@ use zarrs_codec::{Codec, CodecError, CodecPluginV3, CodecTraitsV3};
 pub use zarrs_metadata_ext::codec::reshape::{
     ReshapeCodecConfiguration, ReshapeCodecConfigurationV1, ReshapeDim, ReshapeShape,
 };
-use zarrs_plugin::PluginCreateError;
 
 fn get_encoded_shape(
     reshape_shape: &ReshapeShape,
@@ -134,7 +133,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for ReshapeCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: ReshapeCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(ReshapeCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToArray(codec))

--- a/zarrs/src/array/codec/array_to_array/reshape.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape.rs
@@ -150,7 +150,8 @@ mod tests {
     use crate::array::codec::BytesCodec;
     use crate::array::{ArrayBytes, ArraySubset, ChunkShapeTraits, DataType, FillValue, data_type};
     use zarrs_codec::{
-        ArrayPartialDecoderTraits, ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, CodecOptions,
+        ArrayPartialDecoderTraits, CodecOptions, UnboundArrayToArrayCodecTraits,
+        UnboundArrayToBytesCodecTraits,
     };
 
     fn nz(value: u64) -> NonZeroU64 {

--- a/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
@@ -7,9 +7,9 @@ use zarrs_plugin::ZarrVersion;
 
 use crate::array::{ChunkShape, DataType, FillValue};
 use zarrs_codec::{
-    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
@@ -172,9 +172,9 @@ impl CodecTraits for ReshapeCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToArrayCodecTraits for ReshapeCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
-        self as Arc<dyn ArrayToArrayCodecTraits>
+impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToArrayCodecTraits> {
+        self as Arc<dyn UnboundArrayToArrayCodecTraits>
     }
 
     fn encoded_data_type(&self, decoded_data_type: &DataType) -> Result<DataType, CodecError> {

--- a/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
@@ -200,6 +200,10 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
 }
 
 impl ArrayCodecTraits for ReshapeCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }

--- a/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
@@ -147,10 +147,6 @@ impl ReshapeCodec {
 }
 
 impl CodecTraits for ReshapeCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
@@ -8,8 +8,8 @@ use zarrs_plugin::ZarrVersion;
 use crate::array::{ChunkShape, DataType, FillValue};
 use zarrs_codec::{
     ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayToArrayCodecTraits, CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
     UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
@@ -186,7 +186,7 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecCreateError> {
         Ok(Arc::new(ReshapeCodecBound {
             shape: self.shape.clone(),
             data_type,

--- a/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape/reshape_codec.rs
@@ -7,9 +7,10 @@ use zarrs_plugin::ZarrVersion;
 
 use crate::array::{ChunkShape, DataType, FillValue};
 use zarrs_codec::{
-    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
+    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
@@ -23,6 +24,14 @@ use zarrs_plugin::PluginCreateError;
 #[derive(Clone, Debug)]
 pub struct ReshapeCodec {
     shape: ReshapeShape,
+}
+
+/// A `reshape` codec implementation bound to a data type and fill value.
+#[derive(Clone, Debug)]
+struct ReshapeCodecBound {
+    shape: ReshapeShape,
+    data_type: DataType,
+    fill_value: FillValue,
 }
 
 /// Return the row-major linear length of an encoded granule if every encoded
@@ -177,16 +186,52 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
         self as Arc<dyn UnboundArrayToArrayCodecTraits>
     }
 
-    fn encoded_data_type(&self, decoded_data_type: &DataType) -> Result<DataType, CodecError> {
-        Ok(decoded_data_type.clone())
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+        Ok(Arc::new(ReshapeCodecBound {
+            shape: self.shape.clone(),
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for ReshapeCodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
     }
 
-    fn encoded_fill_value(
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn recommended_concurrency(
         &self,
-        _decoded_data_type: &DataType,
-        decoded_fill_value: &FillValue,
-    ) -> Result<FillValue, CodecError> {
-        Ok(decoded_fill_value.clone())
+        _shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        Ok(RecommendedConcurrency::new_maximum(1))
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToArrayCodecTraits for ReshapeCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
+        self as Arc<dyn ArrayToArrayCodecTraits>
+    }
+
+    fn encoded_data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn encoded_fill_value(&self) -> &FillValue {
+        &self.fill_value
     }
 
     fn encoded_shape(&self, decoded_shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError> {
@@ -230,8 +275,6 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
         &self,
         bytes: ArrayBytes<'a>,
         _shape: &[NonZeroU64],
-        _data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         Ok(bytes)
@@ -241,8 +284,6 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
         &self,
         bytes: ArrayBytes<'a>,
         _shape: &[NonZeroU64],
-        _data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         Ok(bytes)
@@ -252,8 +293,6 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         let encoded_shape = super::get_encoded_shape(&self.shape, shape)?;
@@ -261,8 +300,8 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
             super::reshape_codec_partial::ReshapeCodecPartial::new(
                 input_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 encoded_shape,
             ),
         ))
@@ -272,8 +311,6 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
         self: Arc<Self>,
         input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
         let encoded_shape = super::get_encoded_shape(&self.shape, shape)?;
@@ -281,8 +318,8 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
             super::reshape_codec_partial::ReshapeCodecPartial::new(
                 input_output_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 encoded_shape,
             ),
         ))
@@ -293,8 +330,6 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         let encoded_shape = super::get_encoded_shape(&self.shape, shape)?;
@@ -302,8 +337,8 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
             super::reshape_codec_partial::ReshapeCodecPartial::new(
                 input_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 encoded_shape,
             ),
         ))
@@ -314,8 +349,6 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
         self: Arc<Self>,
         input_output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
         let encoded_shape = super::get_encoded_shape(&self.shape, shape)?;
@@ -323,20 +356,10 @@ impl UnboundArrayToArrayCodecTraits for ReshapeCodec {
             super::reshape_codec_partial::ReshapeCodecPartial::new(
                 input_output_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 encoded_shape,
             ),
         ))
-    }
-}
-
-impl ArrayCodecTraits for ReshapeCodec {
-    fn recommended_concurrency(
-        &self,
-        _shape: &[NonZeroU64],
-        _data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        Ok(RecommendedConcurrency::new_maximum(1))
     }
 }

--- a/zarrs/src/array/codec/array_to_array/squeeze.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze.rs
@@ -123,7 +123,9 @@ mod tests {
     use super::*;
     use crate::array::codec::BytesCodec;
     use crate::array::{ArrayBytes, ArraySubset, ChunkShapeTraits, DataType, FillValue, data_type};
-    use zarrs_codec::{ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, CodecOptions};
+    use zarrs_codec::{
+        CodecOptions, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
+    };
 
     fn nz(value: u64) -> NonZeroU64 {
         NonZeroU64::new(value).unwrap()

--- a/zarrs/src/array/codec/array_to_array/squeeze.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze.rs
@@ -149,7 +149,9 @@ mod tests {
         let bytes: ArrayBytes = bytes.into();
 
         let configuration: SqueezeCodecConfiguration = serde_json::from_str(json).unwrap();
-        let codec = SqueezeCodec::new_with_configuration(&configuration).unwrap();
+        let codec = Arc::new(SqueezeCodec::new_with_configuration(&configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
         assert_eq!(
             codec.encoded_shape(&shape).unwrap(),
             vec![
@@ -160,22 +162,10 @@ mod tests {
         );
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(bytes, decoded);
     }
@@ -188,7 +178,9 @@ mod tests {
 
     #[test]
     fn codec_squeeze_partial_decode_granularity() {
-        let codec = SqueezeCodec::new();
+        let codec = Arc::new(SqueezeCodec::new())
+            .with_context(data_type::uint8(), FillValue::from(0u8))
+            .unwrap();
 
         assert_eq!(
             codec
@@ -232,37 +224,25 @@ mod tests {
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
 
+        let codec = codec
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
         let encoded = codec
-            .encode(
-                bytes,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes, &shape, &CodecOptions::default())
             .unwrap();
         let input_handle = Arc::new(encoded.into_fixed().unwrap());
         let bytes_codec = Arc::new(BytesCodec::default());
-        let (encoded_shape, encoded_data_type, encoded_fill_value) = codec
-            .encoded_representation(&shape, &data_type, &fill_value)
+        let encoded_shape = codec.encoded_shape(&shape).unwrap();
+        let encoded_data_type = codec.encoded_data_type().clone();
+        let encoded_fill_value = codec.encoded_fill_value().clone();
+        let bytes_codec = bytes_codec
+            .with_context(encoded_data_type.clone(), encoded_fill_value.clone())
             .unwrap();
         let input_handle = bytes_codec
-            .partial_decoder(
-                input_handle,
-                &encoded_shape,
-                &encoded_data_type,
-                &encoded_fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle, &encoded_shape, &CodecOptions::default())
             .unwrap();
         let partial_decoder = codec
-            .partial_decoder(
-                input_handle.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle.clone(), &shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // squeeze partial decoder does not hold bytes
 

--- a/zarrs/src/array/codec/array_to_array/squeeze.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze.rs
@@ -42,7 +42,6 @@ use zarrs_codec::{Codec, CodecError, CodecPluginV3, CodecTraitsV3};
 pub use zarrs_metadata_ext::codec::squeeze::{
     SqueezeCodecConfiguration, SqueezeCodecConfigurationV0,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(SqueezeCodec,
   v3: "zarrs.squeeze", []
@@ -54,7 +53,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for SqueezeCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         crate::warn_experimental_extension(metadata.name(), "codec");
         let configuration: SqueezeCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(SqueezeCodec::new_with_configuration(&configuration)?);

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
@@ -5,9 +5,9 @@ use zarrs_plugin::ZarrVersion;
 
 use crate::array::{ChunkShape, DataType, FillValue};
 use zarrs_codec::{
-    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
@@ -81,9 +81,9 @@ impl CodecTraits for SqueezeCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToArrayCodecTraits for SqueezeCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
-        self as Arc<dyn ArrayToArrayCodecTraits>
+impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToArrayCodecTraits> {
+        self as Arc<dyn UnboundArrayToArrayCodecTraits>
     }
 
     fn encoded_data_type(&self, decoded_data_type: &DataType) -> Result<DataType, CodecError> {

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
@@ -57,10 +57,6 @@ impl Default for SqueezeCodec {
 }
 
 impl CodecTraits for SqueezeCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
@@ -6,8 +6,8 @@ use zarrs_plugin::ZarrVersion;
 use crate::array::{ChunkShape, DataType, FillValue};
 use zarrs_codec::{
     ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayToArrayCodecTraits, CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
     UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
@@ -94,7 +94,7 @@ impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecCreateError> {
         Ok(Arc::new(SqueezeCodecBound {
             data_type,
             fill_value,

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
@@ -5,9 +5,10 @@ use zarrs_plugin::ZarrVersion;
 
 use crate::array::{ChunkShape, DataType, FillValue};
 use zarrs_codec::{
-    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
+    ArrayBytes, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
@@ -18,6 +19,13 @@ use zarrs_plugin::PluginCreateError;
 /// A Squeeze codec implementation.
 #[derive(Clone, Debug)]
 pub struct SqueezeCodec {}
+
+/// A Squeeze codec implementation bound to a data type and fill value.
+#[derive(Clone, Debug)]
+struct SqueezeCodecBound {
+    data_type: DataType,
+    fill_value: FillValue,
+}
 
 impl SqueezeCodec {
     /// Create a new squeeze codec from configuration.
@@ -86,16 +94,51 @@ impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
         self as Arc<dyn UnboundArrayToArrayCodecTraits>
     }
 
-    fn encoded_data_type(&self, decoded_data_type: &DataType) -> Result<DataType, CodecError> {
-        Ok(decoded_data_type.clone())
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+        Ok(Arc::new(SqueezeCodecBound {
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for SqueezeCodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
     }
 
-    fn encoded_fill_value(
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn recommended_concurrency(
         &self,
-        _decoded_data_type: &DataType,
-        decoded_fill_value: &FillValue,
-    ) -> Result<FillValue, CodecError> {
-        Ok(decoded_fill_value.clone())
+        _shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        Ok(RecommendedConcurrency::new_maximum(1))
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToArrayCodecTraits for SqueezeCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
+        self as Arc<dyn ArrayToArrayCodecTraits>
+    }
+
+    fn encoded_data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn encoded_fill_value(&self) -> &FillValue {
+        &self.fill_value
     }
 
     fn encoded_shape(&self, decoded_shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError> {
@@ -151,8 +194,6 @@ impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
         &self,
         bytes: ArrayBytes<'a>,
         _shape: &[NonZeroU64],
-        _data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         Ok(bytes)
@@ -162,8 +203,6 @@ impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
         &self,
         bytes: ArrayBytes<'a>,
         _shape: &[NonZeroU64],
-        _data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         Ok(bytes)
@@ -173,16 +212,14 @@ impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::squeeze_codec_partial::SqueezeCodecPartial::new(
                 input_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
             ),
         ))
     }
@@ -191,16 +228,14 @@ impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
         self: Arc<Self>,
         input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(
             super::squeeze_codec_partial::SqueezeCodecPartial::new(
                 input_output_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
             ),
         ))
     }
@@ -210,16 +245,14 @@ impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::squeeze_codec_partial::SqueezeCodecPartial::new(
                 input_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
             ),
         ))
     }
@@ -229,27 +262,15 @@ impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
         self: Arc<Self>,
         input_output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(
             super::squeeze_codec_partial::SqueezeCodecPartial::new(
                 input_output_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
             ),
         ))
-    }
-}
-
-impl ArrayCodecTraits for SqueezeCodec {
-    fn recommended_concurrency(
-        &self,
-        _shape: &[NonZeroU64],
-        _data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        Ok(RecommendedConcurrency::new_maximum(1))
     }
 }

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
@@ -107,6 +107,10 @@ impl UnboundArrayToArrayCodecTraits for SqueezeCodec {
 }
 
 impl ArrayCodecTraits for SqueezeCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }

--- a/zarrs/src/array/codec/array_to_array/transpose.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose.rs
@@ -408,44 +408,33 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn codec_transpose_async_partial_decode() {
-        let codec = Arc::new(TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap()));
-
         let elements: Vec<f32> = (0..16).map(|i| i as f32).collect();
         let shape = vec![NonZeroU64::new(4).unwrap(), NonZeroU64::new(4).unwrap()];
         let data_type = data_type::float32();
         let fill_value = FillValue::from(0.0f32);
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
+        let codec = Arc::new(TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap()))
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap();
         let input_handle = Arc::new(encoded.into_fixed().unwrap());
         let bytes_codec = Arc::new(BytesCodec::default());
-        let input_handle = bytes_codec
-            .async_partial_decoder(
-                input_handle,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
+        let bytes_codec = bytes_codec
+            .with_context(
+                codec.encoded_data_type().clone(),
+                codec.encoded_fill_value().clone(),
             )
+            .unwrap();
+        let input_handle = bytes_codec
+            .async_partial_decoder(input_handle, &shape, &CodecOptions::default())
             .await
             .unwrap();
         let partial_decoder = codec
-            .async_partial_decoder(
-                input_handle,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .async_partial_decoder(input_handle, &shape, &CodecOptions::default())
             .await
             .unwrap();
         let decoded_regions = [

--- a/zarrs/src/array/codec/array_to_array/transpose.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose.rs
@@ -43,7 +43,6 @@ use zarrs_metadata::DataTypeSize;
 pub use zarrs_metadata_ext::codec::transpose::{
     TransposeCodecConfiguration, TransposeCodecConfigurationV1, TransposeOrder, TransposeOrderError,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(TransposeCodec, v3: "transpose");
 
@@ -53,7 +52,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for TransposeCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: TransposeCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(TransposeCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToArray(codec))

--- a/zarrs/src/array/codec/array_to_array/transpose.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose.rs
@@ -238,7 +238,9 @@ mod tests {
     use super::*;
     use crate::array::codec::BytesCodec;
     use crate::array::{ArrayBytes, ArraySubset, ChunkShapeTraits, DataType, FillValue, data_type};
-    use zarrs_codec::{ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, CodecOptions};
+    use zarrs_codec::{
+        CodecOptions, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
+    };
 
     fn codec_transpose_round_trip_impl(
         json: &str,

--- a/zarrs/src/array/codec/array_to_array/transpose.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose.rs
@@ -258,25 +258,15 @@ mod tests {
         let bytes: ArrayBytes = bytes.into();
 
         let configuration: TransposeCodecConfiguration = serde_json::from_str(json).unwrap();
-        let codec = TransposeCodec::new_with_configuration(&configuration).unwrap();
+        let codec = Arc::new(TransposeCodec::new_with_configuration(&configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(bytes, decoded);
     }
@@ -311,25 +301,15 @@ mod tests {
         let bytes = Element::into_array_bytes(&data_type::string(), strings).unwrap();
 
         // Create transpose codec with order [1, 0] (swap axes)
-        let codec = TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap());
+        let codec = Arc::new(TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap()))
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &shape, &CodecOptions::default())
             .unwrap();
 
         assert_eq!(bytes, decoded);
@@ -380,34 +360,25 @@ mod tests {
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
 
+        let codec = codec
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
         let encoded = codec
-            .encode(
-                bytes,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes, &shape, &CodecOptions::default())
             .unwrap();
         let input_handle = Arc::new(encoded.into_fixed().unwrap());
         let bytes_codec = Arc::new(BytesCodec::default());
-        let input_handle = bytes_codec
-            .partial_decoder(
-                input_handle,
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
+        let bytes_codec = bytes_codec
+            .with_context(
+                codec.encoded_data_type().clone(),
+                codec.encoded_fill_value().clone(),
             )
             .unwrap();
+        let input_handle = bytes_codec
+            .partial_decoder(input_handle, &shape, &CodecOptions::default())
+            .unwrap();
         let partial_decoder = codec
-            .partial_decoder(
-                input_handle.clone(),
-                &shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle.clone(), &shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // transpose partial decoder does not hold bytes
         let decoded_regions = [

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
@@ -9,8 +9,8 @@ use super::{
 use crate::array::{ArrayBytes, ChunkShape, DataType, FillValue};
 use zarrs_codec::{
     ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayToArrayCodecTraits, CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
     UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
@@ -117,9 +117,9 @@ impl UnboundArrayToArrayCodecTraits for TransposeCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecCreateError> {
         if data_type.is_optional() {
-            return Err(CodecError::UnsupportedDataType(
+            return Err(CodecCreateError::UnsupportedDataType(
                 data_type,
                 Self::aliases_v3().default_name.to_string(),
             ));

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
@@ -137,6 +137,10 @@ impl UnboundArrayToArrayCodecTraits for TransposeCodec {
 }
 
 impl ArrayCodecTraits for TransposeCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
@@ -8,9 +8,10 @@ use super::{
 };
 use crate::array::{ArrayBytes, ChunkShape, DataType, FillValue};
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
+    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
@@ -22,6 +23,14 @@ use zarrs_plugin::PluginCreateError;
 #[derive(Clone, Debug)]
 pub struct TransposeCodec {
     pub(crate) order: TransposeOrder,
+}
+
+/// A Transpose codec implementation bound to a data type and fill value.
+#[derive(Clone, Debug)]
+struct TransposeCodecBound {
+    order: TransposeOrder,
+    data_type: DataType,
+    fill_value: FillValue,
 }
 
 impl TransposeCodec {
@@ -48,13 +57,15 @@ impl TransposeCodec {
     pub const fn new(order: TransposeOrder) -> Self {
         Self { order }
     }
+}
 
+impl TransposeCodecBound {
     /// Validate the shape and data type for this codec.
     fn validate(&self, shape: &[NonZeroU64], data_type: &DataType) -> Result<(), CodecError> {
         if data_type.is_optional() {
             return Err(CodecError::UnsupportedDataType(
                 data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
+                TransposeCodec::aliases_v3().default_name.to_string(),
             ));
         }
         if self.order.0.len() != shape.len() {
@@ -106,22 +117,59 @@ impl UnboundArrayToArrayCodecTraits for TransposeCodec {
         self as Arc<dyn UnboundArrayToArrayCodecTraits>
     }
 
-    fn encoded_data_type(&self, decoded_data_type: &DataType) -> Result<DataType, CodecError> {
-        if decoded_data_type.is_optional() {
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError> {
+        if data_type.is_optional() {
             return Err(CodecError::UnsupportedDataType(
-                decoded_data_type.clone(),
+                data_type,
                 Self::aliases_v3().default_name.to_string(),
             ));
         }
-        Ok(decoded_data_type.clone())
+        Ok(Arc::new(TransposeCodecBound {
+            order: self.order.clone(),
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for TransposeCodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
     }
 
-    fn encoded_fill_value(
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn recommended_concurrency(
         &self,
-        _decoded_data_type: &DataType,
-        decoded_fill_value: &FillValue,
-    ) -> Result<FillValue, CodecError> {
-        Ok(decoded_fill_value.clone())
+        _shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        // TODO: This could be increased, need to implement `transpose_array` without ndarray
+        Ok(RecommendedConcurrency::new_maximum(1))
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToArrayCodecTraits for TransposeCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
+        self as Arc<dyn ArrayToArrayCodecTraits>
+    }
+
+    fn encoded_data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn encoded_fill_value(&self) -> &FillValue {
+        &self.fill_value
     }
 
     fn encoded_shape(&self, decoded_shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError> {
@@ -155,26 +203,22 @@ impl UnboundArrayToArrayCodecTraits for TransposeCodec {
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        self.validate(shape, data_type)?;
+        self.validate(shape, &self.data_type)?;
 
         // Encode: apply the transpose order to the decoded shape
         let shape_u64 = bytemuck::must_cast_slice(shape);
-        apply_permutation(&bytes, shape_u64, &self.order.0, data_type)
+        apply_permutation(&bytes, shape_u64, &self.order.0, &self.data_type)
     }
 
     fn decode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        self.validate(shape, data_type)?;
+        self.validate(shape, &self.data_type)?;
 
         // Decode: apply the inverse permutation to the encoded (transposed) shape
         let shape_u64 = bytemuck::must_cast_slice(shape);
@@ -183,7 +227,7 @@ impl UnboundArrayToArrayCodecTraits for TransposeCodec {
             &bytes,
             &transposed_shape,
             &inverse_permutation(&self.order.0),
-            data_type,
+            &self.data_type,
         )
     }
 
@@ -191,16 +235,14 @@ impl UnboundArrayToArrayCodecTraits for TransposeCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::transpose_codec_partial::TransposeCodecPartial::new(
                 input_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 self.order.0.clone(),
             ),
         ))
@@ -210,16 +252,14 @@ impl UnboundArrayToArrayCodecTraits for TransposeCodec {
         self: Arc<Self>,
         input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(
             super::transpose_codec_partial::TransposeCodecPartial::new(
                 input_output_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 self.order.0.clone(),
             ),
         ))
@@ -230,16 +270,14 @@ impl UnboundArrayToArrayCodecTraits for TransposeCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::transpose_codec_partial::TransposeCodecPartial::new(
                 input_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 self.order.0.clone(),
             ),
         ))
@@ -250,29 +288,16 @@ impl UnboundArrayToArrayCodecTraits for TransposeCodec {
         self: Arc<Self>,
         input_output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(
             super::transpose_codec_partial::TransposeCodecPartial::new(
                 input_output_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 self.order.0.clone(),
             ),
         ))
-    }
-}
-
-impl ArrayCodecTraits for TransposeCodec {
-    fn recommended_concurrency(
-        &self,
-        _shape: &[NonZeroU64],
-        _data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        // TODO: This could be increased, need to implement `transpose_array` without ndarray
-        Ok(RecommendedConcurrency::new_maximum(1))
     }
 }

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
@@ -78,10 +78,6 @@ impl TransposeCodecBound {
 }
 
 impl CodecTraits for TransposeCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
@@ -61,10 +61,10 @@ impl TransposeCodec {
 
 impl TransposeCodecBound {
     /// Validate the shape and data type for this codec.
-    fn validate(&self, shape: &[NonZeroU64], data_type: &DataType) -> Result<(), CodecError> {
-        if data_type.is_optional() {
+    fn validate(&self, shape: &[NonZeroU64]) -> Result<(), CodecError> {
+        if self.data_type.is_optional() {
             return Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
+                self.data_type.clone(),
                 TransposeCodec::aliases_v3().default_name.to_string(),
             ));
         }
@@ -205,7 +205,7 @@ impl ArrayToArrayCodecTraits for TransposeCodecBound {
         shape: &[NonZeroU64],
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        self.validate(shape, &self.data_type)?;
+        self.validate(shape)?;
 
         // Encode: apply the transpose order to the decoded shape
         let shape_u64 = bytemuck::must_cast_slice(shape);
@@ -218,7 +218,7 @@ impl ArrayToArrayCodecTraits for TransposeCodecBound {
         shape: &[NonZeroU64],
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        self.validate(shape, &self.data_type)?;
+        self.validate(shape)?;
 
         // Decode: apply the inverse permutation to the encoded (transposed) shape
         let shape_u64 = bytemuck::must_cast_slice(shape);

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec.rs
@@ -8,9 +8,9 @@ use super::{
 };
 use crate::array::{ArrayBytes, ChunkShape, DataType, FillValue};
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
@@ -101,9 +101,9 @@ impl CodecTraits for TransposeCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToArrayCodecTraits for TransposeCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
-        self as Arc<dyn ArrayToArrayCodecTraits>
+impl UnboundArrayToArrayCodecTraits for TransposeCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToArrayCodecTraits> {
+        self as Arc<dyn UnboundArrayToArrayCodecTraits>
     }
 
     fn encoded_data_type(&self, decoded_data_type: &DataType) -> Result<DataType, CodecError> {

--- a/zarrs/src/array/codec/array_to_bytes/bytes.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes.rs
@@ -120,6 +120,7 @@ mod tests {
     };
     use zarrs_codec::{
         BytesPartialDecoderTraits, CodecMetadataOptions, CodecOptions, CodecTraits,
+        UnboundArrayToBytesCodecTraits,
     };
 
     #[test]
@@ -173,23 +174,12 @@ mod tests {
         let size = chunk_shape.num_elements_u64() as usize * data_type.fixed_size().unwrap();
         let bytes: ArrayBytes = (0..size).map(|s| s as u8).collect::<Vec<_>>().into();
 
-        let codec = BytesCodec::new(endianness);
+        let codec = Arc::new(BytesCodec::new(endianness))
+            .with_context(data_type.clone(), fill_value.clone())?;
 
-        let encoded = codec.encode(
-            bytes.clone(),
-            &chunk_shape,
-            &data_type,
-            &fill_value,
-            &CodecOptions::default(),
-        )?;
+        let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
         let decoded = codec
-            .decode(
-                encoded,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &chunk_shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(bytes, decoded);
         Ok(())
@@ -273,27 +263,17 @@ mod tests {
         let elements: Vec<u8> = (0..chunk_shape.num_elements_u64() as u8).collect();
         let bytes: ArrayBytes = elements.into();
 
-        let codec = Arc::new(BytesCodec::new(None));
+        let codec = Arc::new(BytesCodec::new(None))
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..3, 0..1]);
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .partial_decoder(
-                input_handle.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // bytes partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
@@ -321,27 +301,17 @@ mod tests {
         let elements: Vec<u8> = (0..chunk_shape.num_elements_u64() as u8).collect();
         let bytes: ArrayBytes = elements.into();
 
-        let codec = Arc::new(BytesCodec::new(None));
+        let codec = Arc::new(BytesCodec::new(None))
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..3, 0..1]);
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .async_partial_decoder(
-                input_handle,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .async_partial_decoder(input_handle, &chunk_shape, &CodecOptions::default())
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder

--- a/zarrs/src/array/codec/array_to_bytes/bytes.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes.rs
@@ -119,8 +119,8 @@ mod tests {
         ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, Endianness, FillValue, data_type,
     };
     use zarrs_codec::{
-        ArrayToBytesCodecTraits, BytesPartialDecoderTraits, CodecMetadataOptions, CodecOptions,
-        CodecTraits,
+        BytesPartialDecoderTraits, CodecMetadataOptions, CodecOptions, CodecTraits,
+        UnboundArrayToBytesCodecTraits,
     };
 
     #[test]

--- a/zarrs/src/array/codec/array_to_bytes/bytes.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes.rs
@@ -41,7 +41,6 @@ use zarrs_metadata::v3::MetadataV3;
 use crate::array::DataType;
 use zarrs_codec::{Codec, CodecPluginV3, CodecTraitsV3};
 pub use zarrs_metadata_ext::codec::bytes::{BytesCodecConfiguration, BytesCodecConfigurationV1};
-use zarrs_plugin::PluginCreateError;
 
 // Re-export extension trait and macro from zarrs_data_type
 pub use zarrs_data_type::codec_traits::bytes::{
@@ -61,7 +60,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for BytesCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         if metadata.name() == "binary" {
             crate::warn_deprecated_extension("binary", "codec", Some("bytes"));
         }

--- a/zarrs/src/array/codec/array_to_bytes/bytes.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes.rs
@@ -120,7 +120,6 @@ mod tests {
     };
     use zarrs_codec::{
         BytesPartialDecoderTraits, CodecMetadataOptions, CodecOptions, CodecTraits,
-        UnboundArrayToBytesCodecTraits,
     };
 
     #[test]

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
@@ -35,7 +35,7 @@ pub struct BytesCodec {
 /// A `bytes` codec implementation bound to a data type and fill value.
 #[derive(Debug, Clone)]
 struct BytesCodecBound {
-    codec: Arc<BytesCodec>,
+    endian: Option<Endianness>,
     data_type: DataType,
     fill_value: FillValue,
 }
@@ -136,7 +136,7 @@ impl UnboundArrayToBytesCodecTraits for BytesCodec {
         }
         data_type.codec_bytes()?;
         Ok(Arc::new(BytesCodecBound {
-            codec: self,
+            endian: self.endian,
             data_type,
             fill_value,
         }))
@@ -144,6 +144,10 @@ impl UnboundArrayToBytesCodecTraits for BytesCodec {
 }
 
 impl ArrayCodecTraits for BytesCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }
@@ -193,10 +197,7 @@ impl ArrayToBytesCodecTraits for BytesCodecBound {
         bytes.validate(num_elements, &self.data_type)?;
         let bytes = bytes.into_fixed()?;
 
-        let bytes_encoded = self
-            .data_type
-            .codec_bytes()?
-            .encode(bytes, self.codec.endian)?;
+        let bytes_encoded = self.data_type.codec_bytes()?.encode(bytes, self.endian)?;
         Ok(bytes_encoded)
     }
 
@@ -209,7 +210,7 @@ impl ArrayToBytesCodecTraits for BytesCodecBound {
         let bytes_decoded: ArrayBytes = self
             .data_type
             .codec_bytes()?
-            .decode(bytes, self.codec.endian)?
+            .decode(bytes, self.endian)?
             .into();
 
         let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
@@ -229,7 +230,7 @@ impl ArrayToBytesCodecTraits for BytesCodecBound {
             shape,
             &self.data_type,
             &self.fill_value,
-            self.codec.endian,
+            self.endian,
         )))
     }
 
@@ -244,7 +245,7 @@ impl ArrayToBytesCodecTraits for BytesCodecBound {
             shape,
             &self.data_type,
             &self.fill_value,
-            self.codec.endian,
+            self.endian,
         )))
     }
 
@@ -260,7 +261,7 @@ impl ArrayToBytesCodecTraits for BytesCodecBound {
             shape,
             &self.data_type,
             &self.fill_value,
-            self.codec.endian,
+            self.endian,
         )))
     }
 
@@ -276,7 +277,7 @@ impl ArrayToBytesCodecTraits for BytesCodecBound {
             shape,
             &self.data_type,
             &self.fill_value,
-            self.codec.endian,
+            self.endian,
         )))
     }
 

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
@@ -15,9 +15,10 @@ use crate::array::{
 use std::num::NonZeroU64;
 use zarrs_codec::{
     ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToBytesCodecTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
+    ArrayToBytesCodecTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits,
+    CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{
@@ -123,9 +124,9 @@ impl UnboundArrayToBytesCodecTraits for BytesCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         if data_type.is_optional() {
-            return Err(CodecError::UnsupportedDataType(
+            return Err(CodecCreateError::UnsupportedDataType(
                 data_type,
                 Self::aliases_v3().default_name.to_string(),
             ));

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
@@ -84,10 +84,6 @@ impl BytesCodec {
 }
 
 impl CodecTraits for BytesCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
@@ -15,9 +15,9 @@ use crate::array::{
 use std::num::NonZeroU64;
 use zarrs_codec::{
     ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToBytesCodecTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency,
+    BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError, CodecMetadataOptions,
+    CodecOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
+    RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{
@@ -133,9 +133,9 @@ impl ArrayCodecTraits for BytesCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for BytesCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for BytesCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec.rs
@@ -15,9 +15,9 @@ use crate::array::{
 use std::num::NonZeroU64;
 use zarrs_codec::{
     ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError, CodecMetadataOptions,
-    CodecOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
-    RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
+    ArrayToBytesCodecTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{
@@ -30,6 +30,14 @@ use zarrs_metadata::Configuration;
 #[derive(Debug, Clone)]
 pub struct BytesCodec {
     endian: Option<Endianness>,
+}
+
+/// A `bytes` codec implementation bound to a data type and fill value.
+#[derive(Debug, Clone)]
+struct BytesCodecBound {
+    codec: Arc<BytesCodec>,
+    data_type: DataType,
+    fill_value: FillValue,
 }
 
 impl Default for BytesCodec {
@@ -105,11 +113,48 @@ impl CodecTraits for BytesCodec {
     }
 }
 
-impl ArrayCodecTraits for BytesCodec {
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl UnboundArrayToBytesCodecTraits for BytesCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
+    }
+
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        if data_type.is_optional() {
+            return Err(CodecError::UnsupportedDataType(
+                data_type,
+                Self::aliases_v3().default_name.to_string(),
+            ));
+        }
+        data_type.codec_bytes()?;
+        Ok(Arc::new(BytesCodecBound {
+            codec: self,
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for BytesCodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
     fn recommended_concurrency(
         &self,
         _shape: &[NonZeroU64],
-        _data_type: &DataType,
     ) -> Result<RecommendedConcurrency, CodecError> {
         // TODO: Recomment > 1 if endianness needs changing and input is sufficiently large
         // if let Some(endian) = &self.endian {
@@ -133,32 +178,25 @@ impl ArrayCodecTraits for BytesCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl UnboundArrayToBytesCodecTraits for BytesCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
-        self as Arc<dyn UnboundArrayToBytesCodecTraits>
+impl ArrayToBytesCodecTraits for BytesCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self as Arc<dyn ArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-        // Reject optional data types explicitly
-        if data_type.is_optional() {
-            return Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
-            ));
-        }
-
         let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
-        bytes.validate(num_elements, data_type)?;
+        bytes.validate(num_elements, &self.data_type)?;
         let bytes = bytes.into_fixed()?;
 
-        let bytes_encoded = data_type.codec_bytes()?.encode(bytes, self.endian)?;
+        let bytes_encoded = self
+            .data_type
+            .codec_bytes()?
+            .encode(bytes, self.codec.endian)?;
         Ok(bytes_encoded)
     }
 
@@ -166,22 +204,16 @@ impl UnboundArrayToBytesCodecTraits for BytesCodec {
         &self,
         bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        // Reject optional data types explicitly
-        if data_type.is_optional() {
-            return Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
-            ));
-        }
-
-        let bytes_decoded: ArrayBytes = data_type.codec_bytes()?.decode(bytes, self.endian)?.into();
+        let bytes_decoded: ArrayBytes = self
+            .data_type
+            .codec_bytes()?
+            .decode(bytes, self.codec.endian)?
+            .into();
 
         let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
-        bytes_decoded.validate(num_elements, data_type)?;
+        bytes_decoded.validate(num_elements, &self.data_type)?;
 
         Ok(bytes_decoded)
     }
@@ -190,16 +222,14 @@ impl UnboundArrayToBytesCodecTraits for BytesCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(bytes_codec_partial::BytesCodecPartial::new(
             input_handle,
             shape,
-            data_type,
-            fill_value,
-            self.endian,
+            &self.data_type,
+            &self.fill_value,
+            self.codec.endian,
         )))
     }
 
@@ -207,16 +237,14 @@ impl UnboundArrayToBytesCodecTraits for BytesCodec {
         self: Arc<Self>,
         input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(bytes_codec_partial::BytesCodecPartial::new(
             input_output_handle,
             shape,
-            data_type,
-            fill_value,
-            self.endian,
+            &self.data_type,
+            &self.fill_value,
+            self.codec.endian,
         )))
     }
 
@@ -225,16 +253,14 @@ impl UnboundArrayToBytesCodecTraits for BytesCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(bytes_codec_partial::BytesCodecPartial::new(
             input_handle,
             shape,
-            data_type,
-            fill_value,
-            self.endian,
+            &self.data_type,
+            &self.fill_value,
+            self.codec.endian,
         )))
     }
 
@@ -243,37 +269,25 @@ impl UnboundArrayToBytesCodecTraits for BytesCodec {
         self: Arc<Self>,
         input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(bytes_codec_partial::BytesCodecPartial::new(
             input_output_handle,
             shape,
-            data_type,
-            fill_value,
-            self.endian,
+            &self.data_type,
+            &self.fill_value,
+            self.codec.endian,
         )))
     }
 
     fn encoded_representation(
         &self,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
     ) -> Result<BytesRepresentation, CodecError> {
-        // Reject optional data types explicitly
-        if data_type.is_optional() {
-            return Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
-            ));
-        }
-
-        match data_type.size() {
+        match self.data_type.size() {
             DataTypeSize::Variable => Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
+                self.data_type.clone(),
+                BytesCodec::aliases_v3().default_name.to_string(),
             )),
             DataTypeSize::Fixed(data_type_size) => Ok(BytesRepresentation::FixedSize(
                 shape.num_elements_u64() * data_type_size as u64,

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -76,18 +76,38 @@ impl CodecChain {
             .clone()
             .with_context(data_type, fill_value)?;
 
-        // Compute cache index from bytes codecs (reverse iteration)
         let mut cache_index_must = None;
         let mut cache_index_should = None;
-        for (i, codec) in self.bytes_to_bytes.iter().rev().enumerate() {
-            let idx = self.bytes_to_bytes.len() - 1 - i;
+        let mut codec_index = 0;
+        for codec in self.bytes_to_bytes.iter().rev() {
             let cap = codec.partial_decoder_capability();
             if !cap.partial_decode {
-                cache_index_must = Some(idx + 1);
+                cache_index_must = Some(codec_index + 1);
             }
             if !cap.partial_read {
-                cache_index_should = Some(idx);
+                cache_index_should = Some(codec_index);
             }
+            codec_index += 1;
+        }
+        {
+            let cap = self.array_to_bytes.partial_decoder_capability();
+            if !cap.partial_decode {
+                cache_index_must = Some(codec_index + 1);
+            }
+            if !cap.partial_read {
+                cache_index_should = Some(codec_index);
+            }
+            codec_index += 1;
+        }
+        for codec in self.array_to_array.iter().rev() {
+            let cap = codec.partial_decoder_capability();
+            if !cap.partial_decode {
+                cache_index_must = Some(codec_index + 1);
+            }
+            if !cap.partial_read {
+                cache_index_should = Some(codec_index);
+            }
+            codec_index += 1;
         }
         let cache_index = match (cache_index_must, cache_index_should) {
             (Some(m), Some(s)) => Some(m.max(s)),
@@ -507,106 +527,65 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
 
     fn partial_decoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        mut input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         let (array_representations, bytes_representations) = self.get_representations(shape)?;
-        let (encoded_shape, _encoded_data_type, _encoded_fill_value) =
-            array_representations.last().unwrap();
-
-        let mut input_handle = input_handle;
-
-        if let Some(cache_idx) = self.cache_index {
-            // Pre-cache bytes codecs (indices cache_idx..N, processed in reverse)
-            for (codec, bytes_representation) in std::iter::zip(
-                self.bytes_to_bytes[cache_idx..].iter().rev(),
-                bytes_representations[cache_idx + 1..].iter().rev(),
-            ) {
-                input_handle =
-                    Arc::clone(codec).partial_decoder(input_handle, bytes_representation, options)?;
+        let mut codec_index = 0;
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            if Some(codec_index) == self.cache_index {
+                input_handle = Arc::new(BytesPartialDecoderCache::new(&*input_handle, options)?);
             }
+            codec_index += 1;
+            input_handle =
+                Arc::clone(codec).partial_decoder(input_handle, bytes_representation, options)?;
+        }
 
-            // Insert bytes partial decoder cache
-            let cached: Arc<dyn BytesPartialDecoderTraits> =
-                Arc::new(BytesPartialDecoderCache::new(&*input_handle, options)?);
-            input_handle = cached;
+        if Some(codec_index) == self.cache_index {
+            input_handle = Arc::new(BytesPartialDecoderCache::new(&*input_handle, options)?);
+        }
 
-            // Post-cache bytes codecs (indices 0..cache_idx, processed in reverse)
-            for (i, codec) in self.bytes_to_bytes[..cache_idx].iter().rev().enumerate() {
-                let decoded_rep = cache_idx - i;
-                input_handle = Arc::clone(codec).partial_decoder(
-                    Arc::clone(&input_handle),
-                    &bytes_representations[decoded_rep],
-                    options,
-                )?;
-            }
-
-            let array_handle = self
-                .array_to_bytes
+        let mut input_handle = {
+            let (shape, _data_type, _fill_value) = array_representations.last().unwrap();
+            codec_index += 1;
+            self.array_to_bytes
                 .clone()
-                .partial_decoder(input_handle, encoded_shape, options)?;
+                .partial_decoder(input_handle, shape, options)?
+        };
 
-            let mut array_handle = array_handle;
-            for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
-                self.array_to_array.iter().rev(),
-                array_representations.iter().rev().skip(1),
-            ) {
-                array_handle = codec.clone().partial_decoder(array_handle, shape, options)?;
-            }
-
-            if !array_handle.supports_partial_decode()
-                || (array_handle.size_held() > 0
-                    && self.partial_decode_granularity(shape)?.as_slice() == shape)
-            {
-                let (shape, data_type, _fill_value) = array_representations.first().unwrap();
-                array_handle = Arc::new(ArrayPartialDecoderCache::new(
-                    &*array_handle,
+        for (codec, (shape, data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            if Some(codec_index) == self.cache_index {
+                input_handle = Arc::new(ArrayPartialDecoderCache::new(
+                    &*input_handle,
                     shape.clone(),
                     data_type.clone(),
                     options,
                 )?);
             }
-
-            return Ok(array_handle);
+            codec_index += 1;
+            input_handle = codec
+                .clone()
+                .partial_decoder(input_handle, shape, options)?;
         }
 
-        // No cache - original path for full bytes pipeline
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            input_handle =
-                Arc::clone(codec).partial_decoder(input_handle, bytes_representation, options)?;
-        }
-
-        let array_handle = self
-            .array_to_bytes
-            .clone()
-            .partial_decoder(input_handle, encoded_shape, options)?;
-
-        let mut array_handle = array_handle;
-        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            array_handle = codec.clone().partial_decoder(array_handle, shape, options)?;
-        }
-
-        if !array_handle.supports_partial_decode()
-            || (array_handle.size_held() > 0
-                && self.partial_decode_granularity(shape)?.as_slice() == shape)
-        {
+        if Some(codec_index) == self.cache_index {
             let (shape, data_type, _fill_value) = array_representations.first().unwrap();
-            array_handle = Arc::new(ArrayPartialDecoderCache::new(
-                &*array_handle,
+            input_handle = Arc::new(ArrayPartialDecoderCache::new(
+                &*input_handle,
                 shape.clone(),
                 data_type.clone(),
                 options,
             )?);
         }
 
-        Ok(array_handle)
+        Ok(input_handle)
     }
 
     fn partial_encoder(
@@ -650,68 +629,49 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
     #[cfg(feature = "async")]
     async fn async_partial_decoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
+        mut input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         let (array_representations, bytes_representations) = self.get_representations(shape)?;
-        let (encoded_shape, _encoded_data_type, _encoded_fill_value) =
-            array_representations.last().unwrap();
-
-        let mut input_handle = input_handle;
-
-        if let Some(cache_idx) = self.cache_index {
-            // Pre-cache bytes codecs (indices cache_idx..N, processed in reverse)
-            for (codec, bytes_representation) in std::iter::zip(
-                self.bytes_to_bytes[cache_idx..].iter().rev(),
-                bytes_representations[cache_idx + 1..].iter().rev(),
-            ) {
-                input_handle = codec
-                    .clone()
-                    .async_partial_decoder(input_handle, bytes_representation, options)
-                    .await?;
+        let mut codec_index = 0;
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            if Some(codec_index) == self.cache_index {
+                input_handle =
+                    Arc::new(BytesPartialDecoderCache::async_new(&*input_handle, options).await?);
             }
-
-            // Insert bytes partial decoder cache
-            let cached: Arc<dyn AsyncBytesPartialDecoderTraits> = Arc::new(
-                BytesPartialDecoderCache::async_new(&*input_handle, options).await?,
-            );
-            input_handle = cached;
-
-            // Post-cache bytes codecs (indices 0..cache_idx, processed in reverse)
-            for (i, codec) in self.bytes_to_bytes[..cache_idx].iter().rev().enumerate() {
-                let decoded_rep = cache_idx - i;
-                input_handle = codec
-                    .clone()
-                    .async_partial_decoder(Arc::clone(&input_handle), &bytes_representations[decoded_rep], options)
-                    .await?;
-            }
-
-            let array_handle = self
-                .array_to_bytes
+            codec_index += 1;
+            input_handle = codec
                 .clone()
-                .async_partial_decoder(input_handle, encoded_shape, options)
+                .async_partial_decoder(input_handle, bytes_representation, options)
                 .await?;
+        }
 
-            let mut array_handle = array_handle;
-            for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
-                self.array_to_array.iter().rev(),
-                array_representations.iter().rev().skip(1),
-            ) {
-                array_handle = codec
-                    .clone()
-                    .async_partial_decoder(array_handle, shape, options)
-                    .await?;
-            }
+        if Some(codec_index) == self.cache_index {
+            input_handle =
+                Arc::new(BytesPartialDecoderCache::async_new(&*input_handle, options).await?);
+        }
 
-            if !array_handle.supports_partial_decode()
-                || (array_handle.size_held() > 0
-                    && self.partial_decode_granularity(shape)?.as_slice() == shape)
-            {
-                let (shape, data_type, _fill_value) = array_representations.first().unwrap();
-                array_handle = Arc::new(
+        let mut input_handle = {
+            let (shape, _data_type, _fill_value) = array_representations.last().unwrap();
+            codec_index += 1;
+            self.array_to_bytes
+                .clone()
+                .async_partial_decoder(input_handle, shape, options)
+                .await?
+        };
+
+        for (codec, (shape, data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            if Some(codec_index) == self.cache_index {
+                input_handle = Arc::new(
                     ArrayPartialDecoderCache::async_new(
-                        &*array_handle,
+                        &*input_handle,
                         shape.clone(),
                         data_type.clone(),
                         options,
@@ -719,46 +679,18 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
                     .await?,
                 );
             }
-
-            return Ok(array_handle);
-        }
-
-        // No cache
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
+            codec_index += 1;
             input_handle = codec
                 .clone()
-                .async_partial_decoder(input_handle, bytes_representation, options)
+                .async_partial_decoder(input_handle, shape, options)
                 .await?;
         }
 
-        let array_handle = self
-            .array_to_bytes
-            .clone()
-            .async_partial_decoder(input_handle, encoded_shape, options)
-            .await?;
-
-        let mut array_handle = array_handle;
-        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            array_handle = codec
-                .clone()
-                .async_partial_decoder(array_handle, shape, options)
-                .await?;
-        }
-
-        if !array_handle.supports_partial_decode()
-            || (array_handle.size_held() > 0
-                && self.partial_decode_granularity(shape)?.as_slice() == shape)
-        {
+        if Some(codec_index) == self.cache_index {
             let (shape, data_type, _fill_value) = array_representations.first().unwrap();
-            array_handle = Arc::new(
+            input_handle = Arc::new(
                 ArrayPartialDecoderCache::async_new(
-                    &*array_handle,
+                    &*input_handle,
                     shape.clone(),
                     data_type.clone(),
                     options,
@@ -767,7 +699,7 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
             );
         }
 
-        Ok(array_handle)
+        Ok(input_handle)
     }
 
     #[cfg(feature = "async")]
@@ -966,9 +898,11 @@ impl CodecChainBound {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use std::num::NonZeroU64;
 
     use super::*;
+    use crate::array::codec::BytesCodec;
     use crate::array::{ArraySubset, ArraySubsetTraits, ChunkShapeTraits, data_type};
 
     #[cfg(feature = "transpose")]
@@ -1030,6 +964,109 @@ mod tests {
         "endian": "big"
     }
 }"#;
+
+    #[derive(Debug)]
+    struct RepresentationCheckingBytesCodec {
+        expected_decoded_representation: BytesRepresentation,
+    }
+
+    impl zarrs_plugin::ExtensionName for RepresentationCheckingBytesCodec {
+        fn name(
+            &self,
+            _version: zarrs_plugin::ZarrVersion,
+        ) -> Option<std::borrow::Cow<'static, str>> {
+            None
+        }
+    }
+
+    impl CodecTraits for RepresentationCheckingBytesCodec {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn configuration(
+            &self,
+            _version: zarrs_plugin::ZarrVersion,
+            _options: &CodecMetadataOptions,
+        ) -> Option<Configuration> {
+            None
+        }
+
+        fn partial_decoder_capability(&self) -> PartialDecoderCapability {
+            PartialDecoderCapability {
+                partial_read: false,
+                partial_decode: false,
+            }
+        }
+
+        fn partial_encoder_capability(&self) -> PartialEncoderCapability {
+            PartialEncoderCapability {
+                partial_encode: false,
+            }
+        }
+    }
+
+    impl BytesToBytesCodecTraits for RepresentationCheckingBytesCodec {
+        fn into_dyn(self: Arc<Self>) -> Arc<dyn BytesToBytesCodecTraits> {
+            self
+        }
+
+        fn recommended_concurrency(
+            &self,
+            _decoded_representation: &BytesRepresentation,
+        ) -> Result<RecommendedConcurrency, CodecError> {
+            Ok(RecommendedConcurrency::new_maximum(1))
+        }
+
+        fn encoded_representation(
+            &self,
+            decoded_representation: &BytesRepresentation,
+        ) -> BytesRepresentation {
+            match decoded_representation {
+                BytesRepresentation::FixedSize(size) => BytesRepresentation::FixedSize(size + 1),
+                BytesRepresentation::BoundedSize(size) => {
+                    BytesRepresentation::BoundedSize(size + 1)
+                }
+                BytesRepresentation::UnboundedSize => BytesRepresentation::UnboundedSize,
+            }
+        }
+
+        fn encode<'a>(
+            &self,
+            decoded_value: ArrayBytesRaw<'a>,
+            _options: &CodecOptions,
+        ) -> Result<ArrayBytesRaw<'a>, CodecError> {
+            let mut encoded = decoded_value.into_owned();
+            encoded.push(0);
+            Ok(Cow::Owned(encoded))
+        }
+
+        fn decode<'a>(
+            &self,
+            encoded_value: ArrayBytesRaw<'a>,
+            _decoded_representation: &BytesRepresentation,
+            _options: &CodecOptions,
+        ) -> Result<ArrayBytesRaw<'a>, CodecError> {
+            Ok(Cow::Owned(
+                encoded_value[..encoded_value.len() - 1].to_vec(),
+            ))
+        }
+
+        fn partial_decoder(
+            self: Arc<Self>,
+            input_handle: Arc<dyn BytesPartialDecoderTraits>,
+            decoded_representation: &BytesRepresentation,
+            _options: &CodecOptions,
+        ) -> Result<Arc<dyn BytesPartialDecoderTraits>, CodecError> {
+            if decoded_representation != &self.expected_decoded_representation {
+                return Err(CodecError::Other(format!(
+                    "wrong decoded representation: expected {:?}, got {:?}",
+                    self.expected_decoded_representation, decoded_representation
+                )));
+            }
+            Ok(input_handle)
+        }
+    }
 
     #[cfg(feature = "crc32c")]
     const JSON_CRC32C: &str = r#"{ 
@@ -1154,6 +1191,28 @@ mod tests {
             &decoded_region,
             decoded_partial_chunk_true,
         );
+    }
+
+    #[test]
+    fn codec_chain_partial_decoder_uses_decoded_byte_representation_at_cache_boundary() {
+        let shape = ChunkShape::from(vec![NonZeroU64::new(4).unwrap()]);
+        let data_type = data_type::uint16();
+        let fill_value = FillValue::from(0u16);
+        let expected_decoded_representation = BytesRepresentation::FixedSize(8);
+        let codec = CodecChain::new(
+            vec![],
+            Arc::new(BytesCodec::new(Some(crate::array::Endianness::native()))),
+            vec![Arc::new(RepresentationCheckingBytesCodec {
+                expected_decoded_representation,
+            })],
+        )
+        .with_context(data_type, fill_value)
+        .unwrap();
+
+        let encoded_input: Arc<dyn BytesPartialDecoderTraits> = Arc::new(Cow::Owned(vec![0; 9]));
+        codec
+            .partial_decoder(encoded_input, &shape, &CodecOptions::default())
+            .unwrap();
     }
 
     #[cfg(feature = "pcodec")]

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -11,7 +11,7 @@ use crate::array::{
 };
 use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits,
-    ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+    ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, ArrayToArrayCodecTraits, BytesPartialDecoderTraits,
     BytesPartialEncoderTraits, BytesToBytesCodecTraits, Codec, CodecError, CodecMetadataOptions,
     CodecOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
     RecommendedConcurrency, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
@@ -47,7 +47,9 @@ pub struct CodecChain {
 /// A codec chain bound to an array data type and fill value.
 #[derive(Debug)]
 pub struct CodecChainBound {
-    codec: Arc<dyn ArrayToBytesCodecTraits>,
+    codec: Arc<CodecChain>,
+    data_type: DataType,
+    fill_value: FillValue,
 }
 
 impl CodecChain {
@@ -137,8 +139,11 @@ impl CodecChain {
             .clone()
             .with_context(encoded_data_type, encoded_fill_value)?;
 
-        let codec = UnboundArrayToBytesCodecTraits::with_context(self, data_type, fill_value)?;
-        Ok(Arc::new(CodecChainBound { codec }))
+        Ok(Arc::new(CodecChainBound {
+            codec: self,
+            data_type,
+            fill_value,
+        }))
     }
 
     /// Create a new codec chain from a list of metadata.
@@ -276,7 +281,14 @@ impl CodecChain {
         array_representations.push((shape.to_vec(), data_type.clone(), fill_value.clone()));
         for codec in &self.array_to_array {
             let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            array_representations.push(codec.encoded_representation(shape, data_type, fill_value)?);
+            let bound = codec
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?;
+            array_representations.push((
+                bound.encoded_shape(shape)?,
+                bound.encoded_data_type().clone(),
+                bound.encoded_fill_value().clone(),
+            ));
         }
         Ok(array_representations)
     }
@@ -288,10 +300,11 @@ impl CodecChain {
         fill_value: &FillValue,
     ) -> Result<BytesRepresentations, CodecError> {
         let mut bytes_representations = Vec::with_capacity(self.bytes_to_bytes.len() + 1);
-        bytes_representations.push(
-            self.array_to_bytes
-                .encoded_representation(shape, data_type, fill_value)?,
-        );
+        let array_to_bytes = self
+            .array_to_bytes
+            .clone()
+            .with_context(data_type.clone(), fill_value.clone())?;
+        bytes_representations.push(array_to_bytes.encoded_representation(shape)?);
         for codec in &self.bytes_to_bytes {
             bytes_representations
                 .push(codec.encoded_representation(bytes_representations.last().unwrap()));
@@ -316,18 +329,71 @@ impl CodecChain {
 
 impl ArrayCodecTraits for CodecChainBound {
     fn data_type(&self) -> &DataType {
-        self.codec.data_type()
+        &self.data_type
     }
 
     fn fill_value(&self) -> &FillValue {
-        self.codec.fill_value()
+        &self.fill_value
     }
 
     fn recommended_concurrency(
         &self,
         shape: &[NonZeroU64],
     ) -> Result<RecommendedConcurrency, CodecError> {
-        self.codec.recommended_concurrency(shape)
+        let mut concurrency_min = usize::MAX;
+        let mut concurrency_max = 0;
+
+        // Create a dummy fill value for computing array representations.
+        // The fill value doesn't affect concurrency computation.
+        let fill_value: FillValue = vec![0u8; self.data_type.fixed_size().unwrap_or(0)].into();
+        let array_representations =
+            self.codec.get_array_representations(shape, &self.data_type, &fill_value)?;
+        let bytes_representations = {
+            let (shape, data_type, fill_value) = array_representations.last().unwrap();
+            self.codec.get_bytes_representations(shape, data_type, fill_value)?
+        };
+
+        // bytes->bytes
+        for (codec, bytes_representation) in std::iter::zip(
+            self.codec.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            let recommended_concurrency = &codec.recommended_concurrency(bytes_representation)?;
+            concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
+            concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
+        }
+
+        let recommended_concurrency = {
+            let (shape, data_type, _fill_value) = array_representations.last().unwrap();
+            let fill_value = &array_representations.last().unwrap().2;
+            &self
+                .codec.array_to_bytes
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .recommended_concurrency(shape)?
+        };
+        concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
+        concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
+
+        // array->array
+        for (codec, (shape, data_type, _fill_value)) in std::iter::zip(
+            self.codec.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            let recommended_concurrency = codec
+                .clone()
+                .with_context(data_type.clone(), _fill_value.clone())?
+                .recommended_concurrency(shape)?;
+            concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
+            concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
+        }
+
+        let recommended_concurrency = RecommendedConcurrency::new(
+            std::cmp::min(concurrency_min, concurrency_max)
+                ..std::cmp::max(concurrency_max, concurrency_max),
+        );
+
+        Ok(recommended_concurrency)
     }
 }
 
@@ -345,14 +411,16 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         &self,
         shape: &[NonZeroU64],
     ) -> Result<BytesRepresentation, CodecError> {
-        self.codec.encoded_representation(shape)
+        self.codec
+            .encoded_representation(shape, &self.data_type, &self.fill_value)
     }
 
     fn partial_decode_granularity(
         &self,
         decoded_shape: &[NonZeroU64],
     ) -> Result<ChunkShape, CodecError> {
-        self.codec.partial_decode_granularity(decoded_shape)
+        self.codec
+            .partial_decode_granularity(decoded_shape, &self.data_type, &self.fill_value)
     }
 
     fn encode<'a>(
@@ -361,7 +429,8 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-        self.codec.encode(bytes, shape, options)
+        self.codec
+            .encode(bytes, shape, &self.data_type, &self.fill_value, options)
     }
 
     fn decode<'a>(
@@ -370,7 +439,8 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        self.codec.decode(bytes, shape, options)
+        self.codec
+            .decode(bytes, shape, &self.data_type, &self.fill_value, options)
     }
 
     fn compact<'a>(
@@ -379,7 +449,8 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
-        self.codec.compact(bytes, shape, options)
+        self.codec
+            .compact(bytes, shape, &self.data_type, &self.fill_value, options)
     }
 
     fn decode_into(
@@ -389,7 +460,14 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         output_target: ArrayBytesDecodeIntoTarget<'_>,
         options: &CodecOptions,
     ) -> Result<(), CodecError> {
-        self.codec.decode_into(bytes, shape, output_target, options)
+        self.codec.decode_into(
+            bytes,
+            shape,
+            &self.data_type,
+            &self.fill_value,
+            output_target,
+            options,
+        )
     }
 
     fn partial_decoder(
@@ -398,9 +476,13 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-        self.codec
-            .clone()
-            .partial_decoder(input_handle, shape, options)
+        self.codec.clone().partial_decoder(
+            input_handle,
+            shape,
+            &self.data_type,
+            &self.fill_value,
+            options,
+        )
     }
 
     fn partial_encoder(
@@ -409,9 +491,13 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
-        self.codec
-            .clone()
-            .partial_encoder(input_output_handle, shape, options)
+        self.codec.clone().partial_encoder(
+            input_output_handle,
+            shape,
+            &self.data_type,
+            &self.fill_value,
+            options,
+        )
     }
 
     #[cfg(feature = "async")]
@@ -423,7 +509,13 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         self.codec
             .clone()
-            .async_partial_decoder(input_handle, shape, options)
+            .async_partial_decoder(
+                input_handle,
+                shape,
+                &self.data_type,
+                &self.fill_value,
+                options,
+            )
             .await
     }
 
@@ -436,7 +528,13 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
         self.codec
             .clone()
-            .async_partial_encoder(input_output_handle, shape, options)
+            .async_partial_encoder(
+                input_output_handle,
+                shape,
+                &self.data_type,
+                &self.fill_value,
+                options,
+            )
             .await
     }
 }
@@ -519,33 +617,50 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
-    fn partial_decode_granularity(&self, shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError> {
-        let mut array_shapes = Vec::with_capacity(self.array_to_array.len() + 1);
-        array_shapes.push(shape.to_vec());
-        for codec in &self.array_to_array {
-            let decoded_shape = array_shapes.last().expect("array_shapes is non-empty");
-            let encoded_shape = codec.encoded_shape(decoded_shape)?;
-            array_shapes.push(encoded_shape);
-        }
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        CodecChain::with_context(self, data_type, fill_value)
+            .map(|codec| codec as Arc<dyn ArrayToBytesCodecTraits>)
+    }
+}
 
-        let encoded_shape = array_shapes.last().expect("array_shapes is non-empty");
+impl CodecChain {
+    pub(crate) fn partial_decode_granularity(
+        &self,
+        shape: &[NonZeroU64],
+        data_type: &DataType,
+        fill_value: &FillValue,
+    ) -> Result<ChunkShape, CodecError> {
+        let array_representations = self.get_array_representations(shape, data_type, fill_value)?;
+
+        let (encoded_shape, encoded_data_type, encoded_fill_value) = array_representations
+            .last()
+            .expect("array_shapes is non-empty");
         let mut granularity = self
             .array_to_bytes
+            .clone()
+            .with_context(encoded_data_type.clone(), encoded_fill_value.clone())?
             .partial_decode_granularity(encoded_shape)?;
 
-        for (codec, decoded_shape) in self
+        for (codec, (decoded_shape, decoded_data_type, decoded_fill_value)) in self
             .array_to_array
             .iter()
             .rev()
-            .zip(array_shapes.iter().rev().skip(1))
+            .zip(array_representations.iter().rev().skip(1))
         {
-            granularity = codec.partial_decode_granularity(decoded_shape, &granularity)?;
+            granularity = codec
+                .clone()
+                .with_context(decoded_data_type.clone(), decoded_fill_value.clone())?
+                .partial_decode_granularity(decoded_shape, &granularity)?;
         }
 
         Ok(granularity)
     }
 
-    fn encode<'a>(
+    pub(crate) fn encode<'a>(
         &self,
         mut bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
@@ -561,19 +676,22 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
 
         // array->array
         for codec in &self.array_to_array {
-            bytes = codec.encode(bytes, &shape, &data_type, &fill_value, options)?;
-            shape = codec.encoded_shape(&shape)?;
-            fill_value = codec.encoded_fill_value(&data_type, &fill_value)?;
-            data_type = codec.encoded_data_type(&data_type)?;
+            let bound = codec
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?;
+            bytes = bound.encode(bytes, &shape, options)?;
+            shape = bound.encoded_shape(&shape)?;
+            fill_value = bound.encoded_fill_value().clone();
+            data_type = bound.encoded_data_type().clone();
         }
 
         // array->bytes
-        let mut bytes =
-            self.array_to_bytes
-                .encode(bytes, &shape, &data_type, &fill_value, options)?;
-        let mut decoded_representation =
-            self.array_to_bytes
-                .encoded_representation(&shape, &data_type, &fill_value)?;
+        let array_to_bytes = self
+            .array_to_bytes
+            .clone()
+            .with_context(data_type, fill_value)?;
+        let mut bytes = array_to_bytes.encode(bytes, &shape, options)?;
+        let mut decoded_representation = array_to_bytes.encoded_representation(&shape)?;
 
         // bytes->bytes
         for codec in &self.bytes_to_bytes {
@@ -584,7 +702,7 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         Ok(bytes)
     }
 
-    fn decode<'a>(
+    pub(crate) fn decode<'a>(
         &self,
         mut bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
@@ -607,7 +725,9 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         let mut bytes = {
             let (shape, data_type, fill_value) = array_representations.last().unwrap();
             self.array_to_bytes
-                .decode(bytes, shape, data_type, fill_value, options)?
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .decode(bytes, shape, options)?
         };
 
         // array->array
@@ -615,7 +735,10 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
             self.array_to_array.iter().rev(),
             array_representations.iter().rev().skip(1),
         ) {
-            bytes = codec.decode(bytes, shape, data_type, fill_value, options)?;
+            bytes = codec
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .decode(bytes, shape, options)?;
         }
 
         let (shape, data_type, _) = array_representations.first().unwrap();
@@ -624,7 +747,7 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         Ok(bytes)
     }
 
-    fn decode_into(
+    pub(crate) fn decode_into(
         &self,
         mut bytes: ArrayBytesRaw<'_>,
         shape: &[NonZeroU64],
@@ -639,14 +762,11 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         if self.bytes_to_bytes.is_empty() && self.array_to_array.is_empty() {
             // Fast path if no bytes to bytes or array to array codecs
             let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            return self.array_to_bytes.decode_into(
-                bytes,
-                shape,
-                data_type,
-                fill_value,
-                output_target,
-                options,
-            );
+            return self
+                .array_to_bytes
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .decode_into(bytes, shape, output_target, options);
         }
 
         // bytes->bytes
@@ -660,21 +780,20 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         if self.array_to_array.is_empty() {
             // Fast path if no array to array codecs
             let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            return self.array_to_bytes.decode_into(
-                bytes,
-                shape,
-                data_type,
-                fill_value,
-                output_target,
-                options,
-            );
+            return self
+                .array_to_bytes
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .decode_into(bytes, shape, output_target, options);
         }
 
         // bytes->array
         let mut bytes = {
             let (shape, data_type, fill_value) = array_representations.last().unwrap();
             self.array_to_bytes
-                .decode(bytes, shape, data_type, fill_value, options)?
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .decode(bytes, shape, options)?
         };
 
         // array->array
@@ -682,7 +801,10 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
             self.array_to_array.iter().rev(),
             array_representations.iter().rev().skip(1),
         ) {
-            bytes = codec.decode(bytes, shape, data_type, fill_value, options)?;
+            bytes = codec
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .decode(bytes, shape, options)?;
         }
 
         let (shape, data_type, _) = array_representations.first().unwrap();
@@ -691,7 +813,7 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         decode_into_array_bytes_target(&bytes, output_target)
     }
 
-    fn compact<'a>(
+    pub(crate) fn compact<'a>(
         &self,
         mut bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
@@ -714,7 +836,9 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         let compacted = {
             let (shape, data_type, fill_value) = array_representations.last().unwrap();
             self.array_to_bytes
-                .compact(bytes, shape, data_type, fill_value, options)?
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .compact(bytes, shape, options)?
         };
 
         // If compaction occurred, re-encode through bytes_to_bytes codecs
@@ -730,7 +854,7 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         }
     }
 
-    fn partial_decoder(
+    pub(crate) fn partial_decoder(
         self: Arc<Self>,
         mut input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
@@ -763,7 +887,8 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
             codec_index += 1;
             codec
                 .clone()
-                .partial_decoder(input_handle, shape, data_type, fill_value, options)?
+                .with_context(data_type.clone(), fill_value.clone())?
+                .partial_decoder(input_handle, shape, options)?
         };
 
         for (codec, (shape, data_type, fill_value)) in std::iter::zip(
@@ -779,13 +904,10 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
                 )?);
             }
             codec_index += 1;
-            input_handle = codec.clone().partial_decoder(
-                input_handle,
-                shape,
-                data_type,
-                fill_value,
-                options,
-            )?;
+            input_handle = codec
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .partial_decoder(input_handle, shape, options)?;
         }
 
         if Some(codec_index) == self.cache_index {
@@ -801,7 +923,7 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         Ok(input_handle)
     }
 
-    fn partial_encoder(
+    pub(crate) fn partial_encoder(
         self: Arc<Self>,
         mut input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
@@ -825,13 +947,10 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
 
         let mut input_output_handle = {
             let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            self.array_to_bytes.clone().partial_encoder(
-                input_output_handle,
-                shape,
-                data_type,
-                fill_value,
-                options,
-            )?
+            self.array_to_bytes
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?
+                .partial_encoder(input_output_handle, shape, options)?
         };
 
         if self.array_to_array.is_empty() {
@@ -842,20 +961,16 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
             self.array_to_array.iter().rev(),
             array_representations.iter().rev().skip(1),
         ) {
-            input_output_handle = Arc::clone(codec).partial_encoder(
-                input_output_handle,
-                shape,
-                data_type,
-                fill_value,
-                options,
-            )?;
+            input_output_handle = Arc::clone(codec)
+                .with_context(data_type.clone(), fill_value.clone())?
+                .partial_encoder(input_output_handle, shape, options)?;
         }
 
         Ok(input_output_handle)
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_decoder(
+    pub(crate) async fn async_partial_decoder(
         self: Arc<Self>,
         mut input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
@@ -893,7 +1008,8 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
             codec_index += 1;
             codec
                 .clone()
-                .async_partial_decoder(input_handle, shape, data_type, fill_value, options)
+                .with_context(data_type.clone(), fill_value.clone())?
+                .async_partial_decoder(input_handle, shape, options)
                 .await?
         };
 
@@ -915,7 +1031,8 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
             codec_index += 1;
             input_handle = codec
                 .clone()
-                .async_partial_decoder(input_handle, shape, data_type, fill_value, options)
+                .with_context(data_type.clone(), fill_value.clone())?
+                .async_partial_decoder(input_handle, shape, options)
                 .await?;
         }
 
@@ -936,7 +1053,7 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
     }
 
     #[cfg(feature = "async")]
-    async fn async_partial_encoder(
+    pub(crate) async fn async_partial_encoder(
         self: Arc<Self>,
         mut input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
@@ -960,7 +1077,8 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
             let (shape, data_type, fill_value) = array_representations.last().unwrap();
             self.array_to_bytes
                 .clone()
-                .async_partial_encoder(input_output_handle, shape, data_type, fill_value, options)
+                .with_context(data_type.clone(), fill_value.clone())?
+                .async_partial_encoder(input_output_handle, shape, options)
                 .await?
         };
 
@@ -973,14 +1091,15 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
             array_representations.iter().rev().skip(1),
         ) {
             input_output_handle = Arc::clone(codec)
-                .async_partial_encoder(input_output_handle, shape, data_type, fill_value, options)
+                .with_context(data_type.clone(), fill_value.clone())?
+                .async_partial_encoder(input_output_handle, shape, options)
                 .await?;
         }
 
         Ok(input_output_handle)
     }
 
-    fn encoded_representation(
+    pub(crate) fn encoded_representation(
         &self,
         shape: &[NonZeroU64],
         data_type: &DataType,
@@ -990,14 +1109,19 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         let mut data_type = data_type.clone();
         let mut fill_value = fill_value.clone();
         for codec in &self.array_to_array {
-            shape = codec.encoded_shape(&shape)?;
-            fill_value = codec.encoded_fill_value(&data_type, &fill_value)?;
-            data_type = codec.encoded_data_type(&data_type)?;
+            let bound = codec
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?;
+            shape = bound.encoded_shape(&shape)?;
+            fill_value = bound.encoded_fill_value().clone();
+            data_type = bound.encoded_data_type().clone();
         }
 
-        let mut bytes_representation =
-            self.array_to_bytes
-                .encoded_representation(&shape, &data_type, &fill_value)?;
+        let mut bytes_representation = self
+            .array_to_bytes
+            .clone()
+            .with_context(data_type, fill_value)?
+            .encoded_representation(&shape)?;
 
         for codec in &self.bytes_to_bytes {
             bytes_representation = codec.encoded_representation(&bytes_representation);
@@ -1007,60 +1131,23 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
     }
 }
 
-impl ArrayCodecTraits for CodecChain {
-    fn recommended_concurrency(
-        &self,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        let mut concurrency_min = usize::MAX;
-        let mut concurrency_max = 0;
+impl CodecChainBound {
+    /// Get the array to array codecs
+    #[must_use]
+    pub fn array_to_array_codecs(&self) -> &[Arc<dyn ArrayToArrayCodecTraits>] {
+        &self.array_to_array
+    }
 
-        // Create a dummy fill value for computing array representations.
-        // The fill value doesn't affect concurrency computation.
-        let fill_value: FillValue = vec![0u8; data_type.fixed_size().unwrap_or(0)].into();
-        let array_representations =
-            self.get_array_representations(shape, data_type, &fill_value)?;
-        let bytes_representations = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            self.get_bytes_representations(shape, data_type, fill_value)?
-        };
+    /// Get the array to bytes codec
+    #[must_use]
+    pub fn array_to_bytes_codec(&self) -> &Arc<dyn ArrayToBytesCodecTraits> {
+        &self.array_to_bytes
+    }
 
-        // bytes->bytes
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            let recommended_concurrency = &codec.recommended_concurrency(bytes_representation)?;
-            concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
-            concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
-        }
-
-        let recommended_concurrency = {
-            let (shape, data_type, _fill_value) = array_representations.last().unwrap();
-            &self
-                .array_to_bytes
-                .recommended_concurrency(shape, data_type)?
-        };
-        concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
-        concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
-
-        // array->array
-        for (codec, (shape, data_type, _fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            let recommended_concurrency = codec.recommended_concurrency(shape, data_type)?;
-            concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
-            concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
-        }
-
-        let recommended_concurrency = RecommendedConcurrency::new(
-            std::cmp::min(concurrency_min, concurrency_max)
-                ..std::cmp::max(concurrency_max, concurrency_max),
-        );
-
-        Ok(recommended_concurrency)
+    /// Get the bytes to bytes codecs
+    #[must_use]
+    pub fn bytes_to_bytes_codecs(&self) -> &[Arc<dyn BytesToBytesCodecTraits>] {
+        &self.bytes_to_bytes
     }
 }
 

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -329,11 +329,17 @@ impl CodecChain {
 
 impl ArrayCodecTraits for CodecChainBound {
     fn data_type(&self) -> &DataType {
-        &self.data_type
+        self.array_to_array.first().map_or_else(
+            || self.array_to_bytes.data_type(),
+            |codec| codec.data_type(),
+        )
     }
 
     fn fill_value(&self) -> &FillValue {
-        &self.fill_value
+        self.array_to_array.first().map_or_else(
+            || self.array_to_bytes.fill_value(),
+            |codec| codec.fill_value(),
+        )
     }
 
     fn recommended_concurrency(
@@ -343,21 +349,17 @@ impl ArrayCodecTraits for CodecChainBound {
         let mut concurrency_min = usize::MAX;
         let mut concurrency_max = 0;
 
-        // Create a dummy fill value for computing array representations.
-        // The fill value doesn't affect concurrency computation.
-        let fill_value: FillValue = vec![0u8; self.data_type.fixed_size().unwrap_or(0)].into();
-        let array_representations =
-            self.codec
-                .get_array_representations(shape, &self.data_type, &fill_value)?;
-        let bytes_representations = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            self.codec
-                .get_bytes_representations(shape, data_type, fill_value)?
-        };
+        let array_representations = self.get_array_representations(shape)?;
+        let bytes_representations = self.get_bytes_representations(
+            &array_representations
+                .last()
+                .expect("array representations is non-empty")
+                .0,
+        )?;
 
         // bytes->bytes
         for (codec, bytes_representation) in std::iter::zip(
-            self.codec.bytes_to_bytes.iter().rev(),
+            self.bytes_to_bytes.iter().rev(),
             bytes_representations.iter().rev().skip(1),
         ) {
             let recommended_concurrency = &codec.recommended_concurrency(bytes_representation)?;
@@ -365,35 +367,24 @@ impl ArrayCodecTraits for CodecChainBound {
             concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
         }
 
-        let recommended_concurrency = {
-            let (shape, data_type, _fill_value) = array_representations.last().unwrap();
-            let fill_value = &array_representations.last().unwrap().2;
-            &self
-                .codec
-                .array_to_bytes
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .recommended_concurrency(shape)?
-        };
+        let recommended_concurrency = self
+            .array_to_bytes
+            .recommended_concurrency(&array_representations.last().unwrap().0)?;
         concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
         concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
 
         // array->array
-        for (codec, (shape, data_type, _fill_value)) in std::iter::zip(
-            self.codec.array_to_array.iter().rev(),
+        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
             array_representations.iter().rev().skip(1),
         ) {
-            let recommended_concurrency = codec
-                .clone()
-                .with_context(data_type.clone(), _fill_value.clone())?
-                .recommended_concurrency(shape)?;
+            let recommended_concurrency = codec.recommended_concurrency(shape)?;
             concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
             concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
         }
 
         let recommended_concurrency = RecommendedConcurrency::new(
-            std::cmp::min(concurrency_min, concurrency_max)
-                ..std::cmp::max(concurrency_max, concurrency_max),
+            std::cmp::min(concurrency_min, concurrency_max)..concurrency_max,
         );
 
         Ok(recommended_concurrency)
@@ -414,8 +405,14 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         &self,
         shape: &[NonZeroU64],
     ) -> Result<BytesRepresentation, CodecError> {
-        self.codec
-            .encoded_representation(shape, &self.data_type, &self.fill_value)
+        let array_representations = self.get_array_representations(shape)?;
+        let mut bytes_representation = self
+            .array_to_bytes
+            .encoded_representation(&array_representations.last().unwrap().0)?;
+        for codec in &self.bytes_to_bytes {
+            bytes_representation = codec.encoded_representation(&bytes_representation);
+        }
+        Ok(bytes_representation)
     }
 
     fn partial_decode_granularity(
@@ -663,38 +660,25 @@ impl CodecChain {
         Ok(granularity)
     }
 
-    pub(crate) fn encode<'a>(
+    fn encode<'a>(
         &self,
         mut bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-        bytes.validate(shape.iter().map(|v| v.get()).product(), data_type)?;
+        bytes.validate(shape.iter().map(|v| v.get()).product(), self.data_type())?;
 
         let mut shape = ChunkShape::from(shape.to_vec());
-        let mut data_type = data_type.clone();
-        let mut fill_value = fill_value.clone();
 
         // array->array
         for codec in &self.array_to_array {
-            let bound = codec
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?;
-            bytes = bound.encode(bytes, &shape, options)?;
-            shape = bound.encoded_shape(&shape)?;
-            fill_value = bound.encoded_fill_value().clone();
-            data_type = bound.encoded_data_type().clone();
+            bytes = codec.encode(bytes, &shape, options)?;
+            shape = codec.encoded_shape(&shape)?;
         }
 
         // array->bytes
-        let array_to_bytes = self
-            .array_to_bytes
-            .clone()
-            .with_context(data_type, fill_value)?;
-        let mut bytes = array_to_bytes.encode(bytes, &shape, options)?;
-        let mut decoded_representation = array_to_bytes.encoded_representation(&shape)?;
+        let mut bytes = self.array_to_bytes.encode(bytes, &shape, options)?;
+        let mut decoded_representation = self.array_to_bytes.encoded_representation(&shape)?;
 
         // bytes->bytes
         for codec in &self.bytes_to_bytes {
@@ -705,16 +689,13 @@ impl CodecChain {
         Ok(bytes)
     }
 
-    pub(crate) fn decode<'a>(
+    fn decode<'a>(
         &self,
         mut bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        let (array_representations, bytes_representations) =
-            self.get_representations(shape, data_type, fill_value)?;
+        let (array_representations, bytes_representations) = self.get_representations(shape)?;
 
         // bytes->bytes
         for (codec, bytes_representation) in std::iter::zip(
@@ -725,23 +706,16 @@ impl CodecChain {
         }
 
         // bytes->array
-        let mut bytes = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
+        let mut bytes =
             self.array_to_bytes
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .decode(bytes, shape, options)?
-        };
+                .decode(bytes, &array_representations.last().unwrap().0, options)?;
 
         // array->array
-        for (codec, (shape, data_type, fill_value)) in std::iter::zip(
+        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
             self.array_to_array.iter().rev(),
             array_representations.iter().rev().skip(1),
         ) {
-            bytes = codec
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .decode(bytes, shape, options)?;
+            bytes = codec.decode(bytes, shape, options)?;
         }
 
         let (shape, data_type, _) = array_representations.first().unwrap();

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -753,10 +753,6 @@ impl zarrs_plugin::ExtensionName for CodecChain {
 }
 
 impl CodecTraits for CodecChain {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     /// Returns [`None`] since a codec chain does not have standard codec metadata.
     ///
     /// Note that usage of the codec chain is explicit in [`Array`](crate::array::Array) and [`CodecChain::create_metadatas()`] will call [`CodecTraits::configuration()`] from for each codec.
@@ -980,10 +976,6 @@ mod tests {
     }
 
     impl CodecTraits for RepresentationCheckingBytesCodec {
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
-
         fn configuration(
             &self,
             _version: zarrs_plugin::ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -48,7 +48,7 @@ pub struct CodecChainBound {
     array_to_array: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
     array_to_bytes: Arc<dyn ArrayToBytesCodecTraits>,
     bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>>,
-    cache_index: Option<usize>,
+    cache_index: Option<usize>, // for partial decoders
 }
 
 impl CodecChain {
@@ -79,31 +79,31 @@ impl CodecChain {
         let mut cache_index_should = None;
         let mut codec_index = 0;
         for codec in self.bytes_to_bytes.iter().rev() {
-            let cap = codec.partial_decoder_capability();
-            if !cap.partial_decode {
+            let capability = codec.partial_decoder_capability();
+            if !capability.partial_decode {
                 cache_index_must = Some(codec_index + 1);
             }
-            if !cap.partial_read {
+            if !capability.partial_read {
                 cache_index_should = Some(codec_index);
             }
             codec_index += 1;
         }
         {
-            let cap = self.array_to_bytes.partial_decoder_capability();
-            if !cap.partial_decode {
+            let capability = self.array_to_bytes.partial_decoder_capability();
+            if !capability.partial_decode {
                 cache_index_must = Some(codec_index + 1);
             }
-            if !cap.partial_read {
+            if !capability.partial_read {
                 cache_index_should = Some(codec_index);
             }
             codec_index += 1;
         }
         for codec in self.array_to_array.iter().rev() {
-            let cap = codec.partial_decoder_capability();
-            if !cap.partial_decode {
+            let capability = codec.partial_decoder_capability();
+            if !capability.partial_decode {
                 cache_index_must = Some(codec_index + 1);
             }
-            if !cap.partial_read {
+            if !capability.partial_read {
                 cache_index_should = Some(codec_index);
             }
             codec_index += 1;

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -463,7 +463,7 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         )?;
 
         if let Some(mut compacted_bytes) = compacted {
-            let mut bytes_representation = bytes_representations.first().unwrap().clone();
+            let mut bytes_representation = *bytes_representations.first().unwrap();
             for codec in &self.bytes_to_bytes {
                 compacted_bytes = codec.encode(compacted_bytes, options)?;
                 bytes_representation = codec.encoded_representation(&bytes_representation);

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -13,9 +13,9 @@ use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits,
     ArrayPartialEncoderTraits, ArrayToArrayCodecTraits, ArrayToBytesCodecTraits,
     BytesPartialDecoderTraits, BytesPartialEncoderTraits, BytesToBytesCodecTraits, Codec,
-    CodecError, CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
-    UnboundArrayToBytesCodecTraits, decode_into_array_bytes_target,
+    CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits, decode_into_array_bytes_target,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{
@@ -24,7 +24,6 @@ use zarrs_codec::{
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata::v3::MetadataV3;
-use zarrs_plugin::PluginCreateError;
 
 type ArrayRepresentations = Vec<(ChunkShape, DataType, FillValue)>;
 type BytesRepresentations = Vec<BytesRepresentation>;
@@ -56,12 +55,12 @@ impl CodecChain {
     /// Bind this codec chain to a decoded data type and fill value.
     ///
     /// # Errors
-    /// Returns a [`CodecError`] if any codec cannot be bound to the derived context.
+    /// Returns a [`CodecCreateError`] if any codec cannot be bound to the derived context.
     pub fn with_context(
         &self,
         mut data_type: DataType,
         mut fill_value: FillValue,
-    ) -> Result<Arc<CodecChainBound>, CodecError> {
+    ) -> Result<Arc<CodecChainBound>, CodecCreateError> {
         let mut array_to_array = Vec::with_capacity(self.array_to_array.len());
         for codec in &self.array_to_array {
             let bound = codec
@@ -141,11 +140,11 @@ impl CodecChain {
     /// Create a new codec chain from a list of metadata.
     ///
     /// # Errors
-    /// Returns a [`PluginCreateError`] if:
+    /// Returns a [`CodecCreateError`] if:
     ///  - a codec could not be created,
     ///  - no array to bytes codec is supplied, or
     ///  - more than one array to bytes codec is supplied.
-    pub fn from_metadata(metadatas: &[MetadataV3]) -> Result<Self, PluginCreateError> {
+    pub fn from_metadata(metadatas: &[MetadataV3]) -> Result<Self, CodecCreateError> {
         let mut array_to_array: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>> = vec![];
         let mut array_to_bytes: Option<Arc<dyn UnboundArrayToBytesCodecTraits>> = None;
         let mut bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>> = vec![];
@@ -169,7 +168,7 @@ impl CodecChain {
                     if array_to_bytes.is_none() {
                         array_to_bytes = Some(codec);
                     } else {
-                        return Err(PluginCreateError::from("multiple array to bytes codecs"));
+                        return Err(CodecCreateError::from("multiple array to bytes codecs"));
                     }
                 }
                 Codec::BytesToBytes(codec) => {
@@ -179,7 +178,7 @@ impl CodecChain {
         }
 
         array_to_bytes.map_or_else(
-            || Err(PluginCreateError::from("missing array to bytes codec")),
+            || Err(CodecCreateError::from("missing array to bytes codec")),
             |array_to_bytes| Ok(Self::new(array_to_array, array_to_bytes, bytes_to_bytes)),
         )
     }
@@ -192,7 +191,7 @@ impl CodecChain {
     pub fn with_codec_specific_options(
         self,
         opts: &zarrs_codec::CodecSpecificOptions,
-    ) -> Result<Self, CodecError> {
+    ) -> Result<Self, CodecCreateError> {
         Ok(Self::new(
             self.array_to_array
                 .into_iter()
@@ -202,7 +201,7 @@ impl CodecChain {
             self.bytes_to_bytes
                 .into_iter()
                 .map(|c| c.with_codec_specific_options(opts))
-                .collect(),
+                .collect::<Result<_, _>>()?,
         ))
     }
 
@@ -823,7 +822,7 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         Ok(CodecChain::with_context(self, data_type, fill_value)?)
     }
 }

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -263,71 +263,150 @@ impl CodecChain {
     }
 }
 
-impl ArrayCodecTraits for CodecChainBound {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn data_type(&self) -> &DataType {
-        self.array_to_array.first().map_or_else(
-            || self.array_to_bytes.data_type(),
-            |codec| codec.data_type(),
-        )
-    }
-
-    fn fill_value(&self) -> &FillValue {
-        self.array_to_array.first().map_or_else(
-            || self.array_to_bytes.fill_value(),
-            |codec| codec.fill_value(),
-        )
-    }
-
-    fn recommended_concurrency(
+impl CodecChainBound {
+    fn get_array_representations(
         &self,
         shape: &[NonZeroU64],
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        let mut concurrency_min = usize::MAX;
-        let mut concurrency_max = 0;
+    ) -> Result<ArrayRepresentations, CodecError> {
+        let mut array_representations = Vec::with_capacity(self.array_to_array.len() + 1);
+        array_representations.push((
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+        ));
+        for codec in &self.array_to_array {
+            let (shape, _data_type, _fill_value) = array_representations.last().unwrap();
+            array_representations.push((
+                codec.encoded_shape(shape)?,
+                codec.encoded_data_type().clone(),
+                codec.encoded_fill_value().clone(),
+            ));
+        }
+        Ok(array_representations)
+    }
 
+    fn get_bytes_representations(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<BytesRepresentations, CodecError> {
+        let mut bytes_representations = Vec::with_capacity(self.bytes_to_bytes.len() + 1);
+        bytes_representations.push(self.array_to_bytes.encoded_representation(shape)?);
+        for codec in &self.bytes_to_bytes {
+            bytes_representations
+                .push(codec.encoded_representation(bytes_representations.last().unwrap()));
+        }
+        Ok(bytes_representations)
+    }
+
+    fn get_representations(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<(ArrayRepresentations, BytesRepresentations), CodecError> {
         let array_representations = self.get_array_representations(shape)?;
-        let bytes_representations = self.get_bytes_representations(
-            &array_representations
-                .last()
-                .expect("array representations is non-empty")
-                .0,
-        )?;
+        let bytes_representations =
+            self.get_bytes_representations(&array_representations.last().unwrap().0)?;
+        Ok((array_representations, bytes_representations))
+    }
 
-        // bytes->bytes
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            let recommended_concurrency = &codec.recommended_concurrency(bytes_representation)?;
-            concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
-            concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
-        }
+    /// Get the array to array codecs
+    #[must_use]
+    pub fn array_to_array_codecs(&self) -> &[Arc<dyn ArrayToArrayCodecTraits>] {
+        &self.array_to_array
+    }
 
-        let recommended_concurrency = self
-            .array_to_bytes
-            .recommended_concurrency(&array_representations.last().unwrap().0)?;
-        concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
-        concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
+    /// Get the array to bytes codec
+    #[must_use]
+    pub fn array_to_bytes_codec(&self) -> &Arc<dyn ArrayToBytesCodecTraits> {
+        &self.array_to_bytes
+    }
 
-        // array->array
-        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            let recommended_concurrency = codec.recommended_concurrency(shape)?;
-            concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
-            concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
-        }
+    /// Get the bytes to bytes codecs
+    #[must_use]
+    pub fn bytes_to_bytes_codecs(&self) -> &[Arc<dyn BytesToBytesCodecTraits>] {
+        &self.bytes_to_bytes
+    }
+}
 
-        let recommended_concurrency = RecommendedConcurrency::new(
-            std::cmp::min(concurrency_min, concurrency_max)..concurrency_max,
-        );
+impl zarrs_plugin::ExtensionName for CodecChain {
+    fn name(&self, _version: zarrs_plugin::ZarrVersion) -> Option<std::borrow::Cow<'static, str>> {
+        // CodecChain is an internal type and does not have a serialization name
+        None
+    }
+}
 
-        Ok(recommended_concurrency)
+impl CodecTraits for CodecChain {
+    /// Returns [`None`] since a codec chain does not have standard codec metadata.
+    ///
+    /// Note that usage of the codec chain is explicit in [`Array`](crate::array::Array) and [`CodecChain::create_metadatas()`] will call [`CodecTraits::configuration()`] from for each codec.
+    fn configuration(
+        &self,
+        _version: ZarrVersion,
+        _options: &CodecMetadataOptions,
+    ) -> Option<Configuration> {
+        None
+    }
+
+    fn partial_decoder_capability(&self) -> PartialDecoderCapability {
+        // All codecs in the chain must support partial decoding capabilities
+        itertools::chain!(
+            self.array_to_array
+                .iter()
+                .map(|codec| codec.partial_decoder_capability()),
+            std::iter::once(&self.array_to_bytes).map(|codec| codec.partial_decoder_capability()),
+            self.bytes_to_bytes
+                .iter()
+                .map(|codec| codec.partial_decoder_capability())
+        )
+        .fold(
+            PartialDecoderCapability {
+                partial_read: true,
+                partial_decode: true,
+            },
+            |acc, capability| PartialDecoderCapability {
+                partial_read: acc.partial_read && capability.partial_read,
+                partial_decode: acc.partial_decode && capability.partial_decode,
+            },
+        )
+    }
+
+    fn partial_encoder_capability(&self) -> PartialEncoderCapability {
+        // All codecs in the chain must support partial encoding capabilities
+        itertools::chain!(
+            self.array_to_array
+                .iter()
+                .map(|codec| codec.partial_encoder_capability()),
+            std::iter::once(&self.array_to_bytes).map(|codec| codec.partial_encoder_capability()),
+            self.bytes_to_bytes
+                .iter()
+                .map(|codec| codec.partial_encoder_capability())
+        )
+        .fold(
+            PartialEncoderCapability {
+                partial_encode: true,
+            },
+            |acc, capability| PartialEncoderCapability {
+                partial_encode: acc.partial_encode && capability.partial_encode,
+            },
+        )
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl UnboundArrayToBytesCodecTraits for CodecChain {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
+    }
+
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
+        Ok(CodecChain::with_context(self, data_type, fill_value)?)
     }
 }
 
@@ -339,20 +418,6 @@ impl ArrayCodecTraits for CodecChainBound {
 impl ArrayToBytesCodecTraits for CodecChainBound {
     fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
         self
-    }
-
-    fn encoded_representation(
-        &self,
-        shape: &[NonZeroU64],
-    ) -> Result<BytesRepresentation, CodecError> {
-        let array_representations = self.get_array_representations(shape)?;
-        let mut bytes_representation = self
-            .array_to_bytes
-            .encoded_representation(&array_representations.last().unwrap().0)?;
-        for codec in &self.bytes_to_bytes {
-            bytes_representation = codec.encoded_representation(&bytes_representation);
-        }
-        Ok(bytes_representation)
     }
 
     fn partial_decode_granularity(
@@ -440,39 +505,6 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         Ok(bytes)
     }
 
-    fn compact<'a>(
-        &self,
-        mut bytes: ArrayBytesRaw<'a>,
-        shape: &[NonZeroU64],
-        options: &CodecOptions,
-    ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
-        let (array_representations, bytes_representations) = self.get_representations(shape)?;
-
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            bytes = codec.decode(bytes, bytes_representation, options)?;
-        }
-
-        let compacted = self.array_to_bytes.compact(
-            bytes,
-            &array_representations.last().unwrap().0,
-            options,
-        )?;
-
-        if let Some(mut compacted_bytes) = compacted {
-            let mut bytes_representation = *bytes_representations.first().unwrap();
-            for codec in &self.bytes_to_bytes {
-                compacted_bytes = codec.encode(compacted_bytes, options)?;
-                bytes_representation = codec.encoded_representation(&bytes_representation);
-            }
-            Ok(Some(compacted_bytes))
-        } else {
-            Ok(None)
-        }
-    }
-
     fn decode_into(
         &self,
         mut bytes: ArrayBytesRaw<'_>,
@@ -522,6 +554,39 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         bytes.validate(shape.iter().map(|v| v.get()).product(), data_type)?;
 
         decode_into_array_bytes_target(&bytes, output_target)
+    }
+
+    fn compact<'a>(
+        &self,
+        mut bytes: ArrayBytesRaw<'a>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
+        let (array_representations, bytes_representations) = self.get_representations(shape)?;
+
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            bytes = codec.decode(bytes, bytes_representation, options)?;
+        }
+
+        let compacted = self.array_to_bytes.compact(
+            bytes,
+            &array_representations.last().unwrap().0,
+            options,
+        )?;
+
+        if let Some(mut compacted_bytes) = compacted {
+            let mut bytes_representation = *bytes_representations.first().unwrap();
+            for codec in &self.bytes_to_bytes {
+                compacted_bytes = codec.encode(compacted_bytes, options)?;
+                bytes_representation = codec.encoded_representation(&bytes_representation);
+            }
+            Ok(Some(compacted_bytes))
+        } else {
+            Ok(None)
+        }
     }
 
     fn partial_decoder(
@@ -742,152 +807,86 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
 
         Ok(input_output_handle)
     }
-}
-
-impl zarrs_plugin::ExtensionName for CodecChain {
-    fn name(&self, _version: zarrs_plugin::ZarrVersion) -> Option<std::borrow::Cow<'static, str>> {
-        // CodecChain is an internal type and does not have a serialization name
-        None
-    }
-}
-
-impl CodecTraits for CodecChain {
-    /// Returns [`None`] since a codec chain does not have standard codec metadata.
-    ///
-    /// Note that usage of the codec chain is explicit in [`Array`](crate::array::Array) and [`CodecChain::create_metadatas()`] will call [`CodecTraits::configuration()`] from for each codec.
-    fn configuration(
-        &self,
-        _version: ZarrVersion,
-        _options: &CodecMetadataOptions,
-    ) -> Option<Configuration> {
-        None
-    }
-
-    fn partial_decoder_capability(&self) -> PartialDecoderCapability {
-        // All codecs in the chain must support partial decoding capabilities
-        itertools::chain!(
-            self.array_to_array
-                .iter()
-                .map(|codec| codec.partial_decoder_capability()),
-            std::iter::once(&self.array_to_bytes).map(|codec| codec.partial_decoder_capability()),
-            self.bytes_to_bytes
-                .iter()
-                .map(|codec| codec.partial_decoder_capability())
-        )
-        .fold(
-            PartialDecoderCapability {
-                partial_read: true,
-                partial_decode: true,
-            },
-            |acc, capability| PartialDecoderCapability {
-                partial_read: acc.partial_read && capability.partial_read,
-                partial_decode: acc.partial_decode && capability.partial_decode,
-            },
-        )
-    }
-
-    fn partial_encoder_capability(&self) -> PartialEncoderCapability {
-        // All codecs in the chain must support partial encoding capabilities
-        itertools::chain!(
-            self.array_to_array
-                .iter()
-                .map(|codec| codec.partial_encoder_capability()),
-            std::iter::once(&self.array_to_bytes).map(|codec| codec.partial_encoder_capability()),
-            self.bytes_to_bytes
-                .iter()
-                .map(|codec| codec.partial_encoder_capability())
-        )
-        .fold(
-            PartialEncoderCapability {
-                partial_encode: true,
-            },
-            |acc, capability| PartialEncoderCapability {
-                partial_encode: acc.partial_encode && capability.partial_encode,
-            },
-        )
-    }
-}
-
-#[cfg_attr(
-    all(feature = "async", not(target_arch = "wasm32")),
-    async_trait::async_trait
-)]
-#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl UnboundArrayToBytesCodecTraits for CodecChain {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
-        self as Arc<dyn UnboundArrayToBytesCodecTraits>
-    }
-
-    fn with_context(
-        &self,
-        data_type: DataType,
-        fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
-        Ok(CodecChain::with_context(self, data_type, fill_value)?)
-    }
-}
-
-impl CodecChainBound {
-    fn get_array_representations(
+    fn encoded_representation(
         &self,
         shape: &[NonZeroU64],
-    ) -> Result<ArrayRepresentations, CodecError> {
-        let mut array_representations = Vec::with_capacity(self.array_to_array.len() + 1);
-        array_representations.push((
-            shape.to_vec(),
-            self.data_type().clone(),
-            self.fill_value().clone(),
-        ));
-        for codec in &self.array_to_array {
-            let (shape, _data_type, _fill_value) = array_representations.last().unwrap();
-            array_representations.push((
-                codec.encoded_shape(shape)?,
-                codec.encoded_data_type().clone(),
-                codec.encoded_fill_value().clone(),
-            ));
-        }
-        Ok(array_representations)
-    }
-
-    fn get_bytes_representations(
-        &self,
-        shape: &[NonZeroU64],
-    ) -> Result<BytesRepresentations, CodecError> {
-        let mut bytes_representations = Vec::with_capacity(self.bytes_to_bytes.len() + 1);
-        bytes_representations.push(self.array_to_bytes.encoded_representation(shape)?);
-        for codec in &self.bytes_to_bytes {
-            bytes_representations
-                .push(codec.encoded_representation(bytes_representations.last().unwrap()));
-        }
-        Ok(bytes_representations)
-    }
-
-    fn get_representations(
-        &self,
-        shape: &[NonZeroU64],
-    ) -> Result<(ArrayRepresentations, BytesRepresentations), CodecError> {
+    ) -> Result<BytesRepresentation, CodecError> {
         let array_representations = self.get_array_representations(shape)?;
-        let bytes_representations =
-            self.get_bytes_representations(&array_representations.last().unwrap().0)?;
-        Ok((array_representations, bytes_representations))
+        let mut bytes_representation = self
+            .array_to_bytes
+            .encoded_representation(&array_representations.last().unwrap().0)?;
+        for codec in &self.bytes_to_bytes {
+            bytes_representation = codec.encoded_representation(&bytes_representation);
+        }
+        Ok(bytes_representation)
+    }
+}
+
+impl ArrayCodecTraits for CodecChainBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 
-    /// Get the array to array codecs
-    #[must_use]
-    pub fn array_to_array_codecs(&self) -> &[Arc<dyn ArrayToArrayCodecTraits>] {
-        &self.array_to_array
+    fn data_type(&self) -> &DataType {
+        self.array_to_array.first().map_or_else(
+            || self.array_to_bytes.data_type(),
+            |codec| codec.data_type(),
+        )
     }
 
-    /// Get the array to bytes codec
-    #[must_use]
-    pub fn array_to_bytes_codec(&self) -> &Arc<dyn ArrayToBytesCodecTraits> {
-        &self.array_to_bytes
+    fn fill_value(&self) -> &FillValue {
+        self.array_to_array.first().map_or_else(
+            || self.array_to_bytes.fill_value(),
+            |codec| codec.fill_value(),
+        )
     }
 
-    /// Get the bytes to bytes codecs
-    #[must_use]
-    pub fn bytes_to_bytes_codecs(&self) -> &[Arc<dyn BytesToBytesCodecTraits>] {
-        &self.bytes_to_bytes
+    fn recommended_concurrency(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        let mut concurrency_min = usize::MAX;
+        let mut concurrency_max = 0;
+
+        let array_representations = self.get_array_representations(shape)?;
+        let bytes_representations = self.get_bytes_representations(
+            &array_representations
+                .last()
+                .expect("array representations is non-empty")
+                .0,
+        )?;
+
+        // bytes->bytes
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            let recommended_concurrency = &codec.recommended_concurrency(bytes_representation)?;
+            concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
+            concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
+        }
+
+        let recommended_concurrency = self
+            .array_to_bytes
+            .recommended_concurrency(&array_representations.last().unwrap().0)?;
+        concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
+        concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
+
+        // array->array
+        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            let recommended_concurrency = codec.recommended_concurrency(shape)?;
+            concurrency_min = std::cmp::min(concurrency_min, recommended_concurrency.min());
+            concurrency_max = std::cmp::max(concurrency_max, recommended_concurrency.max());
+        }
+
+        let recommended_concurrency = RecommendedConcurrency::new(
+            std::cmp::min(concurrency_min, concurrency_max)..concurrency_max,
+        );
+
+        Ok(recommended_concurrency)
     }
 }
 

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -11,11 +11,11 @@ use crate::array::{
 };
 use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits,
-    ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, ArrayToArrayCodecTraits, BytesPartialDecoderTraits,
-    BytesPartialEncoderTraits, BytesToBytesCodecTraits, Codec, CodecError, CodecMetadataOptions,
-    CodecOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
-    RecommendedConcurrency, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
-    decode_into_array_bytes_target,
+    ArrayPartialEncoderTraits, ArrayToArrayCodecTraits, ArrayToBytesCodecTraits,
+    BytesPartialDecoderTraits, BytesPartialEncoderTraits, BytesToBytesCodecTraits, Codec,
+    CodecError, CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
+    UnboundArrayToBytesCodecTraits, decode_into_array_bytes_target,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{
@@ -347,10 +347,12 @@ impl ArrayCodecTraits for CodecChainBound {
         // The fill value doesn't affect concurrency computation.
         let fill_value: FillValue = vec![0u8; self.data_type.fixed_size().unwrap_or(0)].into();
         let array_representations =
-            self.codec.get_array_representations(shape, &self.data_type, &fill_value)?;
+            self.codec
+                .get_array_representations(shape, &self.data_type, &fill_value)?;
         let bytes_representations = {
             let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            self.codec.get_bytes_representations(shape, data_type, fill_value)?
+            self.codec
+                .get_bytes_representations(shape, data_type, fill_value)?
         };
 
         // bytes->bytes
@@ -367,7 +369,8 @@ impl ArrayCodecTraits for CodecChainBound {
             let (shape, data_type, _fill_value) = array_representations.last().unwrap();
             let fill_value = &array_representations.last().unwrap().2;
             &self
-                .codec.array_to_bytes
+                .codec
+                .array_to_bytes
                 .clone()
                 .with_context(data_type.clone(), fill_value.clone())?
                 .recommended_concurrency(shape)?

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -424,16 +424,24 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         &self,
         decoded_shape: &[NonZeroU64],
     ) -> Result<ChunkShape, CodecError> {
-        let array_representations = self.get_array_representations(decoded_shape)?;
+        let mut array_shapes = Vec::with_capacity(self.array_to_array.len() + 1);
+        array_shapes.push(decoded_shape.to_vec());
+        for codec in &self.array_to_array {
+            let decoded_shape = array_shapes.last().expect("array_shapes is non-empty");
+            let encoded_shape = codec.encoded_shape(decoded_shape)?;
+            array_shapes.push(encoded_shape);
+        }
+
+        let encoded_shape = array_shapes.last().expect("array_shapes is non-empty");
         let mut granularity = self
             .array_to_bytes
-            .partial_decode_granularity(&array_representations.last().unwrap().0)?;
+            .partial_decode_granularity(encoded_shape)?;
 
-        for (codec, (decoded_shape, _decoded_data_type, _decoded_fill_value)) in self
+        for (codec, decoded_shape) in self
             .array_to_array
             .iter()
             .rev()
-            .zip(array_representations.iter().rev().skip(1))
+            .zip(array_shapes.iter().rev().skip(1))
         {
             granularity = codec.partial_decode_granularity(decoded_shape, &granularity)?;
         }

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use zarrs_plugin::{ExtensionName, ZarrVersion};
 
-use crate::array::codec::{ArrayPartialDecoderCache, BytesPartialDecoderCache};
+use crate::array::codec::ArrayPartialDecoderCache;
 use crate::array::{
     ArrayBytes, ArrayBytesRaw, BytesRepresentation, ChunkShape, DataType, FillValue,
 };
@@ -41,18 +41,47 @@ pub struct CodecChain {
     array_to_array: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>>,
     array_to_bytes: Arc<dyn UnboundArrayToBytesCodecTraits>,
     bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>>,
-    cache_index: Option<usize>, // for partial decoders
 }
 
 /// A codec chain bound to an array data type and fill value.
 #[derive(Debug)]
 pub struct CodecChainBound {
-    codec: Arc<CodecChain>,
-    data_type: DataType,
-    fill_value: FillValue,
+    array_to_array: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
+    array_to_bytes: Arc<dyn ArrayToBytesCodecTraits>,
+    bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>>,
 }
 
 impl CodecChain {
+    /// Bind this codec chain to a decoded data type and fill value.
+    ///
+    /// # Errors
+    /// Returns a [`CodecError`] if any codec cannot be bound to the derived context.
+    pub fn with_context(
+        &self,
+        mut data_type: DataType,
+        mut fill_value: FillValue,
+    ) -> Result<Arc<CodecChainBound>, CodecError> {
+        let mut array_to_array = Vec::with_capacity(self.array_to_array.len());
+        for codec in &self.array_to_array {
+            let bound = codec
+                .clone()
+                .with_context(data_type.clone(), fill_value.clone())?;
+            data_type = bound.encoded_data_type().clone();
+            fill_value = bound.encoded_fill_value().clone();
+            array_to_array.push(bound);
+        }
+        let array_to_bytes = self
+            .array_to_bytes
+            .clone()
+            .with_context(data_type, fill_value)?;
+
+        Ok(Arc::new(CodecChainBound {
+            array_to_array,
+            array_to_bytes,
+            bytes_to_bytes: self.bytes_to_bytes.clone(),
+        }))
+    }
+
     /// Create a new codec chain.
     #[must_use]
     pub fn new(
@@ -60,90 +89,11 @@ impl CodecChain {
         array_to_bytes: Arc<dyn UnboundArrayToBytesCodecTraits>,
         bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>>,
     ) -> Self {
-        let mut cache_index_must = None;
-        let mut cache_index_should = None;
-        let mut codec_index = 0;
-        for codec in bytes_to_bytes.iter().rev() {
-            let capability = codec.partial_decoder_capability();
-            if !capability.partial_read {
-                cache_index_should = Some(codec_index);
-            }
-            if !capability.partial_decode {
-                cache_index_must = Some(codec_index + 1);
-            }
-            codec_index += 1;
-        }
-
-        {
-            let codec = &array_to_bytes;
-            let capability = codec.partial_decoder_capability();
-            if !capability.partial_read {
-                cache_index_should = Some(codec_index);
-            }
-            if !capability.partial_decode {
-                cache_index_must = Some(codec_index + 1);
-            }
-            codec_index += 1;
-        }
-
-        for codec in array_to_array.iter().rev() {
-            let capability = codec.partial_decoder_capability();
-            if !capability.partial_read {
-                cache_index_should = Some(codec_index);
-            }
-            if !capability.partial_decode {
-                cache_index_must = Some(codec_index + 1);
-            }
-            codec_index += 1;
-        }
-
-        let cache_index = if let (Some(cache_index_must), Some(cache_index_should)) =
-            (cache_index_must, cache_index_should)
-        {
-            Some(std::cmp::max(cache_index_must, cache_index_should))
-        } else if cache_index_must.is_some() {
-            cache_index_must
-        } else if cache_index_should.is_some() {
-            cache_index_should
-        } else {
-            None
-        };
-
         Self {
             array_to_array,
             array_to_bytes,
             bytes_to_bytes,
-            cache_index,
         }
-    }
-
-    /// Bind this codec chain to an array data type and fill value.
-    ///
-    /// # Errors
-    /// Returns a [`CodecError`] if any array codec does not support its derived context.
-    pub fn with_context(
-        self: Arc<Self>,
-        data_type: DataType,
-        fill_value: FillValue,
-    ) -> Result<Arc<CodecChainBound>, CodecError> {
-        let mut encoded_data_type = data_type.clone();
-        let mut encoded_fill_value = fill_value.clone();
-        for codec in &self.array_to_array {
-            let bound = codec
-                .clone()
-                .with_context(encoded_data_type, encoded_fill_value)?;
-            encoded_data_type = bound.encoded_data_type().clone();
-            encoded_fill_value = bound.encoded_fill_value().clone();
-        }
-        self.array_to_bytes
-            .clone()
-            .with_context(encoded_data_type, encoded_fill_value)?;
-
-        Ok(Arc::new(CodecChainBound {
-            codec: self,
-            data_type,
-            fill_value,
-        }))
     }
 
     /// Create a new codec chain from a list of metadata.
@@ -270,64 +220,13 @@ impl CodecChain {
     pub fn bytes_to_bytes_codecs(&self) -> &[Arc<dyn BytesToBytesCodecTraits>] {
         &self.bytes_to_bytes
     }
-
-    fn get_array_representations(
-        &self,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-    ) -> Result<ArrayRepresentations, CodecError> {
-        let mut array_representations = Vec::with_capacity(self.array_to_array.len() + 1);
-        array_representations.push((shape.to_vec(), data_type.clone(), fill_value.clone()));
-        for codec in &self.array_to_array {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            let bound = codec
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?;
-            array_representations.push((
-                bound.encoded_shape(shape)?,
-                bound.encoded_data_type().clone(),
-                bound.encoded_fill_value().clone(),
-            ));
-        }
-        Ok(array_representations)
-    }
-
-    fn get_bytes_representations(
-        &self,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-    ) -> Result<BytesRepresentations, CodecError> {
-        let mut bytes_representations = Vec::with_capacity(self.bytes_to_bytes.len() + 1);
-        let array_to_bytes = self
-            .array_to_bytes
-            .clone()
-            .with_context(data_type.clone(), fill_value.clone())?;
-        bytes_representations.push(array_to_bytes.encoded_representation(shape)?);
-        for codec in &self.bytes_to_bytes {
-            bytes_representations
-                .push(codec.encoded_representation(bytes_representations.last().unwrap()));
-        }
-        Ok(bytes_representations)
-    }
-
-    fn get_representations(
-        &self,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-    ) -> Result<(ArrayRepresentations, BytesRepresentations), CodecError> {
-        let array_representations = self.get_array_representations(shape, data_type, fill_value)?;
-        let bytes_representations = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            self.get_bytes_representations(shape, data_type, fill_value)?
-        };
-        Ok((array_representations, bytes_representations))
-    }
 }
 
 impl ArrayCodecTraits for CodecChainBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         self.array_to_array.first().map_or_else(
             || self.array_to_bytes.data_type(),
@@ -419,123 +318,353 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         &self,
         decoded_shape: &[NonZeroU64],
     ) -> Result<ChunkShape, CodecError> {
-        self.codec
-            .partial_decode_granularity(decoded_shape, &self.data_type, &self.fill_value)
+        let array_representations = self.get_array_representations(decoded_shape)?;
+        let mut granularity = self
+            .array_to_bytes
+            .partial_decode_granularity(&array_representations.last().unwrap().0)?;
+
+        for (codec, (decoded_shape, _decoded_data_type, _decoded_fill_value)) in self
+            .array_to_array
+            .iter()
+            .rev()
+            .zip(array_representations.iter().rev().skip(1))
+        {
+            granularity = codec.partial_decode_granularity(decoded_shape, &granularity)?;
+        }
+
+        Ok(granularity)
     }
 
     fn encode<'a>(
         &self,
-        bytes: ArrayBytes<'a>,
+        mut bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-        self.codec
-            .encode(bytes, shape, &self.data_type, &self.fill_value, options)
+        bytes.validate(shape.iter().map(|v| v.get()).product(), self.data_type())?;
+
+        let mut shape = ChunkShape::from(shape.to_vec());
+
+        // array->array
+        for codec in &self.array_to_array {
+            bytes = codec.encode(bytes, &shape, options)?;
+            shape = codec.encoded_shape(&shape)?;
+        }
+
+        // array->bytes
+        let mut bytes = self.array_to_bytes.encode(bytes, &shape, options)?;
+        let mut decoded_representation = self.array_to_bytes.encoded_representation(&shape)?;
+
+        // bytes->bytes
+        for codec in &self.bytes_to_bytes {
+            bytes = codec.encode(bytes, options)?;
+            decoded_representation = codec.encoded_representation(&decoded_representation);
+        }
+
+        Ok(bytes)
     }
 
     fn decode<'a>(
         &self,
-        bytes: ArrayBytesRaw<'a>,
+        mut bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        self.codec
-            .decode(bytes, shape, &self.data_type, &self.fill_value, options)
+        let (array_representations, bytes_representations) = self.get_representations(shape)?;
+
+        // bytes->bytes
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            bytes = codec.decode(bytes, bytes_representation, options)?;
+        }
+
+        // bytes->array
+        let mut bytes =
+            self.array_to_bytes
+                .decode(bytes, &array_representations.last().unwrap().0, options)?;
+
+        // array->array
+        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            bytes = codec.decode(bytes, shape, options)?;
+        }
+
+        let (shape, data_type, _) = array_representations.first().unwrap();
+        bytes.validate(shape.iter().map(|v| v.get()).product(), data_type)?;
+
+        Ok(bytes)
     }
 
     fn compact<'a>(
         &self,
-        bytes: ArrayBytesRaw<'a>,
+        mut bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
-        self.codec
-            .compact(bytes, shape, &self.data_type, &self.fill_value, options)
+        let (array_representations, bytes_representations) = self.get_representations(shape)?;
+
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            bytes = codec.decode(bytes, bytes_representation, options)?;
+        }
+
+        let compacted = self.array_to_bytes.compact(
+            bytes,
+            &array_representations.last().unwrap().0,
+            options,
+        )?;
+
+        if let Some(mut compacted_bytes) = compacted {
+            let mut bytes_representation = bytes_representations.first().unwrap().clone();
+            for codec in &self.bytes_to_bytes {
+                compacted_bytes = codec.encode(compacted_bytes, options)?;
+                bytes_representation = codec.encoded_representation(&bytes_representation);
+            }
+            Ok(Some(compacted_bytes))
+        } else {
+            Ok(None)
+        }
     }
 
     fn decode_into(
         &self,
-        bytes: ArrayBytesRaw<'_>,
+        mut bytes: ArrayBytesRaw<'_>,
         shape: &[NonZeroU64],
         output_target: ArrayBytesDecodeIntoTarget<'_>,
         options: &CodecOptions,
     ) -> Result<(), CodecError> {
-        self.codec.decode_into(
-            bytes,
-            shape,
-            &self.data_type,
-            &self.fill_value,
-            output_target,
-            options,
-        )
+        let (array_representations, bytes_representations) = self.get_representations(shape)?;
+
+        if self.bytes_to_bytes.is_empty() && self.array_to_array.is_empty() {
+            return self.array_to_bytes.decode_into(
+                bytes,
+                &array_representations.last().unwrap().0,
+                output_target,
+                options,
+            );
+        }
+
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            bytes = codec.decode(bytes, bytes_representation, options)?;
+        }
+
+        if self.array_to_array.is_empty() {
+            return self.array_to_bytes.decode_into(
+                bytes,
+                &array_representations.last().unwrap().0,
+                output_target,
+                options,
+            );
+        }
+
+        let mut bytes =
+            self.array_to_bytes
+                .decode(bytes, &array_representations.last().unwrap().0, options)?;
+
+        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            bytes = codec.decode(bytes, shape, options)?;
+        }
+
+        let (shape, data_type, _) = array_representations.first().unwrap();
+        bytes.validate(shape.iter().map(|v| v.get()).product(), data_type)?;
+
+        decode_into_array_bytes_target(&bytes, output_target)
     }
 
     fn partial_decoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        mut input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-        self.codec.clone().partial_decoder(
-            input_handle,
-            shape,
-            &self.data_type,
-            &self.fill_value,
-            options,
-        )
+        let (array_representations, bytes_representations) = self.get_representations(shape)?;
+
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            input_handle =
+                Arc::clone(codec).partial_decoder(input_handle, bytes_representation, options)?;
+        }
+
+        let (encoded_shape, _encoded_data_type, _encoded_fill_value) =
+            array_representations.last().unwrap();
+        let mut input_handle =
+            self.array_to_bytes
+                .clone()
+                .partial_decoder(input_handle, encoded_shape, options)?;
+
+        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            input_handle = codec
+                .clone()
+                .partial_decoder(input_handle, shape, options)?;
+        }
+
+        if !input_handle.supports_partial_decode()
+            || (input_handle.size_held() > 0
+                && self.partial_decode_granularity(shape)?.as_slice() == shape)
+        {
+            let (shape, data_type, _fill_value) = array_representations.first().unwrap();
+            input_handle = Arc::new(ArrayPartialDecoderCache::new(
+                &*input_handle,
+                shape.clone(),
+                data_type.clone(),
+                options,
+            )?);
+        }
+
+        Ok(input_handle)
     }
 
     fn partial_encoder(
         self: Arc<Self>,
-        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        mut input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
-        self.codec.clone().partial_encoder(
+        let (array_representations, bytes_representations) = self.get_representations(shape)?;
+
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            input_output_handle = Arc::clone(codec).partial_encoder(
+                input_output_handle,
+                bytes_representation,
+                options,
+            )?;
+        }
+
+        let mut input_output_handle = self.array_to_bytes.clone().partial_encoder(
             input_output_handle,
-            shape,
-            &self.data_type,
-            &self.fill_value,
+            &array_representations.last().unwrap().0,
             options,
-        )
+        )?;
+
+        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            input_output_handle =
+                codec
+                    .clone()
+                    .partial_encoder(input_output_handle, shape, options)?;
+        }
+
+        Ok(input_output_handle)
     }
 
     #[cfg(feature = "async")]
     async fn async_partial_decoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
+        mut input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
-        self.codec
+        let (array_representations, bytes_representations) = self.get_representations(shape)?;
+
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            input_handle = codec
+                .clone()
+                .async_partial_decoder(input_handle, bytes_representation, options)
+                .await?;
+        }
+
+        let (encoded_shape, _encoded_data_type, _encoded_fill_value) =
+            array_representations.last().unwrap();
+        let mut input_handle = self
+            .array_to_bytes
             .clone()
-            .async_partial_decoder(
-                input_handle,
-                shape,
-                &self.data_type,
-                &self.fill_value,
-                options,
-            )
-            .await
+            .async_partial_decoder(input_handle, encoded_shape, options)
+            .await?;
+
+        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            input_handle = codec
+                .clone()
+                .async_partial_decoder(input_handle, shape, options)
+                .await?;
+        }
+
+        if !input_handle.supports_partial_decode()
+            || (input_handle.size_held() > 0
+                && self.partial_decode_granularity(shape)?.as_slice() == shape)
+        {
+            let (shape, data_type, _fill_value) = array_representations.first().unwrap();
+            input_handle = Arc::new(
+                ArrayPartialDecoderCache::async_new(
+                    &*input_handle,
+                    shape.clone(),
+                    data_type.clone(),
+                    options,
+                )
+                .await?,
+            );
+        }
+
+        Ok(input_handle)
     }
 
     #[cfg(feature = "async")]
     async fn async_partial_encoder(
         self: Arc<Self>,
-        input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
+        mut input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
-        self.codec
+        let (array_representations, bytes_representations) = self.get_representations(shape)?;
+
+        for (codec, bytes_representation) in std::iter::zip(
+            self.bytes_to_bytes.iter().rev(),
+            bytes_representations.iter().rev().skip(1),
+        ) {
+            input_output_handle = codec
+                .clone()
+                .async_partial_encoder(input_output_handle, bytes_representation, options)
+                .await?;
+        }
+
+        let mut input_output_handle = self
+            .array_to_bytes
             .clone()
             .async_partial_encoder(
                 input_output_handle,
-                shape,
-                &self.data_type,
-                &self.fill_value,
+                &array_representations.last().unwrap().0,
                 options,
             )
-            .await
+            .await?;
+
+        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+            self.array_to_array.iter().rev(),
+            array_representations.iter().rev().skip(1),
+        ) {
+            input_output_handle = codec
+                .clone()
+                .async_partial_encoder(input_output_handle, shape, options)
+                .await?;
+        }
+
+        Ok(input_output_handle)
     }
 }
 
@@ -622,493 +751,55 @@ impl UnboundArrayToBytesCodecTraits for CodecChain {
         data_type: DataType,
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
-        CodecChain::with_context(self, data_type, fill_value)
-            .map(|codec| codec as Arc<dyn ArrayToBytesCodecTraits>)
-    }
-}
-
-impl CodecChain {
-    pub(crate) fn partial_decode_granularity(
-        &self,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-    ) -> Result<ChunkShape, CodecError> {
-        let array_representations = self.get_array_representations(shape, data_type, fill_value)?;
-
-        let (encoded_shape, encoded_data_type, encoded_fill_value) = array_representations
-            .last()
-            .expect("array_shapes is non-empty");
-        let mut granularity = self
-            .array_to_bytes
-            .clone()
-            .with_context(encoded_data_type.clone(), encoded_fill_value.clone())?
-            .partial_decode_granularity(encoded_shape)?;
-
-        for (codec, (decoded_shape, decoded_data_type, decoded_fill_value)) in self
-            .array_to_array
-            .iter()
-            .rev()
-            .zip(array_representations.iter().rev().skip(1))
-        {
-            granularity = codec
-                .clone()
-                .with_context(decoded_data_type.clone(), decoded_fill_value.clone())?
-                .partial_decode_granularity(decoded_shape, &granularity)?;
-        }
-
-        Ok(granularity)
-    }
-
-    fn encode<'a>(
-        &self,
-        mut bytes: ArrayBytes<'a>,
-        shape: &[NonZeroU64],
-        options: &CodecOptions,
-    ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-        bytes.validate(shape.iter().map(|v| v.get()).product(), self.data_type())?;
-
-        let mut shape = ChunkShape::from(shape.to_vec());
-
-        // array->array
-        for codec in &self.array_to_array {
-            bytes = codec.encode(bytes, &shape, options)?;
-            shape = codec.encoded_shape(&shape)?;
-        }
-
-        // array->bytes
-        let mut bytes = self.array_to_bytes.encode(bytes, &shape, options)?;
-        let mut decoded_representation = self.array_to_bytes.encoded_representation(&shape)?;
-
-        // bytes->bytes
-        for codec in &self.bytes_to_bytes {
-            bytes = codec.encode(bytes, options)?;
-            decoded_representation = codec.encoded_representation(&decoded_representation);
-        }
-
-        Ok(bytes)
-    }
-
-    fn decode<'a>(
-        &self,
-        mut bytes: ArrayBytesRaw<'a>,
-        shape: &[NonZeroU64],
-        options: &CodecOptions,
-    ) -> Result<ArrayBytes<'a>, CodecError> {
-        let (array_representations, bytes_representations) = self.get_representations(shape)?;
-
-        // bytes->bytes
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            bytes = codec.decode(bytes, bytes_representation, options)?;
-        }
-
-        // bytes->array
-        let mut bytes =
-            self.array_to_bytes
-                .decode(bytes, &array_representations.last().unwrap().0, options)?;
-
-        // array->array
-        for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            bytes = codec.decode(bytes, shape, options)?;
-        }
-
-        let (shape, data_type, _) = array_representations.first().unwrap();
-        bytes.validate(shape.iter().map(|v| v.get()).product(), data_type)?;
-
-        Ok(bytes)
-    }
-
-    pub(crate) fn decode_into(
-        &self,
-        mut bytes: ArrayBytesRaw<'_>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
-    ) -> Result<(), CodecError> {
-        let (array_representations, bytes_representations) =
-            self.get_representations(shape, data_type, fill_value)?;
-
-        if self.bytes_to_bytes.is_empty() && self.array_to_array.is_empty() {
-            // Fast path if no bytes to bytes or array to array codecs
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            return self
-                .array_to_bytes
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .decode_into(bytes, shape, output_target, options);
-        }
-
-        // bytes->bytes
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            bytes = codec.decode(bytes, bytes_representation, options)?;
-        }
-
-        if self.array_to_array.is_empty() {
-            // Fast path if no array to array codecs
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            return self
-                .array_to_bytes
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .decode_into(bytes, shape, output_target, options);
-        }
-
-        // bytes->array
-        let mut bytes = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            self.array_to_bytes
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .decode(bytes, shape, options)?
-        };
-
-        // array->array
-        for (codec, (shape, data_type, fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            bytes = codec
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .decode(bytes, shape, options)?;
-        }
-
-        let (shape, data_type, _) = array_representations.first().unwrap();
-        bytes.validate(shape.iter().map(|v| v.get()).product(), data_type)?;
-
-        decode_into_array_bytes_target(&bytes, output_target)
-    }
-
-    pub(crate) fn compact<'a>(
-        &self,
-        mut bytes: ArrayBytesRaw<'a>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
-        let (array_representations, bytes_representations) =
-            self.get_representations(shape, data_type, fill_value)?;
-
-        // Decode through bytes_to_bytes codecs (in reverse) to get to array_to_bytes level
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            bytes = codec.decode(bytes, bytes_representation, options)?;
-        }
-
-        // Compact at the array_to_bytes level (e.g., ShardingCodec compact)
-        let compacted = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            self.array_to_bytes
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .compact(bytes, shape, options)?
-        };
-
-        // If compaction occurred, re-encode through bytes_to_bytes codecs
-        if let Some(mut compacted_bytes) = compacted {
-            let mut bytes_representation = *bytes_representations.first().unwrap();
-            for codec in &self.bytes_to_bytes {
-                compacted_bytes = codec.encode(compacted_bytes, options)?;
-                bytes_representation = codec.encoded_representation(&bytes_representation);
-            }
-            Ok(Some(compacted_bytes))
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub(crate) fn partial_decoder(
-        self: Arc<Self>,
-        mut input_handle: Arc<dyn BytesPartialDecoderTraits>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-        let (array_representations, bytes_representations) =
-            self.get_representations(shape, data_type, fill_value)?;
-        let mut codec_index = 0;
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            if Some(codec_index) == self.cache_index {
-                input_handle = Arc::new(BytesPartialDecoderCache::new(&*input_handle, options)?);
-            }
-            codec_index += 1;
-            input_handle =
-                Arc::clone(codec).partial_decoder(input_handle, bytes_representation, options)?;
-        }
-
-        if Some(codec_index) == self.cache_index {
-            input_handle = Arc::new(BytesPartialDecoderCache::new(&*input_handle, options)?);
-        }
-
-        let mut input_handle = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            let codec = &self.array_to_bytes;
-            codec_index += 1;
-            codec
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .partial_decoder(input_handle, shape, options)?
-        };
-
-        for (codec, (shape, data_type, fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            if Some(codec_index) == self.cache_index {
-                input_handle = Arc::new(ArrayPartialDecoderCache::new(
-                    &*input_handle,
-                    shape.clone(),
-                    data_type.clone(),
-                    options,
-                )?);
-            }
-            codec_index += 1;
-            input_handle = codec
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .partial_decoder(input_handle, shape, options)?;
-        }
-
-        if Some(codec_index) == self.cache_index {
-            let (shape, data_type, _fill_value) = array_representations.first().unwrap();
-            input_handle = Arc::new(ArrayPartialDecoderCache::new(
-                &*input_handle,
-                shape.clone(),
-                data_type.clone(),
-                options,
-            )?);
-        }
-
-        Ok(input_handle)
-    }
-
-    pub(crate) fn partial_encoder(
-        self: Arc<Self>,
-        mut input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
-        let (array_representations, bytes_representations) =
-            self.get_representations(shape, data_type, fill_value)?;
-
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            input_output_handle = Arc::clone(codec).partial_encoder(
-                input_output_handle,
-                bytes_representation,
-                options,
-            )?;
-        }
-
-        let mut input_output_handle = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            self.array_to_bytes
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .partial_encoder(input_output_handle, shape, options)?
-        };
-
-        if self.array_to_array.is_empty() {
-            return Ok(input_output_handle);
-        }
-
-        for (codec, (shape, data_type, fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            input_output_handle = Arc::clone(codec)
-                .with_context(data_type.clone(), fill_value.clone())?
-                .partial_encoder(input_output_handle, shape, options)?;
-        }
-
-        Ok(input_output_handle)
-    }
-
-    #[cfg(feature = "async")]
-    pub(crate) async fn async_partial_decoder(
-        self: Arc<Self>,
-        mut input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
-        let (array_representations, bytes_representations) =
-            self.get_representations(shape, data_type, fill_value)?;
-
-        let mut codec_index = 0;
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            if Some(codec_index) == self.cache_index {
-                input_handle =
-                    Arc::new(BytesPartialDecoderCache::async_new(&*input_handle, options).await?);
-            }
-            codec_index += 1;
-            input_handle = codec
-                .clone()
-                .async_partial_decoder(input_handle, bytes_representation, options)
-                .await?;
-        }
-
-        if Some(codec_index) == self.cache_index {
-            input_handle =
-                Arc::new(BytesPartialDecoderCache::async_new(&*input_handle, options).await?);
-        }
-
-        let mut input_handle = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            let codec = &self.array_to_bytes;
-            codec_index += 1;
-            codec
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .async_partial_decoder(input_handle, shape, options)
-                .await?
-        };
-
-        for (codec, (shape, data_type, fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            if Some(codec_index) == self.cache_index {
-                input_handle = Arc::new(
-                    ArrayPartialDecoderCache::async_new(
-                        &*input_handle,
-                        shape.clone(),
-                        data_type.clone(),
-                        options,
-                    )
-                    .await?,
-                );
-            }
-            codec_index += 1;
-            input_handle = codec
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .async_partial_decoder(input_handle, shape, options)
-                .await?;
-        }
-
-        if Some(codec_index) == self.cache_index {
-            let (shape, data_type, _fill_value) = array_representations.first().unwrap();
-            input_handle = Arc::new(
-                ArrayPartialDecoderCache::async_new(
-                    &*input_handle,
-                    shape.clone(),
-                    data_type.clone(),
-                    options,
-                )
-                .await?,
-            );
-        }
-
-        Ok(input_handle)
-    }
-
-    #[cfg(feature = "async")]
-    pub(crate) async fn async_partial_encoder(
-        self: Arc<Self>,
-        mut input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
-        let (array_representations, bytes_representations) =
-            self.get_representations(shape, data_type, fill_value)?;
-
-        for (codec, bytes_representation) in std::iter::zip(
-            self.bytes_to_bytes.iter().rev(),
-            bytes_representations.iter().rev().skip(1),
-        ) {
-            input_output_handle = Arc::clone(codec)
-                .async_partial_encoder(input_output_handle, bytes_representation, options)
-                .await?;
-        }
-
-        let mut input_output_handle = {
-            let (shape, data_type, fill_value) = array_representations.last().unwrap();
-            self.array_to_bytes
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?
-                .async_partial_encoder(input_output_handle, shape, options)
-                .await?
-        };
-
-        if self.array_to_array.is_empty() {
-            return Ok(input_output_handle);
-        }
-
-        for (codec, (shape, data_type, fill_value)) in std::iter::zip(
-            self.array_to_array.iter().rev(),
-            array_representations.iter().rev().skip(1),
-        ) {
-            input_output_handle = Arc::clone(codec)
-                .with_context(data_type.clone(), fill_value.clone())?
-                .async_partial_encoder(input_output_handle, shape, options)
-                .await?;
-        }
-
-        Ok(input_output_handle)
-    }
-
-    pub(crate) fn encoded_representation(
-        &self,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-    ) -> Result<BytesRepresentation, CodecError> {
-        let mut shape = ChunkShape::from(shape.to_vec());
-        let mut data_type = data_type.clone();
-        let mut fill_value = fill_value.clone();
-        for codec in &self.array_to_array {
-            let bound = codec
-                .clone()
-                .with_context(data_type.clone(), fill_value.clone())?;
-            shape = bound.encoded_shape(&shape)?;
-            fill_value = bound.encoded_fill_value().clone();
-            data_type = bound.encoded_data_type().clone();
-        }
-
-        let mut bytes_representation = self
-            .array_to_bytes
-            .clone()
-            .with_context(data_type, fill_value)?
-            .encoded_representation(&shape)?;
-
-        for codec in &self.bytes_to_bytes {
-            bytes_representation = codec.encoded_representation(&bytes_representation);
-        }
-
-        Ok(bytes_representation)
+        Ok(CodecChain::with_context(self, data_type, fill_value)?)
     }
 }
 
 impl CodecChainBound {
+    fn get_array_representations(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<ArrayRepresentations, CodecError> {
+        let mut array_representations = Vec::with_capacity(self.array_to_array.len() + 1);
+        array_representations.push((
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+        ));
+        for codec in &self.array_to_array {
+            let (shape, _data_type, _fill_value) = array_representations.last().unwrap();
+            array_representations.push((
+                codec.encoded_shape(shape)?,
+                codec.encoded_data_type().clone(),
+                codec.encoded_fill_value().clone(),
+            ));
+        }
+        Ok(array_representations)
+    }
+
+    fn get_bytes_representations(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<BytesRepresentations, CodecError> {
+        let mut bytes_representations = Vec::with_capacity(self.bytes_to_bytes.len() + 1);
+        bytes_representations.push(self.array_to_bytes.encoded_representation(shape)?);
+        for codec in &self.bytes_to_bytes {
+            bytes_representations
+                .push(codec.encoded_representation(bytes_representations.last().unwrap()));
+        }
+        Ok(bytes_representations)
+    }
+
+    fn get_representations(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<(ArrayRepresentations, BytesRepresentations), CodecError> {
+        let array_representations = self.get_array_representations(shape)?;
+        let bytes_representations =
+            self.get_bytes_representations(&array_representations.last().unwrap().0)?;
+        Ok((array_representations, bytes_representations))
+    }
+
     /// Get the array to array codecs
     #[must_use]
     pub fn array_to_array_codecs(&self) -> &[Arc<dyn ArrayToArrayCodecTraits>] {
@@ -1245,25 +936,16 @@ mod tests {
         ];
         println!("{codec_configurations:?}");
         let not_just_bytes = codec_configurations.len() > 1;
-        let codec = Arc::new(CodecChain::from_metadata(&codec_configurations).unwrap());
+        let codec = CodecChain::from_metadata(&codec_configurations)
+            .unwrap()
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                shape,
-                data_type,
-                fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded.clone(),
-                shape,
-                data_type,
-                fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded.clone(), shape, &CodecOptions::default())
             .unwrap();
         if not_just_bytes {
             assert_ne!(encoded, decoded.clone().into_fixed().unwrap());
@@ -1284,13 +966,7 @@ mod tests {
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
             .clone()
-            .partial_decoder(
-                input_handle.clone(),
-                shape,
-                data_type,
-                fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle.clone(), shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(partial_decoder.size_held(), decoded.size()); // codec chain caches with most decompression codecs
         let decoded_partial_chunk = partial_decoder

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use zarrs_plugin::{ExtensionName, ZarrVersion};
 
-use crate::array::codec::ArrayPartialDecoderCache;
+use crate::array::codec::{ArrayPartialDecoderCache, BytesPartialDecoderCache};
 use crate::array::{
     ArrayBytes, ArrayBytesRaw, BytesRepresentation, ChunkShape, DataType, FillValue,
 };
@@ -49,6 +49,7 @@ pub struct CodecChainBound {
     array_to_array: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
     array_to_bytes: Arc<dyn ArrayToBytesCodecTraits>,
     bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>>,
+    cache_index: Option<usize>,
 }
 
 impl CodecChain {
@@ -75,10 +76,31 @@ impl CodecChain {
             .clone()
             .with_context(data_type, fill_value)?;
 
+        // Compute cache index from bytes codecs (reverse iteration)
+        let mut cache_index_must = None;
+        let mut cache_index_should = None;
+        for (i, codec) in self.bytes_to_bytes.iter().rev().enumerate() {
+            let idx = self.bytes_to_bytes.len() - 1 - i;
+            let cap = codec.partial_decoder_capability();
+            if !cap.partial_decode {
+                cache_index_must = Some(idx + 1);
+            }
+            if !cap.partial_read {
+                cache_index_should = Some(idx);
+            }
+        }
+        let cache_index = match (cache_index_must, cache_index_should) {
+            (Some(m), Some(s)) => Some(m.max(s)),
+            (Some(m), None) => Some(m),
+            (None, Some(s)) => Some(s),
+            (None, None) => None,
+        };
+
         Ok(Arc::new(CodecChainBound {
             array_to_array,
             array_to_bytes,
             bytes_to_bytes: self.bytes_to_bytes.clone(),
+            cache_index,
         }))
     }
 
@@ -485,12 +507,71 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
 
     fn partial_decoder(
         self: Arc<Self>,
-        mut input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         let (array_representations, bytes_representations) = self.get_representations(shape)?;
+        let (encoded_shape, _encoded_data_type, _encoded_fill_value) =
+            array_representations.last().unwrap();
 
+        let mut input_handle = input_handle;
+
+        if let Some(cache_idx) = self.cache_index {
+            // Pre-cache bytes codecs (indices cache_idx..N, processed in reverse)
+            for (codec, bytes_representation) in std::iter::zip(
+                self.bytes_to_bytes[cache_idx..].iter().rev(),
+                bytes_representations[cache_idx + 1..].iter().rev(),
+            ) {
+                input_handle =
+                    Arc::clone(codec).partial_decoder(input_handle, bytes_representation, options)?;
+            }
+
+            // Insert bytes partial decoder cache
+            let cached: Arc<dyn BytesPartialDecoderTraits> =
+                Arc::new(BytesPartialDecoderCache::new(&*input_handle, options)?);
+            input_handle = cached;
+
+            // Post-cache bytes codecs (indices 0..cache_idx, processed in reverse)
+            for (i, codec) in self.bytes_to_bytes[..cache_idx].iter().rev().enumerate() {
+                let decoded_rep = cache_idx - i;
+                input_handle = Arc::clone(codec).partial_decoder(
+                    Arc::clone(&input_handle),
+                    &bytes_representations[decoded_rep],
+                    options,
+                )?;
+            }
+
+            let array_handle = self
+                .array_to_bytes
+                .clone()
+                .partial_decoder(input_handle, encoded_shape, options)?;
+
+            let mut array_handle = array_handle;
+            for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+                self.array_to_array.iter().rev(),
+                array_representations.iter().rev().skip(1),
+            ) {
+                array_handle = codec.clone().partial_decoder(array_handle, shape, options)?;
+            }
+
+            if !array_handle.supports_partial_decode()
+                || (array_handle.size_held() > 0
+                    && self.partial_decode_granularity(shape)?.as_slice() == shape)
+            {
+                let (shape, data_type, _fill_value) = array_representations.first().unwrap();
+                array_handle = Arc::new(ArrayPartialDecoderCache::new(
+                    &*array_handle,
+                    shape.clone(),
+                    data_type.clone(),
+                    options,
+                )?);
+            }
+
+            return Ok(array_handle);
+        }
+
+        // No cache - original path for full bytes pipeline
         for (codec, bytes_representation) in std::iter::zip(
             self.bytes_to_bytes.iter().rev(),
             bytes_representations.iter().rev().skip(1),
@@ -499,36 +580,33 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
                 Arc::clone(codec).partial_decoder(input_handle, bytes_representation, options)?;
         }
 
-        let (encoded_shape, _encoded_data_type, _encoded_fill_value) =
-            array_representations.last().unwrap();
-        let mut input_handle =
-            self.array_to_bytes
-                .clone()
-                .partial_decoder(input_handle, encoded_shape, options)?;
+        let array_handle = self
+            .array_to_bytes
+            .clone()
+            .partial_decoder(input_handle, encoded_shape, options)?;
 
+        let mut array_handle = array_handle;
         for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
             self.array_to_array.iter().rev(),
             array_representations.iter().rev().skip(1),
         ) {
-            input_handle = codec
-                .clone()
-                .partial_decoder(input_handle, shape, options)?;
+            array_handle = codec.clone().partial_decoder(array_handle, shape, options)?;
         }
 
-        if !input_handle.supports_partial_decode()
-            || (input_handle.size_held() > 0
+        if !array_handle.supports_partial_decode()
+            || (array_handle.size_held() > 0
                 && self.partial_decode_granularity(shape)?.as_slice() == shape)
         {
             let (shape, data_type, _fill_value) = array_representations.first().unwrap();
-            input_handle = Arc::new(ArrayPartialDecoderCache::new(
-                &*input_handle,
+            array_handle = Arc::new(ArrayPartialDecoderCache::new(
+                &*array_handle,
                 shape.clone(),
                 data_type.clone(),
                 options,
             )?);
         }
 
-        Ok(input_handle)
+        Ok(array_handle)
     }
 
     fn partial_encoder(
@@ -572,12 +650,80 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
     #[cfg(feature = "async")]
     async fn async_partial_decoder(
         self: Arc<Self>,
-        mut input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         let (array_representations, bytes_representations) = self.get_representations(shape)?;
+        let (encoded_shape, _encoded_data_type, _encoded_fill_value) =
+            array_representations.last().unwrap();
 
+        let mut input_handle = input_handle;
+
+        if let Some(cache_idx) = self.cache_index {
+            // Pre-cache bytes codecs (indices cache_idx..N, processed in reverse)
+            for (codec, bytes_representation) in std::iter::zip(
+                self.bytes_to_bytes[cache_idx..].iter().rev(),
+                bytes_representations[cache_idx + 1..].iter().rev(),
+            ) {
+                input_handle = codec
+                    .clone()
+                    .async_partial_decoder(input_handle, bytes_representation, options)
+                    .await?;
+            }
+
+            // Insert bytes partial decoder cache
+            let cached: Arc<dyn AsyncBytesPartialDecoderTraits> = Arc::new(
+                BytesPartialDecoderCache::async_new(&*input_handle, options).await?,
+            );
+            input_handle = cached;
+
+            // Post-cache bytes codecs (indices 0..cache_idx, processed in reverse)
+            for (i, codec) in self.bytes_to_bytes[..cache_idx].iter().rev().enumerate() {
+                let decoded_rep = cache_idx - i;
+                input_handle = codec
+                    .clone()
+                    .async_partial_decoder(Arc::clone(&input_handle), &bytes_representations[decoded_rep], options)
+                    .await?;
+            }
+
+            let array_handle = self
+                .array_to_bytes
+                .clone()
+                .async_partial_decoder(input_handle, encoded_shape, options)
+                .await?;
+
+            let mut array_handle = array_handle;
+            for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
+                self.array_to_array.iter().rev(),
+                array_representations.iter().rev().skip(1),
+            ) {
+                array_handle = codec
+                    .clone()
+                    .async_partial_decoder(array_handle, shape, options)
+                    .await?;
+            }
+
+            if !array_handle.supports_partial_decode()
+                || (array_handle.size_held() > 0
+                    && self.partial_decode_granularity(shape)?.as_slice() == shape)
+            {
+                let (shape, data_type, _fill_value) = array_representations.first().unwrap();
+                array_handle = Arc::new(
+                    ArrayPartialDecoderCache::async_new(
+                        &*array_handle,
+                        shape.clone(),
+                        data_type.clone(),
+                        options,
+                    )
+                    .await?,
+                );
+            }
+
+            return Ok(array_handle);
+        }
+
+        // No cache
         for (codec, bytes_representation) in std::iter::zip(
             self.bytes_to_bytes.iter().rev(),
             bytes_representations.iter().rev().skip(1),
@@ -588,32 +734,31 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
                 .await?;
         }
 
-        let (encoded_shape, _encoded_data_type, _encoded_fill_value) =
-            array_representations.last().unwrap();
-        let mut input_handle = self
+        let array_handle = self
             .array_to_bytes
             .clone()
             .async_partial_decoder(input_handle, encoded_shape, options)
             .await?;
 
+        let mut array_handle = array_handle;
         for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
             self.array_to_array.iter().rev(),
             array_representations.iter().rev().skip(1),
         ) {
-            input_handle = codec
+            array_handle = codec
                 .clone()
-                .async_partial_decoder(input_handle, shape, options)
+                .async_partial_decoder(array_handle, shape, options)
                 .await?;
         }
 
-        if !input_handle.supports_partial_decode()
-            || (input_handle.size_held() > 0
+        if !array_handle.supports_partial_decode()
+            || (array_handle.size_held() > 0
                 && self.partial_decode_granularity(shape)?.as_slice() == shape)
         {
             let (shape, data_type, _fill_value) = array_representations.first().unwrap();
-            input_handle = Arc::new(
+            array_handle = Arc::new(
                 ArrayPartialDecoderCache::async_new(
-                    &*input_handle,
+                    &*array_handle,
                     shape.clone(),
                     data_type.clone(),
                     options,
@@ -622,7 +767,7 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
             );
         }
 
-        Ok(input_handle)
+        Ok(array_handle)
     }
 
     #[cfg(feature = "async")]

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -11,10 +11,11 @@ use crate::array::{
 };
 use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits,
-    ArrayPartialEncoderTraits, ArrayToArrayCodecTraits, ArrayToBytesCodecTraits,
-    BytesPartialDecoderTraits, BytesPartialEncoderTraits, BytesToBytesCodecTraits, Codec,
-    CodecError, CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, decode_into_array_bytes_target,
+    ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+    BytesPartialEncoderTraits, BytesToBytesCodecTraits, Codec, CodecError, CodecMetadataOptions,
+    CodecOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
+    RecommendedConcurrency, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
+    decode_into_array_bytes_target,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{
@@ -37,18 +38,24 @@ type BytesRepresentations = Vec<BytesRepresentation>;
 ///    - preceding the first codec with `partial_decode` true and `partial_read` false.
 #[derive(Debug, Clone)]
 pub struct CodecChain {
-    array_to_array: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
-    array_to_bytes: Arc<dyn ArrayToBytesCodecTraits>,
+    array_to_array: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>>,
+    array_to_bytes: Arc<dyn UnboundArrayToBytesCodecTraits>,
     bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>>,
     cache_index: Option<usize>, // for partial decoders
+}
+
+/// A codec chain bound to an array data type and fill value.
+#[derive(Debug)]
+pub struct CodecChainBound {
+    codec: Arc<dyn ArrayToBytesCodecTraits>,
 }
 
 impl CodecChain {
     /// Create a new codec chain.
     #[must_use]
     pub fn new(
-        array_to_array: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
-        array_to_bytes: Arc<dyn ArrayToBytesCodecTraits>,
+        array_to_array: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>>,
+        array_to_bytes: Arc<dyn UnboundArrayToBytesCodecTraits>,
         bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>>,
     ) -> Self {
         let mut cache_index_must = None;
@@ -108,6 +115,32 @@ impl CodecChain {
         }
     }
 
+    /// Bind this codec chain to an array data type and fill value.
+    ///
+    /// # Errors
+    /// Returns a [`CodecError`] if any array codec does not support its derived context.
+    pub fn with_context(
+        self: Arc<Self>,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<CodecChainBound>, CodecError> {
+        let mut encoded_data_type = data_type.clone();
+        let mut encoded_fill_value = fill_value.clone();
+        for codec in &self.array_to_array {
+            let bound = codec
+                .clone()
+                .with_context(encoded_data_type, encoded_fill_value)?;
+            encoded_data_type = bound.encoded_data_type().clone();
+            encoded_fill_value = bound.encoded_fill_value().clone();
+        }
+        self.array_to_bytes
+            .clone()
+            .with_context(encoded_data_type, encoded_fill_value)?;
+
+        let codec = UnboundArrayToBytesCodecTraits::with_context(self, data_type, fill_value)?;
+        Ok(Arc::new(CodecChainBound { codec }))
+    }
+
     /// Create a new codec chain from a list of metadata.
     ///
     /// # Errors
@@ -116,8 +149,8 @@ impl CodecChain {
     ///  - no array to bytes codec is supplied, or
     ///  - more than one array to bytes codec is supplied.
     pub fn from_metadata(metadatas: &[MetadataV3]) -> Result<Self, PluginCreateError> {
-        let mut array_to_array: Vec<Arc<dyn ArrayToArrayCodecTraits>> = vec![];
-        let mut array_to_bytes: Option<Arc<dyn ArrayToBytesCodecTraits>> = None;
+        let mut array_to_array: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>> = vec![];
+        let mut array_to_bytes: Option<Arc<dyn UnboundArrayToBytesCodecTraits>> = None;
         let mut bytes_to_bytes: Vec<Arc<dyn BytesToBytesCodecTraits>> = vec![];
         for metadata in metadatas {
             let codec = match Codec::from_metadata(metadata) {
@@ -159,19 +192,21 @@ impl CodecChain {
     /// Each codec in the chain is given the opportunity to read its own options type
     /// from `opts` and return a new instance. Codecs that do not recognise any option
     /// in `opts` are returned unchanged (default behaviour).
-    #[must_use]
-    pub fn with_codec_specific_options(self, opts: &zarrs_codec::CodecSpecificOptions) -> Self {
-        Self::new(
+    pub fn with_codec_specific_options(
+        self,
+        opts: &zarrs_codec::CodecSpecificOptions,
+    ) -> Result<Self, CodecError> {
+        Ok(Self::new(
             self.array_to_array
                 .into_iter()
                 .map(|c| c.with_codec_specific_options(opts))
-                .collect(),
-            self.array_to_bytes.with_codec_specific_options(opts),
+                .collect::<Result<_, _>>()?,
+            self.array_to_bytes.with_codec_specific_options(opts)?,
             self.bytes_to_bytes
                 .into_iter()
                 .map(|c| c.with_codec_specific_options(opts))
                 .collect(),
-        )
+        ))
     }
 
     /// Create codec chain metadata.
@@ -215,13 +250,13 @@ impl CodecChain {
 
     /// Get the array to array codecs
     #[must_use]
-    pub fn array_to_array_codecs(&self) -> &[Arc<dyn ArrayToArrayCodecTraits>] {
+    pub fn array_to_array_codecs(&self) -> &[Arc<dyn UnboundArrayToArrayCodecTraits>] {
         &self.array_to_array
     }
 
     /// Get the array to bytes codec
     #[must_use]
-    pub fn array_to_bytes_codec(&self) -> &Arc<dyn ArrayToBytesCodecTraits> {
+    pub fn array_to_bytes_codec(&self) -> &Arc<dyn UnboundArrayToBytesCodecTraits> {
         &self.array_to_bytes
     }
 
@@ -276,6 +311,133 @@ impl CodecChain {
             self.get_bytes_representations(shape, data_type, fill_value)?
         };
         Ok((array_representations, bytes_representations))
+    }
+}
+
+impl ArrayCodecTraits for CodecChainBound {
+    fn data_type(&self) -> &DataType {
+        self.codec.data_type()
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        self.codec.fill_value()
+    }
+
+    fn recommended_concurrency(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        self.codec.recommended_concurrency(shape)
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToBytesCodecTraits for CodecChainBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self
+    }
+
+    fn encoded_representation(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<BytesRepresentation, CodecError> {
+        self.codec.encoded_representation(shape)
+    }
+
+    fn partial_decode_granularity(
+        &self,
+        decoded_shape: &[NonZeroU64],
+    ) -> Result<ChunkShape, CodecError> {
+        self.codec.partial_decode_granularity(decoded_shape)
+    }
+
+    fn encode<'a>(
+        &self,
+        bytes: ArrayBytes<'a>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<ArrayBytesRaw<'a>, CodecError> {
+        self.codec.encode(bytes, shape, options)
+    }
+
+    fn decode<'a>(
+        &self,
+        bytes: ArrayBytesRaw<'a>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<ArrayBytes<'a>, CodecError> {
+        self.codec.decode(bytes, shape, options)
+    }
+
+    fn compact<'a>(
+        &self,
+        bytes: ArrayBytesRaw<'a>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
+        self.codec.compact(bytes, shape, options)
+    }
+
+    fn decode_into(
+        &self,
+        bytes: ArrayBytesRaw<'_>,
+        shape: &[NonZeroU64],
+        output_target: ArrayBytesDecodeIntoTarget<'_>,
+        options: &CodecOptions,
+    ) -> Result<(), CodecError> {
+        self.codec.decode_into(bytes, shape, output_target, options)
+    }
+
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
+        self.codec
+            .clone()
+            .partial_decoder(input_handle, shape, options)
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        self.codec
+            .clone()
+            .partial_encoder(input_output_handle, shape, options)
+    }
+
+    #[cfg(feature = "async")]
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
+        self.codec
+            .clone()
+            .async_partial_decoder(input_handle, shape, options)
+            .await
+    }
+
+    #[cfg(feature = "async")]
+    async fn async_partial_encoder(
+        self: Arc<Self>,
+        input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
+        self.codec
+            .clone()
+            .async_partial_encoder(input_output_handle, shape, options)
+            .await
     }
 }
 
@@ -352,9 +514,9 @@ impl CodecTraits for CodecChain {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for CodecChain {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for CodecChain {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn partial_decode_granularity(&self, shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError> {

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -527,6 +527,7 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
         let (array_representations, bytes_representations) = self.get_representations(shape)?;
 
         if self.bytes_to_bytes.is_empty() && self.array_to_array.is_empty() {
+            // Fast path if no bytes to bytes or array to array codecs
             return self.array_to_bytes.decode_into(
                 bytes,
                 &array_representations.last().unwrap().0,
@@ -535,6 +536,7 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
             );
         }
 
+        // bytes->bytes
         for (codec, bytes_representation) in std::iter::zip(
             self.bytes_to_bytes.iter().rev(),
             bytes_representations.iter().rev().skip(1),
@@ -542,6 +544,7 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
             bytes = codec.decode(bytes, bytes_representation, options)?;
         }
 
+        // Fast path if no array to array codecs
         if self.array_to_array.is_empty() {
             return self.array_to_bytes.decode_into(
                 bytes,
@@ -551,10 +554,12 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
             );
         }
 
+        // bytes->array
         let mut bytes =
             self.array_to_bytes
                 .decode(bytes, &array_representations.last().unwrap().0, options)?;
 
+        // array->array
         for (codec, (shape, _data_type, _fill_value)) in std::iter::zip(
             self.array_to_array.iter().rev(),
             array_representations.iter().rev().skip(1),
@@ -576,6 +581,7 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
     ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
         let (array_representations, bytes_representations) = self.get_representations(shape)?;
 
+        // Decode through bytes_to_bytes codecs (in reverse) to get to array_to_bytes level
         for (codec, bytes_representation) in std::iter::zip(
             self.bytes_to_bytes.iter().rev(),
             bytes_representations.iter().rev().skip(1),
@@ -583,12 +589,14 @@ impl ArrayToBytesCodecTraits for CodecChainBound {
             bytes = codec.decode(bytes, bytes_representation, options)?;
         }
 
+        // Compact at the array_to_bytes level (e.g., ShardingCodec compact)
         let compacted = self.array_to_bytes.compact(
             bytes,
             &array_representations.last().unwrap().0,
             options,
         )?;
 
+        // If compaction occurred, re-encode through bytes_to_bytes codecs
         if let Some(mut compacted_bytes) = compacted {
             let mut bytes_representation = *bytes_representations.first().unwrap();
             for codec in &self.bytes_to_bytes {

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -80,34 +80,38 @@ impl CodecChain {
         let mut codec_index = 0;
         for codec in self.bytes_to_bytes.iter().rev() {
             let capability = codec.partial_decoder_capability();
-            if !capability.partial_decode {
-                cache_index_must = Some(codec_index + 1);
-            }
             if !capability.partial_read {
                 cache_index_should = Some(codec_index);
             }
+            if !capability.partial_decode {
+                cache_index_must = Some(codec_index + 1);
+            }
             codec_index += 1;
         }
+
         {
-            let capability = self.array_to_bytes.partial_decoder_capability();
-            if !capability.partial_decode {
-                cache_index_must = Some(codec_index + 1);
-            }
+            let codec = &self.array_to_bytes;
+            let capability = codec.partial_decoder_capability();
             if !capability.partial_read {
                 cache_index_should = Some(codec_index);
             }
+            if !capability.partial_decode {
+                cache_index_must = Some(codec_index + 1);
+            }
             codec_index += 1;
         }
+
         for codec in self.array_to_array.iter().rev() {
             let capability = codec.partial_decoder_capability();
-            if !capability.partial_decode {
-                cache_index_must = Some(codec_index + 1);
-            }
             if !capability.partial_read {
                 cache_index_should = Some(codec_index);
             }
+            if !capability.partial_decode {
+                cache_index_must = Some(codec_index + 1);
+            }
             codec_index += 1;
         }
+
         let cache_index = match (cache_index_must, cache_index_should) {
             (Some(m), Some(s)) => Some(m.max(s)),
             (Some(m), None) => Some(m),

--- a/zarrs/src/array/codec/array_to_bytes/optional.rs
+++ b/zarrs/src/array/codec/array_to_bytes/optional.rs
@@ -95,7 +95,6 @@ use zarrs_codec::{Codec, CodecPluginV3, CodecTraitsV3};
 pub use zarrs_metadata_ext::codec::optional::{
     OptionalCodecConfiguration, OptionalCodecConfigurationV1,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(OptionalCodec,
   v3: "zarrs.optional", []
@@ -107,7 +106,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for OptionalCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         crate::warn_experimental_extension(metadata.name(), "codec");
         let configuration: OptionalCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(OptionalCodec::new_with_configuration(&configuration)?);

--- a/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
@@ -9,7 +9,7 @@ use zarrs_data_type::FillValue;
 use zarrs_plugin::{PluginCreateError, ZarrVersion};
 
 use super::{OptionalCodecConfiguration, OptionalCodecConfigurationV1};
-use crate::array::codec::CodecChain;
+use crate::array::codec::{CodecChain, CodecChainBound};
 use crate::array::{ArrayBytes, ArrayBytesOffsets, ArrayBytesRaw, BytesRepresentation, DataType};
 use zarrs_codec::{
     ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError, CodecMetadataOptions, CodecOptions,
@@ -28,7 +28,8 @@ pub struct OptionalCodec {
 /// An `optional` codec implementation bound to a data type and fill value.
 #[derive(Debug, Clone)]
 struct OptionalCodecBound {
-    codec: Arc<OptionalCodec>,
+    mask_codecs: Arc<CodecChainBound>,
+    data_codecs: Arc<CodecChainBound>,
     data_type: DataType,
     fill_value: FillValue,
 }
@@ -332,8 +333,19 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
                 "optional codec requires an optional data type".to_string(),
             ));
         }
+        let inner_type = data_type.as_optional().ok_or_else(|| {
+            CodecError::Other("optional codec requires an optional data type".to_string())
+        })?;
+        let inner_fill_value = OptionalCodec::create_fill_value_for_inner_type(inner_type.data_type());
         Ok(Arc::new(OptionalCodecBound {
-            codec: self,
+            mask_codecs: self.mask_codecs.clone().with_context(
+                crate::array::data_type::bool(),
+                FillValue::from(0u8),
+            )?,
+            data_codecs: self.data_codecs.clone().with_context(
+                inner_type.data_type().clone(),
+                inner_fill_value,
+            )?,
             data_type,
             fill_value,
         }))
@@ -341,6 +353,10 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
 }
 
 impl ArrayCodecTraits for OptionalCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }
@@ -395,10 +411,8 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
 
         // Encode mask
         let encoded_mask = self
-            .codec
             .mask_codecs
             .clone()
-            .with_context(crate::array::data_type::bool(), FillValue::from(0u8))?
             .encode(ArrayBytes::from(mask.as_ref()), shape, options)?;
 
         // Convert dense data to sparse data (extract only valid elements)
@@ -409,11 +423,8 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
         let num_valid = mask.iter().filter(|&&v| v != 0).count();
         let encoded_data = if num_valid > 0 {
             let data_shape = vec![std::num::NonZeroU64::try_from(num_valid as u64).unwrap()];
-            let fill_value = OptionalCodec::create_fill_value_for_inner_type(opt.data_type());
-            self.codec
-                .data_codecs
+            self.data_codecs
                 .clone()
-                .with_context(opt.data_type().clone(), fill_value)?
                 .encode(sparse_data, &data_shape, options)?
         } else {
             ArrayBytesRaw::from(vec![])
@@ -452,10 +463,8 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
 
         // Decode mask
         let decoded_mask = self
-            .codec
             .mask_codecs
             .clone()
-            .with_context(crate::array::data_type::bool(), FillValue::from(0u8))?
             .decode(encoded_mask.into(), shape, options)?;
         let mask = decoded_mask.into_fixed()?.into_owned();
 
@@ -467,16 +476,13 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
         // Decode sparse data (only valid elements)
         let valid_count = mask.iter().filter(|&&v| v != 0).count();
         let dense_data = if valid_count > 0 {
-            let sparse_data = {
-                let data_shape = vec![std::num::NonZeroU64::try_from(valid_count as u64).unwrap()];
-                let fill_value = OptionalCodec::create_fill_value_for_inner_type(opt.data_type());
-                self.codec
-                    .data_codecs
-                    .clone()
-                    .with_context(opt.data_type().clone(), fill_value)?
-                    .decode(encoded_data.into(), &data_shape, options)?
-                    .into_owned()
-            };
+                let sparse_data = {
+                    let data_shape = vec![std::num::NonZeroU64::try_from(valid_count as u64).unwrap()];
+                    self.data_codecs
+                        .clone()
+                        .decode(encoded_data.into(), &data_shape, options)?
+                        .into_owned()
+                };
 
             // Expand sparse data to dense format (supports nested optional types)
             OptionalCodec::expand_to_dense(sparse_data, &mask, opt.data_type())?
@@ -503,19 +509,14 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
 
         // Compute mask representation: bool array with same shape
         let mask_bytes_repr = self
-            .codec
             .mask_codecs
             .clone()
-            .with_context(crate::array::data_type::bool(), FillValue::from(0u8))?
             .encoded_representation(shape)?;
 
         // Compute data representation: inner type array with same shape (worst case: all elements valid)
-        let fill_value = OptionalCodec::create_fill_value_for_inner_type(inner_type.data_type());
         let data_bytes_repr = self
-            .codec
             .data_codecs
             .clone()
-            .with_context(inner_type.data_type().clone(), fill_value)?
             .encoded_representation(shape)?;
 
         // Combine sizes: if either is unbounded, result is unbounded
@@ -538,7 +539,7 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
 mod tests {
     use super::*;
     use crate::array::{ArrayBytes, ChunkShapeTraits, DataType, data_type};
-    use zarrs_codec::{CodecOptions, CodecTraits};
+    use zarrs_codec::{CodecOptions, CodecTraits, UnboundArrayToBytesCodecTraits};
 
     #[test]
     fn codec_optional_configuration() {
@@ -646,25 +647,14 @@ mod tests {
                 }}"#
         ))
         .unwrap();
-        let codec = OptionalCodec::new_with_configuration(&codec_configuration)?;
+        let codec = Arc::new(OptionalCodec::new_with_configuration(&codec_configuration)?)
+            .with_context(data_type.clone(), fill_value.clone())?;
 
         // Build nested ArrayBytes structure for input
         let input = build_nested_array_bytes(&data_type, num_elements);
 
-        let encoded = codec.encode(
-            input,
-            &chunk_shape,
-            &data_type,
-            &fill_value,
-            &CodecOptions::default(),
-        )?;
-        let decoded = codec.decode(
-            encoded,
-            &chunk_shape,
-            &data_type,
-            &fill_value,
-            &CodecOptions::default(),
-        )?;
+        let encoded = codec.encode(input, &chunk_shape, &CodecOptions::default())?;
+        let decoded = codec.decode(encoded, &chunk_shape, &CodecOptions::default())?;
 
         // The codec now returns optional ArrayBytes
         assert!(matches!(decoded, ArrayBytes::Optional(..)));
@@ -851,25 +841,15 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let codec = OptionalCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec = Arc::new(OptionalCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                input.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(input.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &chunk_shape, &CodecOptions::default())
             .unwrap();
 
         // Verify the decoded structure
@@ -926,25 +906,15 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let codec = OptionalCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec = Arc::new(OptionalCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                input.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(input.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &chunk_shape, &CodecOptions::default())
             .unwrap();
 
         // Verify the decoded structure
@@ -1029,25 +999,15 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let codec = OptionalCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec = Arc::new(OptionalCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                input.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(input.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &chunk_shape, &CodecOptions::default())
             .unwrap();
 
         // Verify the 3-level nested structure
@@ -1108,25 +1068,15 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let codec = OptionalCodec::new_with_configuration(&codec_configuration).unwrap();
+        let codec = Arc::new(OptionalCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                input.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(input.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, &chunk_shape, &CodecOptions::default())
             .unwrap();
 
         // Verify the decoded structure

--- a/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
@@ -12,9 +12,9 @@ use super::{OptionalCodecConfiguration, OptionalCodecConfigurationV1};
 use crate::array::codec::CodecChain;
 use crate::array::{ArrayBytes, ArrayBytesOffsets, ArrayBytesRaw, BytesRepresentation, DataType};
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError, CodecMetadataOptions, CodecOptions,
-    CodecTraits, InvalidBytesLengthError, PartialDecoderCapability, PartialEncoderCapability,
-    RecommendedConcurrency,
+    ArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    InvalidBytesLengthError, PartialDecoderCapability, PartialEncoderCapability,
+    RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::{Configuration, DataTypeSize};
 
@@ -320,9 +320,9 @@ impl ArrayCodecTraits for OptionalCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for OptionalCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for OptionalCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(
@@ -509,7 +509,7 @@ impl ArrayToBytesCodecTraits for OptionalCodec {
 mod tests {
     use super::*;
     use crate::array::{ArrayBytes, ChunkShapeTraits, DataType, data_type};
-    use zarrs_codec::{ArrayToBytesCodecTraits, CodecOptions, CodecTraits};
+    use zarrs_codec::{CodecOptions, CodecTraits, UnboundArrayToBytesCodecTraits};
 
     #[test]
     fn codec_optional_configuration() {

--- a/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
@@ -68,7 +68,9 @@ impl OptionalCodec {
             )),
         }
     }
+}
 
+impl OptionalCodecBound {
     /// Recursively extract sparse data from dense data based on a validity mask.
     /// This supports arbitrarily nested optional types.
     fn extract_sparse_data<'a>(
@@ -339,7 +341,7 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
             CodecCreateError::Other("optional codec requires an optional data type".to_string())
         })?;
         let inner_fill_value =
-            OptionalCodec::create_fill_value_for_inner_type(inner_type.data_type());
+            OptionalCodecBound::create_fill_value_for_inner_type(inner_type.data_type());
         Ok(Arc::new(OptionalCodecBound {
             mask_codecs: self
                 .mask_codecs
@@ -420,7 +422,7 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
 
         // Convert dense data to sparse data (extract only valid elements)
         // This supports arbitrarily nested optional types
-        let sparse_data = OptionalCodec::extract_sparse_data(&dense_data, &mask, opt.data_type())?;
+        let sparse_data = Self::extract_sparse_data(&dense_data, &mask, opt.data_type())?;
 
         // Encode sparse data
         let num_valid = mask.iter().filter(|&&v| v != 0).count();
@@ -488,10 +490,10 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
             };
 
             // Expand sparse data to dense format (supports nested optional types)
-            OptionalCodec::expand_to_dense(sparse_data, &mask, opt.data_type())?
+            Self::expand_to_dense(sparse_data, &mask, opt.data_type())?
         } else {
             // No valid elements - create empty dense data of the right type/size
-            OptionalCodec::create_empty_dense_data(&mask, opt.data_type())?
+            Self::create_empty_dense_data(&mask, opt.data_type())?
         };
 
         // Return ArrayBytes with mask and dense data

--- a/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
@@ -336,16 +336,17 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
         let inner_type = data_type.as_optional().ok_or_else(|| {
             CodecError::Other("optional codec requires an optional data type".to_string())
         })?;
-        let inner_fill_value = OptionalCodec::create_fill_value_for_inner_type(inner_type.data_type());
+        let inner_fill_value =
+            OptionalCodec::create_fill_value_for_inner_type(inner_type.data_type());
         Ok(Arc::new(OptionalCodecBound {
-            mask_codecs: self.mask_codecs.clone().with_context(
-                crate::array::data_type::bool(),
-                FillValue::from(0u8),
-            )?,
-            data_codecs: self.data_codecs.clone().with_context(
-                inner_type.data_type().clone(),
-                inner_fill_value,
-            )?,
+            mask_codecs: self
+                .mask_codecs
+                .clone()
+                .with_context(crate::array::data_type::bool(), FillValue::from(0u8))?,
+            data_codecs: self
+                .data_codecs
+                .clone()
+                .with_context(inner_type.data_type().clone(), inner_fill_value)?,
             data_type,
             fill_value,
         }))
@@ -410,10 +411,10 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
         })?;
 
         // Encode mask
-        let encoded_mask = self
-            .mask_codecs
-            .clone()
-            .encode(ArrayBytes::from(mask.as_ref()), shape, options)?;
+        let encoded_mask =
+            self.mask_codecs
+                .clone()
+                .encode(ArrayBytes::from(mask.as_ref()), shape, options)?;
 
         // Convert dense data to sparse data (extract only valid elements)
         // This supports arbitrarily nested optional types
@@ -476,13 +477,13 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
         // Decode sparse data (only valid elements)
         let valid_count = mask.iter().filter(|&&v| v != 0).count();
         let dense_data = if valid_count > 0 {
-                let sparse_data = {
-                    let data_shape = vec![std::num::NonZeroU64::try_from(valid_count as u64).unwrap()];
-                    self.data_codecs
-                        .clone()
-                        .decode(encoded_data.into(), &data_shape, options)?
-                        .into_owned()
-                };
+            let sparse_data = {
+                let data_shape = vec![std::num::NonZeroU64::try_from(valid_count as u64).unwrap()];
+                self.data_codecs
+                    .clone()
+                    .decode(encoded_data.into(), &data_shape, options)?
+                    .into_owned()
+            };
 
             // Expand sparse data to dense format (supports nested optional types)
             OptionalCodec::expand_to_dense(sparse_data, &mask, opt.data_type())?
@@ -508,16 +509,10 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
         })?;
 
         // Compute mask representation: bool array with same shape
-        let mask_bytes_repr = self
-            .mask_codecs
-            .clone()
-            .encoded_representation(shape)?;
+        let mask_bytes_repr = self.mask_codecs.clone().encoded_representation(shape)?;
 
         // Compute data representation: inner type array with same shape (worst case: all elements valid)
-        let data_bytes_repr = self
-            .data_codecs
-            .clone()
-            .encoded_representation(shape)?;
+        let data_bytes_repr = self.data_codecs.clone().encoded_representation(shape)?;
 
         // Combine sizes: if either is unbounded, result is unbounded
         match (mask_bytes_repr.size(), data_bytes_repr.size()) {

--- a/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
@@ -503,11 +503,6 @@ impl ArrayToBytesCodecTraits for OptionalCodecBound {
         // Header: mask_len (u64) + data_len (u64) = 16 bytes
         const HEADER_SIZE: u64 = 16;
 
-        // Get the inner data type (unwrap Optional)
-        let inner_type = self.data_type.as_optional().ok_or_else(|| {
-            CodecError::Other("optional codec requires an optional data type".to_string())
-        })?;
-
         // Compute mask representation: bool array with same shape
         let mask_bytes_repr = self.mask_codecs.clone().encoded_representation(shape)?;
 

--- a/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
@@ -12,9 +12,9 @@ use super::{OptionalCodecConfiguration, OptionalCodecConfigurationV1};
 use crate::array::codec::{CodecChain, CodecChainBound};
 use crate::array::{ArrayBytes, ArrayBytesOffsets, ArrayBytesRaw, BytesRepresentation, DataType};
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError, CodecMetadataOptions, CodecOptions,
-    CodecTraits, InvalidBytesLengthError, PartialDecoderCapability, PartialEncoderCapability,
-    RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
+    ArrayCodecTraits, ArrayToBytesCodecTraits, CodecCreateError, CodecError, CodecMetadataOptions,
+    CodecOptions, CodecTraits, InvalidBytesLengthError, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::{Configuration, DataTypeSize};
 
@@ -53,8 +53,14 @@ impl OptionalCodec {
     ) -> Result<Self, PluginCreateError> {
         match configuration {
             OptionalCodecConfiguration::V1(configuration) => {
-                let mask_codecs = Arc::new(CodecChain::from_metadata(&configuration.mask_codecs)?);
-                let data_codecs = Arc::new(CodecChain::from_metadata(&configuration.data_codecs)?);
+                let mask_codecs = Arc::new(
+                    CodecChain::from_metadata(&configuration.mask_codecs)
+                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
+                );
+                let data_codecs = Arc::new(
+                    CodecChain::from_metadata(&configuration.data_codecs)
+                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
+                );
                 Ok(Self::new(mask_codecs, data_codecs))
             }
             _ => Err(PluginCreateError::Other(
@@ -323,14 +329,14 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         if !data_type.is_optional() {
-            return Err(CodecError::Other(
+            return Err(CodecCreateError::Other(
                 "optional codec requires an optional data type".to_string(),
             ));
         }
         let inner_type = data_type.as_optional().ok_or_else(|| {
-            CodecError::Other("optional codec requires an optional data type".to_string())
+            CodecCreateError::Other("optional codec requires an optional data type".to_string())
         })?;
         let inner_fill_value =
             OptionalCodec::create_fill_value_for_inner_type(inner_type.data_type());

--- a/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
@@ -282,10 +282,6 @@ impl OptionalCodec {
 }
 
 impl CodecTraits for OptionalCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/optional/optional_codec.rs
@@ -12,8 +12,8 @@ use super::{OptionalCodecConfiguration, OptionalCodecConfigurationV1};
 use crate::array::codec::CodecChain;
 use crate::array::{ArrayBytes, ArrayBytesOffsets, ArrayBytesRaw, BytesRepresentation, DataType};
 use zarrs_codec::{
-    ArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    InvalidBytesLengthError, PartialDecoderCapability, PartialEncoderCapability,
+    ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, InvalidBytesLengthError, PartialDecoderCapability, PartialEncoderCapability,
     RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::{Configuration, DataTypeSize};
@@ -23,6 +23,14 @@ use zarrs_metadata::{Configuration, DataTypeSize};
 pub struct OptionalCodec {
     mask_codecs: Arc<CodecChain>,
     data_codecs: Arc<CodecChain>,
+}
+
+/// An `optional` codec implementation bound to a data type and fill value.
+#[derive(Debug, Clone)]
+struct OptionalCodecBound {
+    codec: Arc<OptionalCodec>,
+    data_type: DataType,
+    fill_value: FillValue,
 }
 
 impl OptionalCodec {
@@ -304,11 +312,46 @@ impl CodecTraits for OptionalCodec {
     }
 }
 
-impl ArrayCodecTraits for OptionalCodec {
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl UnboundArrayToBytesCodecTraits for OptionalCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
+    }
+
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        if !data_type.is_optional() {
+            return Err(CodecError::Other(
+                "optional codec requires an optional data type".to_string(),
+            ));
+        }
+        Ok(Arc::new(OptionalCodecBound {
+            codec: self,
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for OptionalCodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
     fn recommended_concurrency(
         &self,
         _shape: &[NonZeroU64],
-        _data_type: &DataType,
     ) -> Result<RecommendedConcurrency, CodecError> {
         // Sequential processing for now
         Ok(RecommendedConcurrency::new_maximum(1))
@@ -320,24 +363,17 @@ impl ArrayCodecTraits for OptionalCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl UnboundArrayToBytesCodecTraits for OptionalCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
-        self as Arc<dyn UnboundArrayToBytesCodecTraits>
+impl ArrayToBytesCodecTraits for OptionalCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self as Arc<dyn ArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-        if !data_type.is_optional() {
-            return Err(CodecError::Other(
-                "optional codec requires an optional data type".to_string(),
-            ));
-        }
         let ArrayBytes::Optional(optional_bytes) = bytes else {
             return Err(CodecError::Other(
                 "expected optional array bytes for optional codec".to_string(),
@@ -353,35 +389,32 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
             )));
         }
 
-        let opt = data_type.as_optional().ok_or_else(|| {
+        let opt = self.data_type.as_optional().ok_or_else(|| {
             CodecError::Other("optional codec requires an optional data type".to_string())
         })?;
 
         // Encode mask
-        let encoded_mask = self.mask_codecs.encode(
-            ArrayBytes::from(mask.as_ref()),
-            shape,
-            &crate::array::data_type::bool(),
-            &FillValue::from(0u8),
-            options,
-        )?;
+        let encoded_mask = self
+            .codec
+            .mask_codecs
+            .clone()
+            .with_context(crate::array::data_type::bool(), FillValue::from(0u8))?
+            .encode(ArrayBytes::from(mask.as_ref()), shape, options)?;
 
         // Convert dense data to sparse data (extract only valid elements)
         // This supports arbitrarily nested optional types
-        let sparse_data = Self::extract_sparse_data(&dense_data, &mask, opt.data_type())?;
+        let sparse_data = OptionalCodec::extract_sparse_data(&dense_data, &mask, opt.data_type())?;
 
         // Encode sparse data
         let num_valid = mask.iter().filter(|&&v| v != 0).count();
         let encoded_data = if num_valid > 0 {
             let data_shape = vec![std::num::NonZeroU64::try_from(num_valid as u64).unwrap()];
-            let fill_value = Self::create_fill_value_for_inner_type(opt.data_type());
-            self.data_codecs.encode(
-                sparse_data,
-                &data_shape,
-                opt.data_type(),
-                &fill_value,
-                options,
-            )?
+            let fill_value = OptionalCodec::create_fill_value_for_inner_type(opt.data_type());
+            self.codec
+                .data_codecs
+                .clone()
+                .with_context(opt.data_type().clone(), fill_value)?
+                .encode(sparse_data, &data_shape, options)?
         } else {
             ArrayBytesRaw::from(vec![])
         };
@@ -400,8 +433,6 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
         &self,
         bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         // Extract mask length and data length from header
@@ -420,17 +451,16 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
         let encoded_data = &bytes[16 + mask_len..];
 
         // Decode mask
-        let decoded_mask = self.mask_codecs.decode(
-            encoded_mask.into(),
-            shape,
-            &crate::array::data_type::bool(),
-            &FillValue::from(0u8),
-            options,
-        )?;
+        let decoded_mask = self
+            .codec
+            .mask_codecs
+            .clone()
+            .with_context(crate::array::data_type::bool(), FillValue::from(0u8))?
+            .decode(encoded_mask.into(), shape, options)?;
         let mask = decoded_mask.into_fixed()?.into_owned();
 
         // Decode data
-        let opt = data_type.as_optional().ok_or_else(|| {
+        let opt = self.data_type.as_optional().ok_or_else(|| {
             CodecError::Other("optional codec requires an optional data type".to_string())
         })?;
 
@@ -439,23 +469,20 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
         let dense_data = if valid_count > 0 {
             let sparse_data = {
                 let data_shape = vec![std::num::NonZeroU64::try_from(valid_count as u64).unwrap()];
-                let fill_value = Self::create_fill_value_for_inner_type(opt.data_type());
-                self.data_codecs
-                    .decode(
-                        encoded_data.into(),
-                        &data_shape,
-                        opt.data_type(),
-                        &fill_value,
-                        options,
-                    )?
+                let fill_value = OptionalCodec::create_fill_value_for_inner_type(opt.data_type());
+                self.codec
+                    .data_codecs
+                    .clone()
+                    .with_context(opt.data_type().clone(), fill_value)?
+                    .decode(encoded_data.into(), &data_shape, options)?
                     .into_owned()
             };
 
             // Expand sparse data to dense format (supports nested optional types)
-            Self::expand_to_dense(sparse_data, &mask, opt.data_type())?
+            OptionalCodec::expand_to_dense(sparse_data, &mask, opt.data_type())?
         } else {
             // No valid elements - create empty dense data of the right type/size
-            Self::create_empty_dense_data(&mask, opt.data_type())?
+            OptionalCodec::create_empty_dense_data(&mask, opt.data_type())?
         };
 
         // Return ArrayBytes with mask and dense data
@@ -465,29 +492,31 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
     fn encoded_representation(
         &self,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
     ) -> Result<BytesRepresentation, CodecError> {
         // Header: mask_len (u64) + data_len (u64) = 16 bytes
         const HEADER_SIZE: u64 = 16;
 
         // Get the inner data type (unwrap Optional)
-        let inner_type = data_type.as_optional().ok_or_else(|| {
+        let inner_type = self.data_type.as_optional().ok_or_else(|| {
             CodecError::Other("optional codec requires an optional data type".to_string())
         })?;
 
         // Compute mask representation: bool array with same shape
-        let mask_bytes_repr = self.mask_codecs.encoded_representation(
-            shape,
-            &crate::array::data_type::bool(),
-            &FillValue::from(0u8),
-        )?;
+        let mask_bytes_repr = self
+            .codec
+            .mask_codecs
+            .clone()
+            .with_context(crate::array::data_type::bool(), FillValue::from(0u8))?
+            .encoded_representation(shape)?;
 
         // Compute data representation: inner type array with same shape (worst case: all elements valid)
-        let fill_value = Self::create_fill_value_for_inner_type(inner_type.data_type());
-        let data_bytes_repr =
-            self.data_codecs
-                .encoded_representation(shape, inner_type.data_type(), &fill_value)?;
+        let fill_value = OptionalCodec::create_fill_value_for_inner_type(inner_type.data_type());
+        let data_bytes_repr = self
+            .codec
+            .data_codecs
+            .clone()
+            .with_context(inner_type.data_type().clone(), fill_value)?
+            .encoded_representation(shape)?;
 
         // Combine sizes: if either is unbounded, result is unbounded
         match (mask_bytes_repr.size(), data_bytes_repr.size()) {
@@ -509,7 +538,7 @@ impl UnboundArrayToBytesCodecTraits for OptionalCodec {
 mod tests {
     use super::*;
     use crate::array::{ArrayBytes, ChunkShapeTraits, DataType, data_type};
-    use zarrs_codec::{CodecOptions, CodecTraits, UnboundArrayToBytesCodecTraits};
+    use zarrs_codec::{CodecOptions, CodecTraits};
 
     #[test]
     fn codec_optional_configuration() {

--- a/zarrs/src/array/codec/array_to_bytes/packbits.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits.rs
@@ -98,7 +98,7 @@ mod tests {
     use crate::array::codec::BytesCodec;
     use crate::array::element::{Element, ElementOwned};
     use crate::array::{ArrayBytes, ArraySubset, data_type};
-    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
+    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions};
     use zarrs_metadata_ext::codec::packbits::PackBitsPaddingEncoding;
 
     #[test]

--- a/zarrs/src/array/codec/array_to_bytes/packbits.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits.rs
@@ -98,7 +98,7 @@ mod tests {
     use crate::array::codec::BytesCodec;
     use crate::array::element::{Element, ElementOwned};
     use crate::array::{ArrayBytes, ArraySubset, data_type};
-    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions};
+    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
     use zarrs_metadata_ext::codec::packbits::PackBitsPaddingEncoding;
 
     #[test]
@@ -133,10 +133,11 @@ mod tests {
             PackBitsPaddingEncoding::FirstByte,
             PackBitsPaddingEncoding::LastByte,
         ] {
-            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let chunk_shape = vec![NonZeroU64::new(8).unwrap(), NonZeroU64::new(5).unwrap()];
             let data_type = data_type::bool();
             let fill_value = FillValue::from(false);
+            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())?;
 
             let elements: Vec<bool> = (0..40).map(|i| i % 3 == 0).collect();
             let bytes = bool::into_array_bytes(&data_type, elements)?.into_owned();
@@ -147,24 +148,12 @@ mod tests {
             // ...
 
             // Encoding
-            let encoded = codec.encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )?;
+            let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
             assert!((encoded.len() as u64) <= 40.div_ceil(&8) + 1);
 
             // Decoding
             let decoded = codec
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(bytes, decoded);
 
@@ -172,13 +161,7 @@ mod tests {
             let decoded_region = ArraySubset::new_with_ranges(&[1..4, 1..4]);
             let input_handle = Arc::new(encoded);
             let partial_decoder = codec
-                .partial_decoder(
-                    input_handle.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .partial_decoder(input_handle.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // packbits partial decoder does not hold bytes
             let decoded_partial_chunk = partial_decoder
@@ -200,45 +183,29 @@ mod tests {
             PackBitsPaddingEncoding::FirstByte,
             PackBitsPaddingEncoding::LastByte,
         ] {
-            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let chunk_shape = vec![NonZeroU64::new(8).unwrap(), NonZeroU64::new(5).unwrap()];
             let data_type = data_type::float32();
             let fill_value = FillValue::from(0.0f32);
+            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())?;
 
             let elements: Vec<f32> = (0..40).map(|i| i as f32).collect();
             let bytes = f32::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
-            let encoded = codec.encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )?;
+            let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
             assert!((encoded.len() as u64) <= (40 * 32).div_ceil(&8) + 1);
 
             // Decoding
             let decoded = codec
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(bytes, decoded);
 
             // Check it matches little endian bytes
-            let decoded = BytesCodec::little()
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+            let decoded = Arc::new(BytesCodec::little())
+                .with_context(data_type.clone(), fill_value.clone())?
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(bytes, decoded);
         }
@@ -254,38 +221,28 @@ mod tests {
                     PackBitsPaddingEncoding::FirstByte,
                     PackBitsPaddingEncoding::LastByte,
                 ] {
-                    let codec = Arc::new(
-                        super::PackBitsCodec::new(encoding, Some(first_bit), Some(last_bit))
-                            .unwrap(),
-                    );
                     let chunk_shape =
                         vec![NonZeroU64::new(8).unwrap(), NonZeroU64::new(5).unwrap()];
                     let data_type = data_type::int16();
                     let fill_value = FillValue::from(0i16);
+                    let codec = Arc::new(
+                        super::PackBitsCodec::new(encoding, Some(first_bit), Some(last_bit))
+                            .unwrap(),
+                    )
+                    .with_context(data_type.clone(), fill_value.clone())?;
                     let elements: Vec<i16> = (-20..20).map(|i| (i as i16) << first_bit).collect();
                     let bytes = i16::to_array_bytes(&data_type, &elements)?.into_owned();
 
                     // Encoding
-                    let encoded = codec.encode(
-                        bytes.clone(),
-                        &chunk_shape,
-                        &data_type,
-                        &fill_value,
-                        &CodecOptions::default(),
-                    )?;
+                    let encoded =
+                        codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
                     assert!(
                         (encoded.len() as u64) <= (40 * (last_bit - first_bit + 1)).div_ceil(8) + 1
                     );
 
                     // Decoding
                     let decoded = codec
-                        .decode(
-                            encoded.clone(),
-                            &chunk_shape,
-                            &data_type,
-                            &fill_value,
-                            &CodecOptions::default(),
-                        )
+                        .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                         .unwrap();
                     assert_eq!(elements, i16::from_array_bytes(&data_type, decoded)?);
                 }
@@ -301,33 +258,22 @@ mod tests {
             PackBitsPaddingEncoding::FirstByte,
             PackBitsPaddingEncoding::LastByte,
         ] {
-            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let chunk_shape = vec![NonZeroU64::new(4).unwrap(), NonZeroU64::new(1).unwrap()];
             let data_type = data_type::uint2();
             let fill_value = FillValue::from(0u8);
+            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())?;
 
             let elements: Vec<u8> = (0..4).map(|i| i as u8).collect();
             let bytes = u8::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
-            let encoded = codec.encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )?;
+            let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
             assert!((encoded.len() as u64) <= (4 * 4).div_ceil(&8) + 1);
 
             // Decoding
             let decoded = codec
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(elements, u8::from_array_bytes(&data_type, decoded)?);
         }
@@ -341,33 +287,22 @@ mod tests {
             PackBitsPaddingEncoding::FirstByte,
             PackBitsPaddingEncoding::LastByte,
         ] {
-            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let chunk_shape = vec![NonZeroU64::new(16).unwrap(), NonZeroU64::new(1).unwrap()];
             let data_type = data_type::uint4();
             let fill_value = FillValue::from(0u8);
+            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())?;
 
             let elements: Vec<u8> = (0..16).map(|i| i as u8).collect();
             let bytes = u8::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
-            let encoded = codec.encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )?;
+            let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
             assert!((encoded.len() as u64) <= (4 * 16).div_ceil(&8) + 1);
 
             // Decoding
             let decoded = codec
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(elements, u8::from_array_bytes(&data_type, decoded)?);
         }
@@ -381,33 +316,22 @@ mod tests {
             PackBitsPaddingEncoding::FirstByte,
             PackBitsPaddingEncoding::LastByte,
         ] {
-            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let chunk_shape = vec![NonZeroU64::new(4).unwrap(), NonZeroU64::new(1).unwrap()];
             let data_type = data_type::int2();
             let fill_value = FillValue::from(0i8);
+            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())?;
 
             let elements: Vec<i8> = (-2..2).map(|i| i as i8).collect();
             let bytes = i8::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
-            let encoded = codec.encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )?;
+            let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
             assert!((encoded.len() as u64) <= (4 * 4).div_ceil(&8) + 1);
 
             // Decoding
             let decoded = codec
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(elements, i8::from_array_bytes(&data_type, decoded)?);
         }
@@ -421,33 +345,22 @@ mod tests {
             PackBitsPaddingEncoding::FirstByte,
             PackBitsPaddingEncoding::LastByte,
         ] {
-            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let chunk_shape = vec![NonZeroU64::new(16).unwrap(), NonZeroU64::new(1).unwrap()];
             let data_type = data_type::int4();
             let fill_value = FillValue::from(0i8);
+            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())?;
 
             let elements: Vec<i8> = (-8..8).map(|i| i as i8).collect();
             let bytes = i8::to_array_bytes(&data_type, &elements)?.into_owned();
 
             // Encoding
-            let encoded = codec.encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )?;
+            let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
             assert!((encoded.len() as u64) <= (4 * 16).div_ceil(&8) + 1);
 
             // Decoding
             let decoded = codec
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(elements, i8::from_array_bytes(&data_type, decoded)?);
         }
@@ -461,32 +374,21 @@ mod tests {
             PackBitsPaddingEncoding::FirstByte,
             PackBitsPaddingEncoding::LastByte,
         ] {
-            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let chunk_shape = vec![NonZeroU64::new(16).unwrap(), NonZeroU64::new(1).unwrap()];
             let data_type = data_type::float4_e2m1fn();
             let fill_value = FillValue::from(0u8);
+            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())?;
 
             let bytes = ArrayBytes::new_flen((0..16).map(|i| i as u8).collect::<Vec<u8>>());
 
             // Encoding
-            let encoded = codec.encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )?;
+            let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
             assert!((encoded.len() as u64) <= (4 * 16).div_ceil(&8) + 1);
 
             // Decoding
             let decoded = codec
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(bytes, decoded);
         }
@@ -500,32 +402,21 @@ mod tests {
             PackBitsPaddingEncoding::FirstByte,
             PackBitsPaddingEncoding::LastByte,
         ] {
-            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let chunk_shape = vec![NonZeroU64::new(64).unwrap(), NonZeroU64::new(1).unwrap()];
             let data_type = data_type::float6_e2m3fn();
             let fill_value = FillValue::from(0u8);
+            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())?;
 
             let bytes = ArrayBytes::new_flen((0..64).map(|i| i as u8).collect::<Vec<u8>>());
 
             // Encoding
-            let encoded = codec.encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )?;
+            let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
             assert!((encoded.len() as u64) <= (6 * 64).div_ceil(&8) + 1);
 
             // Decoding
             let decoded = codec
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(bytes, decoded);
         }
@@ -539,32 +430,21 @@ mod tests {
             PackBitsPaddingEncoding::FirstByte,
             PackBitsPaddingEncoding::LastByte,
         ] {
-            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let chunk_shape = vec![NonZeroU64::new(64).unwrap(), NonZeroU64::new(1).unwrap()];
             let data_type = data_type::float6_e3m2fn();
             let fill_value = FillValue::from(0u8);
+            let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap())
+                .with_context(data_type.clone(), fill_value.clone())?;
 
             let bytes = ArrayBytes::new_flen((0..64).map(|i| i as u8).collect::<Vec<u8>>());
 
             // Encoding
-            let encoded = codec.encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )?;
+            let encoded = codec.encode(bytes.clone(), &chunk_shape, &CodecOptions::default())?;
             assert!((encoded.len() as u64) <= (6 * 64).div_ceil(&8) + 1);
 
             // Decoding
             let decoded = codec
-                .decode(
-                    encoded.clone(),
-                    &chunk_shape,
-                    &data_type,
-                    &fill_value,
-                    &CodecOptions::default(),
-                )
+                .decode(encoded.clone(), &chunk_shape, &CodecOptions::default())
                 .unwrap();
             assert_eq!(bytes, decoded);
         }

--- a/zarrs/src/array/codec/array_to_bytes/packbits.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits.rs
@@ -98,7 +98,7 @@ mod tests {
     use crate::array::codec::BytesCodec;
     use crate::array::element::{Element, ElementOwned};
     use crate::array::{ArrayBytes, ArraySubset, data_type};
-    use zarrs_codec::{ArrayToBytesCodecTraits, BytesPartialDecoderTraits, CodecOptions};
+    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
     use zarrs_metadata_ext::codec::packbits::PackBitsPaddingEncoding;
 
     #[test]

--- a/zarrs/src/array/codec/array_to_bytes/packbits.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits.rs
@@ -62,7 +62,8 @@ pub use zarrs_data_type::codec_traits::packbits::{
     impl_pack_bits_data_type_traits,
 };
 
-struct PackBitsCodecComponents {
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PackBitsCodecComponents {
     pub component_size_bits: u64,
     pub num_components: u64,
     pub sign_extension: bool,
@@ -174,6 +175,17 @@ mod tests {
             assert_eq!(answer, decoded_partial_chunk);
         }
         Ok(())
+    }
+
+    #[test]
+    fn codec_packbits_rejects_out_of_range_last_bit_when_bound() {
+        let data_type = data_type::uint2();
+        let fill_value = FillValue::from(0u8);
+        let codec = Arc::new(
+            super::PackBitsCodec::new(PackBitsPaddingEncoding::None, None, Some(2)).unwrap(),
+        );
+
+        assert!(codec.with_context(data_type, fill_value).is_err());
     }
 
     #[test]

--- a/zarrs/src/array/codec/array_to_bytes/packbits.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits.rs
@@ -39,7 +39,6 @@ use zarrs_codec::{Codec, CodecPluginV3, CodecTraitsV3};
 pub use zarrs_metadata_ext::codec::packbits::{
     PackBitsCodecConfiguration, PackBitsCodecConfigurationV1,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(PackBitsCodec, v3: "packbits");
 
@@ -49,7 +48,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for PackBitsCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: PackBitsCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(PackBitsCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToBytes(codec))

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
@@ -24,10 +24,10 @@ use crate::array::{
 };
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, InvalidBytesLengthError,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
-    UnboundArrayToBytesCodecTraits,
+    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
+    BytesPartialDecoderTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    InvalidBytesLengthError, PartialDecoderCapability, PartialEncoderCapability,
+    RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
@@ -40,6 +40,14 @@ pub struct PackBitsCodec {
     padding_encoding: PackBitsPaddingEncoding,
     first_bit: Option<u64>,
     last_bit: Option<u64>,
+}
+
+/// A `packbits` codec implementation bound to a data type and fill value.
+#[derive(Debug, Clone)]
+struct PackBitsCodecBound {
+    codec: Arc<PackBitsCodec>,
+    data_type: DataType,
+    fill_value: FillValue,
 }
 
 impl Default for PackBitsCodec {
@@ -132,16 +140,6 @@ impl CodecTraits for PackBitsCodec {
     }
 }
 
-impl ArrayCodecTraits for PackBitsCodec {
-    fn recommended_concurrency(
-        &self,
-        _shape: &[NonZeroU64],
-        _data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        Ok(RecommendedConcurrency::new_maximum(1))
-    }
-}
-
 #[cfg_attr(
     all(feature = "async", not(target_arch = "wasm32")),
     async_trait::async_trait
@@ -152,32 +150,67 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
         self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        pack_bits_components(&data_type)?;
+        Ok(Arc::new(PackBitsCodecBound {
+            codec: self,
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for PackBitsCodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn recommended_concurrency(
+        &self,
+        _shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        Ok(RecommendedConcurrency::new_maximum(1))
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToBytesCodecTraits for PackBitsCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self as Arc<dyn ArrayToBytesCodecTraits>
+    }
+
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
         let PackBitsCodecComponents {
             component_size_bits,
             num_components,
             sign_extension: _,
-        } = pack_bits_components(data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = pack_bits_components(&self.data_type)?;
+        let first_bit = self.codec.first_bit.unwrap_or(0);
+        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
             // Data types are expected to support the bytes codec if their component size in bits is a multiple of 8.
-            return BytesCodec::new(Some(Endianness::Little)).encode(
-                bytes.clone(),
-                shape,
-                data_type,
-                fill_value,
-                options,
-            );
+            return Arc::new(BytesCodec::new(Some(Endianness::Little)))
+                .with_context(self.data_type.clone(), self.fill_value.clone())?
+                .encode(bytes.clone(), shape, options);
         }
 
         // Get the component and element size in bits
@@ -189,7 +222,7 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
 
         // Input checks
         let bytes = bytes.into_fixed()?;
-        let data_type_size_dec = data_type.fixed_size().ok_or_else(|| {
+        let data_type_size_dec = self.data_type.fixed_size().ok_or_else(|| {
             CodecError::Other("data type must have a fixed size for the packbits codec".to_string())
         })?;
         if bytes.len() as u64 != num_elements * data_type_size_dec as u64 {
@@ -201,7 +234,7 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
         }
 
         // Allocate the output
-        let padding_encoding_byte = match self.padding_encoding {
+        let padding_encoding_byte = match self.codec.padding_encoding {
             PackBitsPaddingEncoding::None => 0,
             PackBitsPaddingEncoding::FirstByte | PackBitsPaddingEncoding::LastByte => 1,
         };
@@ -209,7 +242,7 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
 
         // Set the padding encoding byte and grab the element bytes
         let padding_bits = padding_bits(num_elements, element_size_bits);
-        let packed_elements = match self.padding_encoding {
+        let packed_elements = match self.codec.padding_encoding {
             PackBitsPaddingEncoding::None => &mut bytes_enc[..],
             PackBitsPaddingEncoding::FirstByte => {
                 bytes_enc[0] = padding_bits;
@@ -240,28 +273,22 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
         &self,
         bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         let PackBitsCodecComponents {
             component_size_bits,
             num_components,
             sign_extension,
-        } = pack_bits_components(data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = pack_bits_components(&self.data_type)?;
+        let first_bit = self.codec.first_bit.unwrap_or(0);
+        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
             // Data types are expected to support the bytes codec if their element size in bits is a multiple of 8.
-            return BytesCodec::new(Some(Endianness::Little)).decode(
-                bytes.clone(),
-                shape,
-                data_type,
-                fill_value,
-                options,
-            );
+            return Arc::new(BytesCodec::new(Some(Endianness::Little)))
+                .with_context(self.data_type.clone(), self.fill_value.clone())?
+                .decode(bytes.clone(), shape, options);
         }
 
         // Get the component and element size in bits
@@ -272,11 +299,11 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
             usize::try_from((num_elements * element_size_bits).div_ceil(8)).unwrap();
 
         // Input checks
-        let data_type_size_dec = data_type.fixed_size().ok_or_else(|| {
+        let data_type_size_dec = self.data_type.fixed_size().ok_or_else(|| {
             CodecError::Other("data type must have a fixed size for packbits codec".to_string())
         })?;
         let expected_length = elements_size_bytes
-            + match self.padding_encoding {
+            + match self.codec.padding_encoding {
                 PackBitsPaddingEncoding::None => 0,
                 PackBitsPaddingEncoding::FirstByte | PackBitsPaddingEncoding::LastByte => 1,
             };
@@ -285,7 +312,7 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
         }
 
         let padding_bits = padding_bits(num_elements, element_size_bits);
-        let packed_elements = match self.padding_encoding {
+        let packed_elements = match self.codec.padding_encoding {
             PackBitsPaddingEncoding::None => &bytes[..],
             PackBitsPaddingEncoding::FirstByte => {
                 if bytes[0] != padding_bits {
@@ -349,17 +376,15 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         let PackBitsCodecComponents {
             component_size_bits,
             num_components: _,
             sign_extension: _,
-        } = pack_bits_components(data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = pack_bits_components(&self.data_type)?;
+        let first_bit = self.codec.first_bit.unwrap_or(0);
+        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -367,19 +392,19 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
             Ok(Arc::new(BytesCodecPartial::new(
                 input_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 Some(Endianness::Little),
             )))
         } else {
             Ok(Arc::new(PackBitsPartialDecoder::new(
                 input_handle,
                 shape.to_vec(),
-                data_type.clone(),
-                fill_value.clone(),
-                self.padding_encoding,
-                self.first_bit,
-                self.last_bit,
+                self.data_type.clone(),
+                self.fill_value.clone(),
+                self.codec.padding_encoding,
+                self.codec.first_bit,
+                self.codec.last_bit,
             )))
         }
     }
@@ -389,17 +414,15 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         let PackBitsCodecComponents {
             component_size_bits,
             num_components: _,
             sign_extension: _,
-        } = pack_bits_components(data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = pack_bits_components(&self.data_type)?;
+        let first_bit = self.codec.first_bit.unwrap_or(0);
+        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -407,19 +430,19 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
             Ok(Arc::new(BytesCodecPartial::new(
                 input_handle,
                 shape,
-                data_type,
-                fill_value,
+                &self.data_type,
+                &self.fill_value,
                 Some(Endianness::Little),
             )))
         } else {
             Ok(Arc::new(AsyncPackBitsPartialDecoder::new(
                 input_handle,
                 shape.to_vec(),
-                data_type.clone(),
-                fill_value.clone(),
-                self.padding_encoding,
-                self.first_bit,
-                self.last_bit,
+                self.data_type.clone(),
+                self.fill_value.clone(),
+                self.codec.padding_encoding,
+                self.codec.first_bit,
+                self.codec.last_bit,
             )))
         }
     }
@@ -427,23 +450,21 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
     fn encoded_representation(
         &self,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
     ) -> Result<BytesRepresentation, CodecError> {
         let PackBitsCodecComponents {
             component_size_bits,
             num_components,
             sign_extension: _,
-        } = pack_bits_components(data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = pack_bits_components(&self.data_type)?;
+        let first_bit = self.codec.first_bit.unwrap_or(0);
+        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
 
         let num_elements = shape.num_elements_u64();
         let component_size_bits_extracted = last_bit - first_bit + 1;
         let element_size_bits = component_size_bits_extracted * num_components;
         let elements_size_bytes = (num_elements * element_size_bits).div_ceil(8);
 
-        let padding_encoding_byte = match self.padding_encoding {
+        let padding_encoding_byte = match self.codec.padding_encoding {
             PackBitsPaddingEncoding::None => 0,
             PackBitsPaddingEncoding::FirstByte | PackBitsPaddingEncoding::LastByte => 1,
         };

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
@@ -46,8 +46,9 @@ pub struct PackBitsCodec {
 #[derive(Debug, Clone)]
 struct PackBitsCodecBound {
     padding_encoding: PackBitsPaddingEncoding,
-    first_bit: Option<u64>,
-    last_bit: Option<u64>,
+    components: PackBitsCodecComponents,
+    first_bit: u64,
+    last_bit: u64,
     data_type: DataType,
     fill_value: FillValue,
 }
@@ -153,11 +154,26 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
         data_type: DataType,
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
-        pack_bits_components(&data_type)?;
+        let components = pack_bits_components(&data_type)?;
+        let first_bit = self.first_bit.unwrap_or(0);
+        let last_bit = self.last_bit.unwrap_or(components.component_size_bits - 1);
+
+        if last_bit < first_bit {
+            return Err(CodecError::Other(
+                "packbits codec `last_bit` is less than `first_bit`".to_string(),
+            ));
+        }
+        if last_bit >= components.component_size_bits {
+            return Err(CodecError::Other(
+                "packbits codec `last_bit` is outside the data type component".to_string(),
+            ));
+        }
+
         Ok(Arc::new(PackBitsCodecBound {
             padding_encoding: self.padding_encoding,
-            first_bit: self.first_bit,
-            last_bit: self.last_bit,
+            components,
+            first_bit,
+            last_bit,
             data_type,
             fill_value,
         }))
@@ -205,9 +221,9 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             component_size_bits,
             num_components,
             sign_extension: _,
-        } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = self.components;
+        let first_bit = self.first_bit;
+        let last_bit = self.last_bit;
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -283,9 +299,9 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             component_size_bits,
             num_components,
             sign_extension,
-        } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = self.components;
+        let first_bit = self.first_bit;
+        let last_bit = self.last_bit;
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -386,9 +402,9 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             component_size_bits,
             num_components: _,
             sign_extension: _,
-        } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = self.components;
+        let first_bit = self.first_bit;
+        let last_bit = self.last_bit;
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -407,6 +423,7 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
                 self.data_type.clone(),
                 self.fill_value.clone(),
                 self.padding_encoding,
+                self.components,
                 self.first_bit,
                 self.last_bit,
             )))
@@ -424,9 +441,9 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             component_size_bits,
             num_components: _,
             sign_extension: _,
-        } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = self.components;
+        let first_bit = self.first_bit;
+        let last_bit = self.last_bit;
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -445,6 +462,7 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
                 self.data_type.clone(),
                 self.fill_value.clone(),
                 self.padding_encoding,
+                self.components,
                 self.first_bit,
                 self.last_bit,
             )))
@@ -456,12 +474,12 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         shape: &[NonZeroU64],
     ) -> Result<BytesRepresentation, CodecError> {
         let PackBitsCodecComponents {
-            component_size_bits,
+            component_size_bits: _,
             num_components,
             sign_extension: _,
-        } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.first_bit.unwrap_or(0);
-        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
+        } = self.components;
+        let first_bit = self.first_bit;
+        let last_bit = self.last_bit;
 
         let num_elements = shape.num_elements_u64();
         let component_size_bits_extracted = last_bit - first_bit + 1;

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
@@ -406,7 +406,10 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         let last_bit = self.last_bit;
 
         // Bytes codec fast path
-        if component_size_bits.is_multiple_of(8) && first_bit == 0 && last_bit == component_size_bits - 1 {
+        if component_size_bits.is_multiple_of(8)
+            && first_bit == 0
+            && last_bit == component_size_bits - 1
+        {
             // Data types are expected to support the bytes codec if their element size in bits is a multiple of 8.
             Ok(Arc::new(BytesCodecPartial::new(
                 input_handle,

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
@@ -111,10 +111,6 @@ impl PackBitsCodec {
 }
 
 impl CodecTraits for PackBitsCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
@@ -24,10 +24,10 @@ use crate::array::{
 };
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-    BytesPartialDecoderTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    InvalidBytesLengthError, PartialDecoderCapability, PartialEncoderCapability,
-    RecommendedConcurrency,
+    ArrayCodecTraits, ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, InvalidBytesLengthError,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
@@ -147,9 +147,9 @@ impl ArrayCodecTraits for PackBitsCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for PackBitsCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
@@ -226,7 +226,10 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         let last_bit = self.last_bit;
 
         // Bytes codec fast path
-        if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
+        if component_size_bits.is_multiple_of(8)
+            && first_bit == 0
+            && last_bit == component_size_bits - 1
+        {
             // Data types are expected to support the bytes codec if their component size in bits is a multiple of 8.
             return Arc::new(BytesCodec::new(Some(Endianness::Little)))
                 .with_context(self.data_type.clone(), self.fill_value.clone())?
@@ -398,16 +401,12 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         shape: &[NonZeroU64],
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-        let PackBitsCodecComponents {
-            component_size_bits,
-            num_components: _,
-            sign_extension: _,
-        } = self.components;
+        let component_size_bits = self.components.component_size_bits;
         let first_bit = self.first_bit;
         let last_bit = self.last_bit;
 
         // Bytes codec fast path
-        if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
+        if component_size_bits.is_multiple_of(8) && first_bit == 0 && last_bit == component_size_bits - 1 {
             // Data types are expected to support the bytes codec if their element size in bits is a multiple of 8.
             Ok(Arc::new(BytesCodecPartial::new(
                 input_handle,
@@ -437,16 +436,15 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         shape: &[NonZeroU64],
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
-        let PackBitsCodecComponents {
-            component_size_bits,
-            num_components: _,
-            sign_extension: _,
-        } = self.components;
+        let component_size_bits = self.components.component_size_bits;
         let first_bit = self.first_bit;
         let last_bit = self.last_bit;
 
         // Bytes codec fast path
-        if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
+        if component_size_bits.is_multiple_of(8)
+            && first_bit == 0
+            && last_bit == component_size_bits - 1
+        {
             // Data types are expected to support the bytes codec if their element size in bits is a multiple of 8.
             Ok(Arc::new(BytesCodecPartial::new(
                 input_handle,
@@ -473,11 +471,7 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         &self,
         shape: &[NonZeroU64],
     ) -> Result<BytesRepresentation, CodecError> {
-        let PackBitsCodecComponents {
-            component_size_bits: _,
-            num_components,
-            sign_extension: _,
-        } = self.components;
+        let num_components = self.components.num_components;
         let first_bit = self.first_bit;
         let last_bit = self.last_bit;
 

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
@@ -25,8 +25,8 @@ use crate::array::{
 use std::num::NonZeroU64;
 use zarrs_codec::{
     ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-    BytesPartialDecoderTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    InvalidBytesLengthError, PartialDecoderCapability, PartialEncoderCapability,
+    BytesPartialDecoderTraits, CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, InvalidBytesLengthError, PartialDecoderCapability, PartialEncoderCapability,
     RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
@@ -153,18 +153,18 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         let components = pack_bits_components(&data_type)?;
         let first_bit = self.first_bit.unwrap_or(0);
         let last_bit = self.last_bit.unwrap_or(components.component_size_bits - 1);
 
         if last_bit < first_bit {
-            return Err(CodecError::Other(
+            return Err(CodecCreateError::Other(
                 "packbits codec `last_bit` is less than `first_bit`".to_string(),
             ));
         }
         if last_bit >= components.component_size_bits {
-            return Err(CodecError::Other(
+            return Err(CodecCreateError::Other(
                 "packbits codec `last_bit` is outside the data type component".to_string(),
             ));
         }
@@ -232,7 +232,8 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         {
             // Data types are expected to support the bytes codec if their component size in bits is a multiple of 8.
             return Arc::new(BytesCodec::new(Some(Endianness::Little)))
-                .with_context(self.data_type.clone(), self.fill_value.clone())?
+                .with_context(self.data_type.clone(), self.fill_value.clone())
+                .map_err(|err| CodecError::Other(err.to_string()))?
                 .encode(bytes.clone(), shape, options);
         }
 
@@ -310,7 +311,8 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
             // Data types are expected to support the bytes codec if their element size in bits is a multiple of 8.
             return Arc::new(BytesCodec::new(Some(Endianness::Little)))
-                .with_context(self.data_type.clone(), self.fill_value.clone())?
+                .with_context(self.data_type.clone(), self.fill_value.clone())
+                .map_err(|err| CodecError::Other(err.to_string()))?
                 .decode(bytes.clone(), shape, options);
         }
 

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_codec.rs
@@ -45,7 +45,9 @@ pub struct PackBitsCodec {
 /// A `packbits` codec implementation bound to a data type and fill value.
 #[derive(Debug, Clone)]
 struct PackBitsCodecBound {
-    codec: Arc<PackBitsCodec>,
+    padding_encoding: PackBitsPaddingEncoding,
+    first_bit: Option<u64>,
+    last_bit: Option<u64>,
     data_type: DataType,
     fill_value: FillValue,
 }
@@ -157,7 +159,9 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
     ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
         pack_bits_components(&data_type)?;
         Ok(Arc::new(PackBitsCodecBound {
-            codec: self,
+            padding_encoding: self.padding_encoding,
+            first_bit: self.first_bit,
+            last_bit: self.last_bit,
             data_type,
             fill_value,
         }))
@@ -165,6 +169,10 @@ impl UnboundArrayToBytesCodecTraits for PackBitsCodec {
 }
 
 impl ArrayCodecTraits for PackBitsCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }
@@ -202,8 +210,8 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             num_components,
             sign_extension: _,
         } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.codec.first_bit.unwrap_or(0);
-        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
+        let first_bit = self.first_bit.unwrap_or(0);
+        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -234,7 +242,7 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         }
 
         // Allocate the output
-        let padding_encoding_byte = match self.codec.padding_encoding {
+        let padding_encoding_byte = match self.padding_encoding {
             PackBitsPaddingEncoding::None => 0,
             PackBitsPaddingEncoding::FirstByte | PackBitsPaddingEncoding::LastByte => 1,
         };
@@ -242,7 +250,7 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
 
         // Set the padding encoding byte and grab the element bytes
         let padding_bits = padding_bits(num_elements, element_size_bits);
-        let packed_elements = match self.codec.padding_encoding {
+        let packed_elements = match self.padding_encoding {
             PackBitsPaddingEncoding::None => &mut bytes_enc[..],
             PackBitsPaddingEncoding::FirstByte => {
                 bytes_enc[0] = padding_bits;
@@ -280,8 +288,8 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             num_components,
             sign_extension,
         } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.codec.first_bit.unwrap_or(0);
-        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
+        let first_bit = self.first_bit.unwrap_or(0);
+        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -303,7 +311,7 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             CodecError::Other("data type must have a fixed size for packbits codec".to_string())
         })?;
         let expected_length = elements_size_bytes
-            + match self.codec.padding_encoding {
+            + match self.padding_encoding {
                 PackBitsPaddingEncoding::None => 0,
                 PackBitsPaddingEncoding::FirstByte | PackBitsPaddingEncoding::LastByte => 1,
             };
@@ -312,7 +320,7 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
         }
 
         let padding_bits = padding_bits(num_elements, element_size_bits);
-        let packed_elements = match self.codec.padding_encoding {
+        let packed_elements = match self.padding_encoding {
             PackBitsPaddingEncoding::None => &bytes[..],
             PackBitsPaddingEncoding::FirstByte => {
                 if bytes[0] != padding_bits {
@@ -383,8 +391,8 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             num_components: _,
             sign_extension: _,
         } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.codec.first_bit.unwrap_or(0);
-        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
+        let first_bit = self.first_bit.unwrap_or(0);
+        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -402,9 +410,9 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
                 shape.to_vec(),
                 self.data_type.clone(),
                 self.fill_value.clone(),
-                self.codec.padding_encoding,
-                self.codec.first_bit,
-                self.codec.last_bit,
+                self.padding_encoding,
+                self.first_bit,
+                self.last_bit,
             )))
         }
     }
@@ -421,8 +429,8 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             num_components: _,
             sign_extension: _,
         } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.codec.first_bit.unwrap_or(0);
-        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
+        let first_bit = self.first_bit.unwrap_or(0);
+        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
 
         // Bytes codec fast path
         if component_size_bits % 8 == 0 && first_bit == 0 && last_bit == component_size_bits - 1 {
@@ -440,9 +448,9 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
                 shape.to_vec(),
                 self.data_type.clone(),
                 self.fill_value.clone(),
-                self.codec.padding_encoding,
-                self.codec.first_bit,
-                self.codec.last_bit,
+                self.padding_encoding,
+                self.first_bit,
+                self.last_bit,
             )))
         }
     }
@@ -456,15 +464,15 @@ impl ArrayToBytesCodecTraits for PackBitsCodecBound {
             num_components,
             sign_extension: _,
         } = pack_bits_components(&self.data_type)?;
-        let first_bit = self.codec.first_bit.unwrap_or(0);
-        let last_bit = self.codec.last_bit.unwrap_or(component_size_bits - 1);
+        let first_bit = self.first_bit.unwrap_or(0);
+        let last_bit = self.last_bit.unwrap_or(component_size_bits - 1);
 
         let num_elements = shape.num_elements_u64();
         let component_size_bits_extracted = last_bit - first_bit + 1;
         let element_size_bits = component_size_bits_extracted * num_components;
         let elements_size_bytes = (num_elements * element_size_bits).div_ceil(8);
 
-        let padding_encoding_byte = match self.codec.padding_encoding {
+        let padding_encoding_byte = match self.padding_encoding {
             PackBitsPaddingEncoding::None => 0,
             PackBitsPaddingEncoding::FirstByte | PackBitsPaddingEncoding::LastByte => 1,
         };

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
@@ -9,7 +9,7 @@ use num::Integer;
 use std::num::NonZeroU64;
 
 use super::PackBitsCodecComponents;
-use crate::array::codec::array_to_bytes::packbits::{div_rem_8bit, pack_bits_components};
+use crate::array::codec::array_to_bytes::packbits::div_rem_8bit;
 use crate::array::{ArrayBytes, ChunkShape, DataType, FillValue};
 use zarrs_codec::{ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError, CodecOptions};
 #[cfg(feature = "async")]
@@ -28,8 +28,9 @@ use zarrs_storage::byte_range::ByteRange;
     data_type: &DataType,
     fill_value: &FillValue,
     padding_encoding: PackBitsPaddingEncoding,
-    first_bit: Option<u64>,
-    last_bit: Option<u64>,
+    components: PackBitsCodecComponents,
+    first_bit: u64,
+    last_bit: u64,
     indexer: &dyn crate::array::Indexer,
     options: &CodecOptions,
 )))]
@@ -39,8 +40,9 @@ fn partial_decode<'a>(
     data_type: &DataType,
     fill_value: &FillValue,
     padding_encoding: PackBitsPaddingEncoding,
-    first_bit: Option<u64>,
-    last_bit: Option<u64>,
+    components: PackBitsCodecComponents,
+    first_bit: u64,
+    last_bit: u64,
     indexer: &dyn crate::array::Indexer,
     options: &CodecOptions,
 ) -> Result<ArrayBytes<'a>, CodecError> {
@@ -48,9 +50,7 @@ fn partial_decode<'a>(
         component_size_bits,
         num_components,
         sign_extension,
-    } = pack_bits_components(data_type)?;
-    let first_bit = first_bit.unwrap_or(0);
-    let last_bit = last_bit.unwrap_or(component_size_bits - 1);
+    } = components;
 
     // Get the component and element size in bits
     let component_size_bits_extracted = last_bit - first_bit + 1;
@@ -151,8 +151,9 @@ pub(crate) struct PackBitsPartialDecoder {
     data_type: DataType,
     fill_value: FillValue,
     padding_encoding: PackBitsPaddingEncoding,
-    first_bit: Option<u64>,
-    last_bit: Option<u64>,
+    components: PackBitsCodecComponents,
+    first_bit: u64,
+    last_bit: u64,
 }
 
 impl PackBitsPartialDecoder {
@@ -163,8 +164,9 @@ impl PackBitsPartialDecoder {
         data_type: DataType,
         fill_value: FillValue,
         padding_encoding: PackBitsPaddingEncoding,
-        first_bit: Option<u64>,
-        last_bit: Option<u64>,
+        components: PackBitsCodecComponents,
+        first_bit: u64,
+        last_bit: u64,
     ) -> Self {
         Self {
             input_handle,
@@ -172,6 +174,7 @@ impl PackBitsPartialDecoder {
             data_type,
             fill_value,
             padding_encoding,
+            components,
             first_bit,
             last_bit,
         }
@@ -202,6 +205,7 @@ impl ArrayPartialDecoderTraits for PackBitsPartialDecoder {
             &self.data_type,
             &self.fill_value,
             self.padding_encoding,
+            self.components,
             self.first_bit,
             self.last_bit,
             indexer,
@@ -222,8 +226,9 @@ pub(crate) struct AsyncPackBitsPartialDecoder {
     data_type: DataType,
     fill_value: FillValue,
     padding_encoding: PackBitsPaddingEncoding,
-    first_bit: Option<u64>,
-    last_bit: Option<u64>,
+    components: PackBitsCodecComponents,
+    first_bit: u64,
+    last_bit: u64,
 }
 
 #[cfg(feature = "async")]
@@ -235,8 +240,9 @@ impl AsyncPackBitsPartialDecoder {
         data_type: DataType,
         fill_value: FillValue,
         padding_encoding: PackBitsPaddingEncoding,
-        first_bit: Option<u64>,
-        last_bit: Option<u64>,
+        components: PackBitsCodecComponents,
+        first_bit: u64,
+        last_bit: u64,
     ) -> Self {
         Self {
             input_handle,
@@ -244,6 +250,7 @@ impl AsyncPackBitsPartialDecoder {
             data_type,
             fill_value,
             padding_encoding,
+            components,
             first_bit,
             last_bit,
         }
@@ -277,6 +284,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncPackBitsPartialDecoder {
             &self.data_type,
             &self.fill_value,
             self.padding_encoding,
+            self.components,
             self.first_bit,
             self.last_bit,
             indexer,

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
@@ -158,6 +158,7 @@ pub(crate) struct PackBitsPartialDecoder {
 
 impl PackBitsPartialDecoder {
     /// Create a new partial decoder for the `packbits` codec.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: ChunkShape,
@@ -234,6 +235,7 @@ pub(crate) struct AsyncPackBitsPartialDecoder {
 #[cfg(feature = "async")]
 impl AsyncPackBitsPartialDecoder {
     /// Create a new partial decoder for the `packbits` codec.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: ChunkShape,

--- a/zarrs/src/array/codec/array_to_bytes/pcodec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec.rs
@@ -98,7 +98,7 @@ mod tests {
         ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, DataType, FillValue, data_type,
         transmute_to_bytes_vec,
     };
-    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
+    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions};
 
     const JSON_VALID: &str = r#"{
         "level": 8,

--- a/zarrs/src/array/codec/array_to_bytes/pcodec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec.rs
@@ -98,7 +98,7 @@ mod tests {
         ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, DataType, FillValue, data_type,
         transmute_to_bytes_vec,
     };
-    use zarrs_codec::{ArrayToBytesCodecTraits, BytesPartialDecoderTraits, CodecOptions};
+    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
 
     const JSON_VALID: &str = r#"{
         "level": 8,

--- a/zarrs/src/array/codec/array_to_bytes/pcodec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec.rs
@@ -98,7 +98,7 @@ mod tests {
         ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, DataType, FillValue, data_type,
         transmute_to_bytes_vec,
     };
-    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions};
+    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
 
     const JSON_VALID: &str = r#"{
         "level": 8,
@@ -125,24 +125,16 @@ mod tests {
         let bytes: Vec<u8> = (0..size).map(|s| s as u8).collect();
         let bytes: ArrayBytes = bytes.into();
 
-        let max_encoded_size =
-            codec.encoded_representation(chunk_shape.as_slice(), &data_type, &fill_value)?;
+        let codec = Arc::new(codec.clone()).with_context(data_type.clone(), fill_value.clone())?;
+        let max_encoded_size = codec.encoded_representation(chunk_shape.as_slice())?;
         let encoded = codec.encode(
             bytes.clone(),
             chunk_shape.as_slice(),
-            &data_type,
-            &fill_value,
             &CodecOptions::default(),
         )?;
         assert!((encoded.len() as u64) <= max_encoded_size.size().unwrap());
         let decoded = codec
-            .decode(
-                encoded,
-                chunk_shape.as_slice(),
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded, chunk_shape.as_slice(), &CodecOptions::default())
             .unwrap();
         assert_eq!(bytes, decoded);
         Ok(())
@@ -330,27 +322,17 @@ mod tests {
         let codec = Arc::new(
             PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
-        );
+        )
+        .with_context(data_type.clone(), fill_value.clone())
+        .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..3, 0..1]);
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .partial_decoder(
-                input_handle.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // packbits partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
@@ -382,27 +364,17 @@ mod tests {
         let codec = Arc::new(
             PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
-        );
+        )
+        .with_context(data_type.clone(), fill_value.clone())
+        .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..3, 0..1]);
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .async_partial_decoder(
-                input_handle,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .async_partial_decoder(input_handle, &chunk_shape, &CodecOptions::default())
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder

--- a/zarrs/src/array/codec/array_to_bytes/pcodec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec.rs
@@ -50,7 +50,6 @@ pub use zarrs_metadata_ext::codec::pcodec::{
     PcodecCodecConfiguration, PcodecCodecConfigurationV1, PcodecCompressionLevel,
     PcodecDeltaEncodingOrder,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(PcodecCodec,
     v3: "numcodecs.pcodec", ["https://codec.zarrs.dev/array_to_bytes/pcodec"],
@@ -67,7 +66,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for PcodecCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration = metadata.to_typed_configuration()?;
         let codec = Arc::new(PcodecCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToBytes(codec))
@@ -75,7 +74,7 @@ impl CodecTraitsV3 for PcodecCodec {
 }
 
 impl CodecTraitsV2 for PcodecCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: PcodecCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(PcodecCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToBytes(codec))

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
@@ -98,10 +98,6 @@ impl PcodecCodec {
 }
 
 impl CodecTraits for PcodecCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
@@ -14,8 +14,8 @@ use crate::array::{
 };
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, BytesRepresentation, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, BytesRepresentation,
+    CodecError, CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
     PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::Configuration;
@@ -27,6 +27,14 @@ use zarrs_metadata_ext::codec::pcodec::{
 #[derive(Debug, Clone)]
 pub struct PcodecCodec {
     chunk_config: ChunkConfig,
+}
+
+/// A `pcodec` codec implementation bound to a data type and fill value.
+#[derive(Debug, Clone)]
+struct PcodecCodecBound {
+    chunk_config: ChunkConfig,
+    data_type: DataType,
+    fill_value: FillValue,
 }
 
 fn mode_spec_config_to_pco(mode_spec: PcodecModeSpecConfiguration) -> ModeSpec {
@@ -145,11 +153,41 @@ impl CodecTraits for PcodecCodec {
     }
 }
 
-impl ArrayCodecTraits for PcodecCodec {
+impl UnboundArrayToBytesCodecTraits for PcodecCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
+    }
+
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        data_type.codec_pcodec()?;
+        Ok(Arc::new(PcodecCodecBound {
+            chunk_config: self.chunk_config.clone(),
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for PcodecCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
     fn recommended_concurrency(
         &self,
         _shape: &[NonZeroU64],
-        _data_type: &DataType,
     ) -> Result<RecommendedConcurrency, CodecError> {
         // pcodec does not support parallel decode
         Ok(RecommendedConcurrency::new_maximum(1))
@@ -161,21 +199,19 @@ impl ArrayCodecTraits for PcodecCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl UnboundArrayToBytesCodecTraits for PcodecCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
-        self as Arc<dyn UnboundArrayToBytesCodecTraits>
+impl ArrayToBytesCodecTraits for PcodecCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self as Arc<dyn ArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
         // Get element type via codec support
-        let pcodec = data_type.codec_pcodec()?;
+        let pcodec = self.data_type.codec_pcodec()?;
         let element_type = pcodec.pcodec_element_type();
 
         let bytes = bytes.into_fixed()?;
@@ -207,12 +243,10 @@ impl UnboundArrayToBytesCodecTraits for PcodecCodec {
         &self,
         bytes: ArrayBytesRaw<'a>,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         // Get element type via codec support
-        let pcodec = data_type.codec_pcodec()?;
+        let pcodec = self.data_type.codec_pcodec()?;
         let element_type = pcodec.pcodec_element_type();
 
         macro_rules! pcodec_decode {
@@ -240,11 +274,9 @@ impl UnboundArrayToBytesCodecTraits for PcodecCodec {
     fn encoded_representation(
         &self,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
     ) -> Result<BytesRepresentation, CodecError> {
         // Get element type via codec support
-        let pcodec = data_type.codec_pcodec()?;
+        let pcodec = self.data_type.codec_pcodec()?;
         let element_type = pcodec.pcodec_element_type();
 
         let num_elements = shape.num_elements_usize() * pcodec.pcodec_elements_per_element();

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
@@ -33,6 +33,8 @@ pub struct PcodecCodec {
 #[derive(Debug, Clone)]
 struct PcodecCodecBound {
     chunk_config: ChunkConfig,
+    element_type: PcodecElementType,
+    elements_per_element: usize,
     data_type: DataType,
     fill_value: FillValue,
 }
@@ -159,9 +161,13 @@ impl UnboundArrayToBytesCodecTraits for PcodecCodec {
         data_type: DataType,
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
-        data_type.codec_pcodec()?;
+        let pcodec = data_type.codec_pcodec()?;
+        let element_type = pcodec.pcodec_element_type();
+        let elements_per_element = pcodec.pcodec_elements_per_element();
         Ok(Arc::new(PcodecCodecBound {
             chunk_config: self.chunk_config.clone(),
+            element_type,
+            elements_per_element,
             data_type,
             fill_value,
         }))
@@ -206,10 +212,6 @@ impl ArrayToBytesCodecTraits for PcodecCodecBound {
         _shape: &[NonZeroU64],
         _options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-        // Get element type via codec support
-        let pcodec = self.data_type.codec_pcodec()?;
-        let element_type = pcodec.pcodec_element_type();
-
         let bytes = bytes.into_fixed()?;
         macro_rules! pcodec_encode {
             ( $t:ty ) => {
@@ -222,7 +224,7 @@ impl ArrayToBytesCodecTraits for PcodecCodecBound {
             };
         }
 
-        match element_type {
+        match self.element_type {
             PcodecElementType::U16 => pcodec_encode!(u16),
             PcodecElementType::U32 => pcodec_encode!(u32),
             PcodecElementType::U64 => pcodec_encode!(u64),
@@ -241,10 +243,6 @@ impl ArrayToBytesCodecTraits for PcodecCodecBound {
         _shape: &[NonZeroU64],
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        // Get element type via codec support
-        let pcodec = self.data_type.codec_pcodec()?;
-        let element_type = pcodec.pcodec_element_type();
-
         macro_rules! pcodec_decode {
             ( $t:ty ) => {
                 pco::standalone::simple_decompress(&bytes)
@@ -253,7 +251,7 @@ impl ArrayToBytesCodecTraits for PcodecCodecBound {
             };
         }
 
-        let bytes = match element_type {
+        let bytes = match self.element_type {
             PcodecElementType::U16 => pcodec_decode!(u16),
             PcodecElementType::U32 => pcodec_decode!(u32),
             PcodecElementType::U64 => pcodec_decode!(u64),
@@ -271,13 +269,9 @@ impl ArrayToBytesCodecTraits for PcodecCodecBound {
         &self,
         shape: &[NonZeroU64],
     ) -> Result<BytesRepresentation, CodecError> {
-        // Get element type via codec support
-        let pcodec = self.data_type.codec_pcodec()?;
-        let element_type = pcodec.pcodec_element_type();
+        let num_elements = shape.num_elements_usize() * self.elements_per_element;
 
-        let num_elements = shape.num_elements_usize() * pcodec.pcodec_elements_per_element();
-
-        let size = match element_type {
+        let size = match self.element_type {
             PcodecElementType::U16 | PcodecElementType::I16 | PcodecElementType::F16 => {
                 file_size::<u16>(num_elements, &self.chunk_config.paging_spec)
                     .map_err(|err| CodecError::from(err.to_string()))?

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
@@ -14,9 +14,9 @@ use crate::array::{
 };
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, BytesRepresentation,
-    CodecError, CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency,
+    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, BytesRepresentation, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata_ext::codec::pcodec::{
@@ -161,9 +161,9 @@ impl ArrayCodecTraits for PcodecCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for PcodecCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for PcodecCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_codec.rs
@@ -15,8 +15,9 @@ use crate::array::{
 use std::num::NonZeroU64;
 use zarrs_codec::{
     ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, BytesRepresentation,
-    CodecError, CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
+    CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata_ext::codec::pcodec::{
@@ -160,7 +161,7 @@ impl UnboundArrayToBytesCodecTraits for PcodecCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         let pcodec = data_type.codec_pcodec()?;
         let element_type = pcodec.pcodec_element_type();
         let elements_per_element = pcodec.pcodec_elements_per_element();

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -131,8 +131,7 @@ fn compute_index_encoded_size(
     index_codecs: &CodecChainBound,
     sharding_index_shape: &[NonZeroU64],
 ) -> Result<u64, CodecError> {
-    let bytes_representation =
-        Arc::new(index_codecs.clone()).encoded_representation(sharding_index_shape)?;
+    let bytes_representation = index_codecs.encoded_representation(sharding_index_shape)?;
     match bytes_representation {
         BytesRepresentation::FixedSize(size) => Ok(size),
         BytesRepresentation::BoundedSize(_) | BytesRepresentation::UnboundedSize => {
@@ -150,11 +149,8 @@ fn decode_shard_index(
     options: &CodecOptions,
 ) -> Result<Vec<u64>, CodecError> {
     // Decode the shard index
-    let decoded_shard_index = Arc::new(index_codecs.clone()).decode(
-        Cow::Borrowed(encoded_shard_index),
-        index_shape,
-        options,
-    )?;
+    let decoded_shard_index =
+        index_codecs.decode(Cow::Borrowed(encoded_shard_index), index_shape, options)?;
     let decoded_shard_index = decoded_shard_index.into_fixed()?;
     Ok(decoded_shard_index
         .as_chunks::<8>()
@@ -287,8 +283,7 @@ mod tests {
     use crate::array::{ArrayBytes, ArraySubset, data_type};
     use zarrs_chunk_grid::Indexer;
     use zarrs_codec::{
-        ArrayCodecTraits, BytesToBytesCodecTraits, CodecSpecificOptions,
-        UnboundArrayToBytesCodecTraits,
+        BytesToBytesCodecTraits, CodecSpecificOptions, UnboundArrayToBytesCodecTraits,
     };
 
     fn get_concurrent_target(parallel: bool) -> usize {
@@ -883,7 +878,6 @@ mod tests {
         let codec = Arc::new(ShardingCodec::new_with_configuration(&codec_configuration).unwrap())
             .with_context(data_type.clone(), fill_value.clone())
             .unwrap();
-        let codec = codec.as_any().downcast_ref::<ShardingCodecBound>().unwrap();
 
         // Step 1: Fully encode the shard
         let original_encoded = codec
@@ -913,6 +907,7 @@ mod tests {
             let updated_elements: Vec<u16> = vec![100, 101, 102, 103]; // New values for this subchunk
             let updated_bytes = crate::array::transmute_to_bytes_vec(updated_elements);
             let partial_encoder = codec
+                .clone()
                 .partial_encoder(
                     input_output_handle.clone(),
                     &chunk_shape,

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -62,21 +62,22 @@ mod sharding_partial_encoder;
 pub(crate) use sharding_partial_decoder_async::AsyncShardingPartialDecoder;
 pub(crate) use sharding_partial_decoder_sync::ShardingPartialDecoder;
 
+
 use std::borrow::Cow;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use crate::array::concurrency::calc_concurrency_outer_inner;
 use crate::array::{
-    ArrayBytes, BytesRepresentation, ChunkShape, ChunkShapeTraits, CodecChain, DataType, FillValue,
+    ArrayBytes, BytesRepresentation, ChunkShape, ChunkShapeTraits, CodecChain, CodecChainBound, DataType, FillValue,
     RecommendedConcurrency, ravel_indices,
 };
 pub use sharding_codec::ShardingCodec;
+pub(crate) use sharding_codec::ShardingCodecBound;
 pub use sharding_codec_builder::ShardingCodecBuilder;
 pub use sharding_options::{ShardingCodecOptions, SubchunkWriteOrder};
 use zarrs_codec::{
-    ArrayCodecTraits, BytesPartialDecoderTraits, Codec, CodecError, CodecOptions, CodecPluginV3,
-    CodecTraitsV3, UnboundArrayToBytesCodecTraits,
+    ArrayCodecTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits, Codec, CodecError, CodecOptions, CodecPluginV3, CodecTraitsV3
 };
 use zarrs_metadata::v3::MetadataV3;
 pub use zarrs_metadata_ext::codec::sharding::{
@@ -127,14 +128,11 @@ fn sharding_index_shape(chunks_per_shard: &[NonZeroU64]) -> ChunkShape {
 }
 
 fn compute_index_encoded_size(
-    index_codecs: &dyn UnboundArrayToBytesCodecTraits,
+    index_codecs: &CodecChainBound,
     sharding_index_shape: &[NonZeroU64],
 ) -> Result<u64, CodecError> {
-    let bytes_representation = index_codecs.encoded_representation(
-        sharding_index_shape,
-        &crate::array::data_type::uint64(),
-        &FillValue::from(u64::MAX),
-    )?;
+    let bytes_representation = Arc::new(index_codecs.clone())
+        .encoded_representation(sharding_index_shape)?;
     match bytes_representation {
         BytesRepresentation::FixedSize(size) => Ok(size),
         BytesRepresentation::BoundedSize(_) | BytesRepresentation::UnboundedSize => {
@@ -148,17 +146,12 @@ fn compute_index_encoded_size(
 fn decode_shard_index(
     encoded_shard_index: &[u8],
     index_shape: &[NonZeroU64],
-    index_codecs: &dyn UnboundArrayToBytesCodecTraits,
+    index_codecs: &CodecChainBound,
     options: &CodecOptions,
 ) -> Result<Vec<u64>, CodecError> {
     // Decode the shard index
-    let decoded_shard_index = index_codecs.decode(
-        Cow::Borrowed(encoded_shard_index),
-        index_shape,
-        &crate::array::data_type::uint64(),
-        &FillValue::from(u64::MAX),
-        options,
-    )?;
+    let decoded_shard_index = Arc::new(index_codecs.clone())
+        .decode(Cow::Borrowed(encoded_shard_index), index_shape, options)?;
     let decoded_shard_index = decoded_shard_index.into_fixed()?;
     Ok(decoded_shard_index
         .as_chunks::<8>()
@@ -170,7 +163,7 @@ fn decode_shard_index(
 
 fn get_index_byte_range(
     index_shape: &[NonZeroU64],
-    index_codecs: &CodecChain,
+    index_codecs: &CodecChainBound,
     index_location: ShardingIndexLocation,
 ) -> Result<ByteRange, CodecError> {
     let index_encoded_size = compute_index_encoded_size(index_codecs, index_shape)
@@ -211,8 +204,7 @@ fn partial_decode_empty_shard<'a>(
 }
 
 fn get_concurrent_target_and_codec_options(
-    inner_codecs: &CodecChain,
-    data_type: &DataType,
+    inner_codecs: &CodecChainBound,
     subchunk_shape: &[NonZeroU64],
     chunks_per_shard: &[u64],
     options: &CodecOptions,
@@ -226,7 +218,7 @@ fn get_concurrent_target_and_codec_options(
             options.concurrent_target(),
             num_chunks,
         )),
-        &inner_codecs.recommended_concurrency(subchunk_shape, data_type)?,
+        &inner_codecs.recommended_concurrency(subchunk_shape)?,
     );
     let options = options.with_concurrent_target(concurrency_limit_codec);
     Ok((subchunk_concurrent_limit, options))
@@ -235,7 +227,7 @@ fn get_concurrent_target_and_codec_options(
 /// Returns `None` if there is no shard.
 fn decode_shard_index_partial_decoder(
     input_handle: &dyn BytesPartialDecoderTraits,
-    index_codecs: &CodecChain,
+    index_codecs: &CodecChainBound,
     index_location: ShardingIndexLocation,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
@@ -260,7 +252,7 @@ fn decode_shard_index_partial_decoder(
 /// Returns `None` if there is no shard.
 async fn decode_shard_index_async_partial_decoder(
     input_handle: &dyn zarrs_codec::AsyncBytesPartialDecoderTraits,
-    index_codecs: &CodecChain,
+    index_codecs: &CodecChainBound,
     index_location: ShardingIndexLocation,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
@@ -407,14 +399,15 @@ mod tests {
         if unbounded {
             bytes_to_bytes_codecs.push(Arc::new(TestUnboundedCodec::new()));
         }
-        let codec: ShardingCodec = ShardingCodecBuilder::new(subchunk_shape, &data_type::uint16())
+        let codec = ShardingCodecBuilder::new(subchunk_shape, &data_type::uint16())
             .index_location(if index_at_end {
                 ShardingIndexLocation::End
             } else {
                 ShardingIndexLocation::Start
             })
             .bytes_to_bytes_codecs(bytes_to_bytes_codecs)
-            .build();
+            .build()
+            .with_context(data_type, fill_value)?;
 
         let encoded = Arc::new(codec.clone())
             .with_codec_specific_options(&CodecSpecificOptions::default().with_option(
@@ -433,8 +426,6 @@ mod tests {
             .decode(
                 encoded.clone(),
                 &chunk_shape,
-                &data_type,
-                &fill_value,
                 options,
             )
             .unwrap();
@@ -583,13 +574,15 @@ mod tests {
                     ShardingIndexLocation::Start
                 })
                 .bytes_to_bytes_codecs(bytes_to_bytes_codecs)
-                .build();
+                .build()
+                .with_context(data_type, fill_value)
+                .unwrap();
 
         let encoded = codec
-            .encode(bytes.clone(), &shape, &data_type, &fill_value, options)
+            .encode(bytes.clone(), &shape, options)
             .unwrap();
         let decoded = codec
-            .decode(encoded.clone(), &shape, &data_type, &fill_value, options)
+            .decode(encoded.clone(), &shape, options)
             .unwrap();
         assert_eq!(bytes, decoded);
         assert_ne!(encoded, decoded.into_fixed().unwrap());
@@ -743,21 +736,19 @@ mod tests {
                 })
                 .bytes_to_bytes_codecs(bytes_to_bytes_codecs)
                 .build(),
-        );
+        ).with_context(data_type, fill_value)?;
 
         let encoded = codec
             .encode(
                 bytes.clone(),
                 &chunk_shape,
-                &data_type,
-                &fill_value,
                 options,
             )
             .unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..3, 0..1]);
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .async_partial_decoder(input_handle, &chunk_shape, &data_type, &fill_value, options)
+            .async_partial_decoder(input_handle, &chunk_shape, options)
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -83,7 +83,6 @@ use zarrs_metadata::v3::MetadataV3;
 pub use zarrs_metadata_ext::codec::sharding::{
     ShardingCodecConfiguration, ShardingCodecConfigurationV1, ShardingIndexLocation,
 };
-use zarrs_plugin::PluginCreateError;
 use zarrs_storage::byte_range::ByteRange;
 
 zarrs_plugin::impl_extension_aliases!(ShardingCodec, v3: "sharding_indexed");
@@ -94,7 +93,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for ShardingCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: ShardingCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(ShardingCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToBytes(codec))

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -62,22 +62,22 @@ mod sharding_partial_encoder;
 pub(crate) use sharding_partial_decoder_async::AsyncShardingPartialDecoder;
 pub(crate) use sharding_partial_decoder_sync::ShardingPartialDecoder;
 
-
 use std::borrow::Cow;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use crate::array::concurrency::calc_concurrency_outer_inner;
 use crate::array::{
-    ArrayBytes, BytesRepresentation, ChunkShape, ChunkShapeTraits, CodecChain, CodecChainBound, DataType, FillValue,
-    RecommendedConcurrency, ravel_indices,
+    ArrayBytes, BytesRepresentation, ChunkShape, ChunkShapeTraits, CodecChain, CodecChainBound,
+    DataType, FillValue, RecommendedConcurrency, ravel_indices,
 };
 pub use sharding_codec::ShardingCodec;
 pub(crate) use sharding_codec::ShardingCodecBound;
 pub use sharding_codec_builder::ShardingCodecBuilder;
 pub use sharding_options::{ShardingCodecOptions, SubchunkWriteOrder};
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits, Codec, CodecError, CodecOptions, CodecPluginV3, CodecTraitsV3
+    ArrayCodecTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits, Codec, CodecError,
+    CodecOptions, CodecPluginV3, CodecTraitsV3,
 };
 use zarrs_metadata::v3::MetadataV3;
 pub use zarrs_metadata_ext::codec::sharding::{
@@ -131,8 +131,8 @@ fn compute_index_encoded_size(
     index_codecs: &CodecChainBound,
     sharding_index_shape: &[NonZeroU64],
 ) -> Result<u64, CodecError> {
-    let bytes_representation = Arc::new(index_codecs.clone())
-        .encoded_representation(sharding_index_shape)?;
+    let bytes_representation =
+        Arc::new(index_codecs.clone()).encoded_representation(sharding_index_shape)?;
     match bytes_representation {
         BytesRepresentation::FixedSize(size) => Ok(size),
         BytesRepresentation::BoundedSize(_) | BytesRepresentation::UnboundedSize => {
@@ -150,8 +150,11 @@ fn decode_shard_index(
     options: &CodecOptions,
 ) -> Result<Vec<u64>, CodecError> {
     // Decode the shard index
-    let decoded_shard_index = Arc::new(index_codecs.clone())
-        .decode(Cow::Borrowed(encoded_shard_index), index_shape, options)?;
+    let decoded_shard_index = Arc::new(index_codecs.clone()).decode(
+        Cow::Borrowed(encoded_shard_index),
+        index_shape,
+        options,
+    )?;
     let decoded_shard_index = decoded_shard_index.into_fixed()?;
     Ok(decoded_shard_index
         .as_chunks::<8>()
@@ -423,11 +426,7 @@ mod tests {
             )
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded.clone(),
-                &chunk_shape,
-                options,
-            )
+            .decode(encoded.clone(), &chunk_shape, options)
             .unwrap();
         assert_eq!(bytes, decoded);
         assert_ne!(encoded, decoded.into_fixed().unwrap());
@@ -578,12 +577,8 @@ mod tests {
                 .with_context(data_type, fill_value)
                 .unwrap();
 
-        let encoded = codec
-            .encode(bytes.clone(), &shape, options)
-            .unwrap();
-        let decoded = codec
-            .decode(encoded.clone(), &shape, options)
-            .unwrap();
+        let encoded = codec.encode(bytes.clone(), &shape, options).unwrap();
+        let decoded = codec.decode(encoded.clone(), &shape, options).unwrap();
         assert_eq!(bytes, decoded);
         assert_ne!(encoded, decoded.into_fixed().unwrap());
     }
@@ -736,15 +731,10 @@ mod tests {
                 })
                 .bytes_to_bytes_codecs(bytes_to_bytes_codecs)
                 .build(),
-        ).with_context(data_type, fill_value)?;
+        )
+        .with_context(data_type, fill_value)?;
 
-        let encoded = codec
-            .encode(
-                bytes.clone(),
-                &chunk_shape,
-                options,
-            )
-            .unwrap();
+        let encoded = codec.encode(bytes.clone(), &chunk_shape, options).unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..3, 0..1]);
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -287,7 +287,8 @@ mod tests {
     use crate::array::{ArrayBytes, ArraySubset, data_type};
     use zarrs_chunk_grid::Indexer;
     use zarrs_codec::{
-        BytesToBytesCodecTraits, CodecSpecificOptions, UnboundArrayToBytesCodecTraits,
+        ArrayCodecTraits, BytesToBytesCodecTraits, CodecSpecificOptions,
+        UnboundArrayToBytesCodecTraits,
     };
 
     fn get_concurrent_target(parallel: bool) -> usize {
@@ -402,29 +403,24 @@ mod tests {
         if unbounded {
             bytes_to_bytes_codecs.push(Arc::new(TestUnboundedCodec::new()));
         }
-        let codec = ShardingCodecBuilder::new(subchunk_shape, &data_type::uint16())
-            .index_location(if index_at_end {
-                ShardingIndexLocation::End
-            } else {
-                ShardingIndexLocation::Start
-            })
-            .bytes_to_bytes_codecs(bytes_to_bytes_codecs)
-            .build()
-            .with_context(data_type, fill_value)?;
-
-        let encoded = Arc::new(codec.clone())
-            .with_codec_specific_options(&CodecSpecificOptions::default().with_option(
-                ShardingCodecOptions::default().with_subchunk_write_order(subchunk_write_order),
-            ))
-            .unwrap()
-            .encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                options,
-            )
-            .unwrap();
+        let codec = Arc::new(
+            ShardingCodecBuilder::new(subchunk_shape, &data_type::uint16())
+                .index_location(if index_at_end {
+                    ShardingIndexLocation::End
+                } else {
+                    ShardingIndexLocation::Start
+                })
+                .bytes_to_bytes_codecs(bytes_to_bytes_codecs)
+                .build(),
+        )
+        .with_codec_specific_options(&CodecSpecificOptions::default().with_option(
+            ShardingCodecOptions::default().with_subchunk_write_order(subchunk_write_order),
+        ))
+        .unwrap()
+        .with_context(data_type.clone(), fill_value.clone())
+        .unwrap();
+        let codec = codec.as_any().downcast_ref::<ShardingCodecBound>().unwrap();
+        let encoded = codec.encode(bytes.clone(), &chunk_shape, options).unwrap();
         let decoded = codec
             .decode(encoded.clone(), &chunk_shape, options)
             .unwrap();
@@ -643,21 +639,15 @@ mod tests {
                 })
                 .bytes_to_bytes_codecs(bytes_to_bytes_codecs)
                 .build(),
-        );
+        )
+        .with_context(data_type.clone(), fill_value.clone())
+        .unwrap();
 
-        let encoded = codec
-            .encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                options,
-            )
-            .unwrap();
+        let encoded = codec.encode(bytes.clone(), &chunk_shape, options).unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..3, 0..1]);
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .partial_decoder(input_handle, &chunk_shape, &data_type, &fill_value, options)
+            .partial_decoder(input_handle, &chunk_shape, options)
             .unwrap();
         let decoded_partial_chunk = partial_decoder
             .partial_decode(&decoded_region, options)
@@ -732,7 +722,8 @@ mod tests {
                 .bytes_to_bytes_codecs(bytes_to_bytes_codecs)
                 .build(),
         )
-        .with_context(data_type, fill_value)?;
+        .with_context(data_type, fill_value)
+        .unwrap();
 
         let encoded = codec.encode(bytes.clone(), &chunk_shape, options).unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..3, 0..1]);
@@ -797,27 +788,17 @@ mod tests {
 
         let codec_configuration: ShardingCodecConfiguration =
             serde_json::from_str(JSON_VALID2).unwrap();
-        let codec = Arc::new(ShardingCodec::new_with_configuration(&codec_configuration).unwrap());
+        let codec = Arc::new(ShardingCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes, &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..2, 0..2, 0..3]);
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .partial_decoder(
-                input_handle.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(
             partial_decoder.size_held(),
@@ -850,27 +831,17 @@ mod tests {
 
         let codec_configuration: ShardingCodecConfiguration =
             serde_json::from_str(JSON_VALID3).unwrap();
-        let codec = Arc::new(ShardingCodec::new_with_configuration(&codec_configuration).unwrap());
+        let codec = Arc::new(ShardingCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes, &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded_region = ArraySubset::new_with_ranges(&[1..3, 0..1]);
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .partial_decoder(
-                input_handle.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(
             partial_decoder.size_held(),
@@ -909,15 +880,16 @@ mod tests {
         // Create a sharding codec with 2x2 subchunks
         let codec_configuration: ShardingCodecConfiguration =
             serde_json::from_str(JSON_VALID3).unwrap();
-        let codec = Arc::new(ShardingCodec::new_with_configuration(&codec_configuration).unwrap());
+        let codec = Arc::new(ShardingCodec::new_with_configuration(&codec_configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
+        let codec = codec.as_any().downcast_ref::<ShardingCodecBound>().unwrap();
 
         // Step 1: Fully encode the shard
         let original_encoded = codec
             .encode(
                 original_bytes.clone(),
                 &chunk_shape,
-                &data_type,
-                &fill_value,
                 &CodecOptions::default(),
             )
             .unwrap();
@@ -928,8 +900,6 @@ mod tests {
             .decode(
                 original_encoded.clone(),
                 &chunk_shape,
-                &data_type,
-                &fill_value,
                 &CodecOptions::default(),
             )
             .unwrap();
@@ -943,12 +913,9 @@ mod tests {
             let updated_elements: Vec<u16> = vec![100, 101, 102, 103]; // New values for this subchunk
             let updated_bytes = crate::array::transmute_to_bytes_vec(updated_elements);
             let partial_encoder = codec
-                .clone()
                 .partial_encoder(
                     input_output_handle.clone(),
                     &chunk_shape,
-                    &data_type,
-                    &fill_value,
                     &CodecOptions::default(),
                 )
                 .unwrap();
@@ -979,8 +946,6 @@ mod tests {
             .compact(
                 updated_encoded.into(),
                 &chunk_shape,
-                &data_type,
-                &fill_value,
                 &CodecOptions::default(),
             )
             .unwrap();
@@ -995,13 +960,7 @@ mod tests {
 
         // Verify the compacted shard decodes correctly
         let decoded_after_compact = codec
-            .decode(
-                compacted.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(compacted.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
 
         // Build expected result: original data with the updated subchunk
@@ -1020,8 +979,6 @@ mod tests {
             .compact(
                 Cow::Borrowed(&compacted),
                 &chunk_shape,
-                &data_type,
-                &fill_value,
                 &CodecOptions::default(),
             )
             .unwrap();
@@ -1032,8 +989,6 @@ mod tests {
             .compact(
                 Cow::Borrowed(&original_encoded),
                 &chunk_shape,
-                &data_type,
-                &fill_value,
                 &CodecOptions::default(),
             )
             .unwrap();

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -75,8 +75,8 @@ pub use sharding_codec::ShardingCodec;
 pub use sharding_codec_builder::ShardingCodecBuilder;
 pub use sharding_options::{ShardingCodecOptions, SubchunkWriteOrder};
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits, Codec, CodecError,
-    CodecOptions, CodecPluginV3, CodecTraitsV3,
+    ArrayCodecTraits, BytesPartialDecoderTraits, Codec, CodecError, CodecOptions, CodecPluginV3,
+    CodecTraitsV3, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::v3::MetadataV3;
 pub use zarrs_metadata_ext::codec::sharding::{
@@ -127,7 +127,7 @@ fn sharding_index_shape(chunks_per_shard: &[NonZeroU64]) -> ChunkShape {
 }
 
 fn compute_index_encoded_size(
-    index_codecs: &dyn ArrayToBytesCodecTraits,
+    index_codecs: &dyn UnboundArrayToBytesCodecTraits,
     sharding_index_shape: &[NonZeroU64],
 ) -> Result<u64, CodecError> {
     let bytes_representation = index_codecs.encoded_representation(
@@ -148,7 +148,7 @@ fn compute_index_encoded_size(
 fn decode_shard_index(
     encoded_shard_index: &[u8],
     index_shape: &[NonZeroU64],
-    index_codecs: &dyn ArrayToBytesCodecTraits,
+    index_codecs: &dyn UnboundArrayToBytesCodecTraits,
     options: &CodecOptions,
 ) -> Result<Vec<u64>, CodecError> {
     // Decode the shard index
@@ -291,7 +291,9 @@ mod tests {
     use crate::array::codec::bytes_to_bytes::test_unbounded::TestUnboundedCodec;
     use crate::array::{ArrayBytes, ArraySubset, data_type};
     use zarrs_chunk_grid::Indexer;
-    use zarrs_codec::{ArrayToBytesCodecTraits, BytesToBytesCodecTraits, CodecSpecificOptions};
+    use zarrs_codec::{
+        BytesToBytesCodecTraits, CodecSpecificOptions, UnboundArrayToBytesCodecTraits,
+    };
 
     fn get_concurrent_target(parallel: bool) -> usize {
         if parallel {
@@ -418,6 +420,7 @@ mod tests {
             .with_codec_specific_options(&CodecSpecificOptions::default().with_option(
                 ShardingCodecOptions::default().with_subchunk_write_order(subchunk_write_order),
             ))
+            .unwrap()
             .encode(
                 bytes.clone(),
                 &chunk_shape,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -25,10 +25,10 @@ use crate::array::{
 };
 use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits,
-    ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
-    BytesPartialEncoderTraits, CodecError, CodecMetadataOptions, CodecOptions,
-    CodecSpecificOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
-    RecommendedConcurrency,
+    ArrayPartialEncoderTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecSpecificOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
@@ -159,9 +159,9 @@ impl ArrayCodecTraits for ShardingCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for ShardingCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for ShardingCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn partial_decode_granularity(
@@ -174,13 +174,13 @@ impl ArrayToBytesCodecTraits for ShardingCodec {
     fn with_codec_specific_options(
         self: Arc<Self>,
         opts: &CodecSpecificOptions,
-    ) -> Arc<dyn ArrayToBytesCodecTraits> {
+    ) -> Result<Arc<dyn UnboundArrayToBytesCodecTraits>, CodecError> {
         if let Some(sharding_opts) = opts.get_option::<ShardingCodecOptions>() {
             let mut codec = self;
             Arc::make_mut(&mut codec).options = sharding_opts.clone();
-            codec
+            Ok(codec)
         } else {
-            self.into_dyn()
+            Ok(self.into_dyn())
         }
     }
 

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -20,15 +20,15 @@ use crate::array::array_bytes_internal::merge_chunks_vlen;
 use crate::array::concurrency::calc_concurrency_outer_inner;
 use crate::array::{
     ArrayBytes, ArrayBytesFixedDisjointView, ArrayBytesRaw, ArraySubset, BytesRepresentation,
-    ChunkShape, ChunkShapeTraits, DataType, DataTypeSize, FillValue, chunk_shape_to_array_shape,
-    transmute_to_bytes_vec, unravel_index,
+    ChunkShape, ChunkShapeTraits, CodecChainBound, DataType, DataTypeSize, FillValue,
+    chunk_shape_to_array_shape, transmute_to_bytes_vec, unravel_index,
 };
 use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits,
-    ArrayPartialEncoderTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecSpecificOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
-    UnboundArrayToBytesCodecTraits,
+    ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+    BytesPartialEncoderTraits, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecSpecificOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
+    RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
@@ -48,6 +48,16 @@ pub struct ShardingCodec {
     pub(crate) index_location: ShardingIndexLocation,
     /// Runtime options applied at array creation/opening time.
     pub(crate) options: ShardingCodecOptions,
+}
+
+/// A `sharding` codec implementation bound to a data type and fill value.
+#[derive(Clone, Debug)]
+pub(crate) struct ShardingCodecBound {
+    subchunk_shape: ChunkShape,
+    inner_codecs: Arc<CodecChainBound>,
+    index_codecs: Arc<CodecChainBound>,
+    index_location: ShardingIndexLocation,
+    options: ShardingCodecOptions,
 }
 
 impl ShardingCodec {
@@ -142,18 +152,6 @@ impl CodecTraits for ShardingCodec {
     }
 }
 
-impl ArrayCodecTraits for ShardingCodec {
-    fn recommended_concurrency(
-        &self,
-        shape: &[NonZeroU64],
-        _data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        let chunks_per_shard = calculate_chunks_per_shard(shape, self.subchunk_shape.as_slice())?;
-        let num_elements = chunks_per_shard.num_elements_nonzero_usize();
-        Ok(RecommendedConcurrency::new_maximum(num_elements.into()))
-    }
-}
-
 #[cfg_attr(
     all(feature = "async", not(target_arch = "wasm32")),
     async_trait::async_trait
@@ -164,11 +162,26 @@ impl UnboundArrayToBytesCodecTraits for ShardingCodec {
         self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
-    fn partial_decode_granularity(
+    fn with_context(
         &self,
-        _decoded_shape: &[NonZeroU64],
-    ) -> Result<ChunkShape, CodecError> {
-        Ok(self.subchunk_shape.clone())
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        let inner_codecs = self
+            .inner_codecs
+            .clone()
+            .with_context(data_type, fill_value)?;
+        let index_codecs = self
+            .index_codecs
+            .clone()
+            .with_context(crate::array::data_type::uint64(), FillValue::from(u64::MAX))?;
+        Ok(Arc::new(ShardingCodecBound {
+            subchunk_shape: self.subchunk_shape.clone(),
+            inner_codecs,
+            index_codecs,
+            index_location: self.index_location.clone(),
+            options: self.options.clone(),
+        }))
     }
 
     fn with_codec_specific_options(
@@ -183,529 +196,9 @@ impl UnboundArrayToBytesCodecTraits for ShardingCodec {
             Ok(self.into_dyn())
         }
     }
-
-    fn encode<'a>(
-        &self,
-        bytes: ArrayBytes<'a>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-        let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
-        bytes.validate(num_elements, data_type)?;
-
-        // Get chunk bytes representation, and choose implementation based on whether the size is unbounded or not
-        let chunk_bytes_representation = self.inner_codecs.encoded_representation(
-            &self.subchunk_shape,
-            data_type,
-            fill_value,
-        )?;
-
-        let bytes = match chunk_bytes_representation {
-            BytesRepresentation::BoundedSize(size) | BytesRepresentation::FixedSize(size) => self
-                .encode_bounded(
-                    &bytes,
-                    data_type,
-                    fill_value,
-                    shape,
-                    &self.subchunk_shape,
-                    size,
-                    options,
-                ),
-            BytesRepresentation::UnboundedSize => self.encode_unbounded(
-                &bytes,
-                data_type,
-                fill_value,
-                shape,
-                &self.subchunk_shape,
-                options,
-            ),
-        }?;
-        Ok(ArrayBytesRaw::from(bytes))
-    }
-
-    #[allow(clippy::too_many_lines)]
-    fn decode<'a>(
-        &self,
-        encoded_shard: ArrayBytesRaw<'a>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<ArrayBytes<'a>, CodecError> {
-        let chunks_per_shard = calculate_chunks_per_shard(shape, &self.subchunk_shape)?;
-        let num_chunks = chunks_per_shard
-            .as_slice()
-            .iter()
-            .map(|i| usize::try_from(i.get()).unwrap())
-            .product::<usize>();
-
-        let shard_index =
-            self.decode_index(&encoded_shard, chunks_per_shard.as_slice(), options)?;
-
-        // Calc self/internal concurrent limits
-        let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
-            options.concurrent_target(),
-            &self.recommended_concurrency(shape, data_type)?,
-            &self
-                .inner_codecs
-                .recommended_concurrency(&self.subchunk_shape, data_type)?,
-        );
-        let options = options.with_concurrent_target(concurrency_limit_subchunks);
-
-        if data_type.is_optional() {
-            return Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
-            ));
-        }
-
-        let shard_shape_u64 = bytemuck::must_cast_slice(shape);
-        match data_type.size() {
-            DataTypeSize::Variable => {
-                let decode_subchunk = |chunk_index: usize| {
-                    let chunk_subset = self
-                        .chunk_index_to_subset(chunk_index as u64, chunks_per_shard.as_slice())
-                        .expect("inbounds chunk");
-
-                    // Read the offset/size
-                    let offset = shard_index[chunk_index * 2];
-                    let size = shard_index[chunk_index * 2 + 1];
-                    let chunk_bytes = if offset == u64::MAX && size == u64::MAX {
-                        ArrayBytes::new_fill_value(
-                            data_type,
-                            self.subchunk_shape.num_elements_u64(),
-                            fill_value,
-                        )?
-                        .into_variable()?
-                    } else if usize::try_from(offset + size).unwrap() > encoded_shard.len() {
-                        return Err(CodecError::Other(
-                            "The shard index references out-of-bounds bytes. The chunk may be corrupted."
-                                .to_string(),
-                        ));
-                    } else {
-                        let offset: usize = offset.try_into().unwrap();
-                        let size: usize = size.try_into().unwrap();
-                        let encoded_chunk = &encoded_shard[offset..offset + size];
-                        self.inner_codecs
-                            .decode(
-                                Cow::Borrowed(encoded_chunk),
-                                &self.subchunk_shape,
-                                data_type,
-                                fill_value,
-                                &options,
-                            )?
-                            .into_variable()?
-                    };
-                    Ok((chunk_bytes, chunk_subset))
-                };
-
-                // Decode the subchunks
-                let chunk_bytes_and_subsets = crate::iter_concurrent_limit!(
-                    shard_concurrent_limit,
-                    (0..num_chunks),
-                    map,
-                    decode_subchunk
-                )
-                .collect::<Result<Vec<_>, _>>()?;
-
-                // Convert into an array
-                Ok(ArrayBytes::Variable(merge_chunks_vlen(
-                    chunk_bytes_and_subsets,
-                    shard_shape_u64,
-                )))
-            }
-            DataTypeSize::Fixed(data_type_size) => {
-                // Allocate an array for the output
-                let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
-                let size_output = usize::try_from(num_elements).unwrap() * data_type_size;
-                if size_output == 0 {
-                    return Ok(ArrayBytes::new_flen(vec![]));
-                }
-                let mut decoded_shard = Vec::<u8>::with_capacity(size_output);
-
-                {
-                    let output =
-                        UnsafeCellSlice::new_from_vec_with_spare_capacity(&mut decoded_shard);
-                    let decode_chunk = |chunk_index: usize| {
-                        let chunk_subset = self
-                            .chunk_index_to_subset(chunk_index as u64, chunks_per_shard.as_slice())
-                            .expect("inbounds chunk");
-                        let mut output_view_subchunk = unsafe {
-                            // SAFETY: chunks represent disjoint array subsets
-                            ArrayBytesFixedDisjointView::new(
-                                output,
-                                data_type_size,
-                                shard_shape_u64,
-                                chunk_subset,
-                            )?
-                        };
-
-                        // Read the offset/size
-                        let offset = shard_index[chunk_index * 2];
-                        let size = shard_index[chunk_index * 2 + 1];
-                        if offset == u64::MAX && size == u64::MAX {
-                            output_view_subchunk.fill(fill_value.as_ne_bytes())?;
-                        } else if usize::try_from(offset + size).unwrap() > encoded_shard.len() {
-                            return Err(CodecError::Other(
-                                "The shard index references out-of-bounds bytes. The chunk may be corrupted."
-                                    .to_string(),
-                            ));
-                        } else {
-                            let offset: usize = offset.try_into().unwrap();
-                            let size: usize = size.try_into().unwrap();
-                            let encoded_chunk = &encoded_shard[offset..offset + size];
-                            self.inner_codecs.decode_into(
-                                Cow::Borrowed(encoded_chunk),
-                                &self.subchunk_shape,
-                                data_type,
-                                fill_value,
-                                ArrayBytesDecodeIntoTarget::Fixed(&mut output_view_subchunk),
-                                &options,
-                            )?;
-                        }
-
-                        Ok::<_, CodecError>(())
-                    };
-
-                    crate::iter_concurrent_limit!(
-                        shard_concurrent_limit,
-                        (0..num_chunks),
-                        try_for_each,
-                        decode_chunk
-                    )?;
-                }
-                unsafe { decoded_shard.set_len(decoded_shard.capacity()) };
-                Ok(ArrayBytes::from(decoded_shard))
-            }
-        }
-    }
-
-    fn compact<'a>(
-        &self,
-        bytes: ArrayBytesRaw<'a>,
-        shape: &[NonZeroU64],
-        _data_type: &DataType,
-        _fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
-        // Calculate chunks per shard
-        let chunks_per_shard = calculate_chunks_per_shard(shape, self.subchunk_shape.as_slice())?;
-
-        // Decode the shard index
-        let shard_index = self.decode_index(&bytes, chunks_per_shard.as_slice(), options)?;
-
-        // Get index metadata
-        let index_shape = sharding_index_shape(chunks_per_shard.as_slice());
-        let index_encoded_size =
-            compute_index_encoded_size(self.index_codecs.as_ref(), &index_shape)?;
-
-        // Check if compaction is needed (no-op optimization)
-        let mut needs_compaction = false;
-        let mut chunks_size = 0;
-        for &[offset, size] in shard_index.as_chunks::<2>().0 {
-            if offset != u64::MAX && size != u64::MAX {
-                chunks_size += size;
-            }
-        }
-        if chunks_size != bytes.len() as u64 - index_encoded_size {
-            needs_compaction = true;
-        }
-
-        if !needs_compaction {
-            return Ok(None); // No compaction needed
-        }
-
-        // Calculate compact size
-        let data_size: usize = shard_index
-            .as_chunks::<2>()
-            .0
-            .iter()
-            .filter(|chunk| chunk[0] != u64::MAX)
-            .map(|chunk| usize::try_from(chunk[1]).unwrap())
-            .sum();
-
-        let compact_size = data_size + usize::try_from(index_encoded_size).unwrap();
-
-        // Build compacted shard
-        let mut compact_shard = vec![0u8; compact_size];
-        let mut new_index = vec![u64::MAX; shard_index.len()];
-
-        let mut write_offset = match self.index_location {
-            ShardingIndexLocation::Start => usize::try_from(index_encoded_size).unwrap(),
-            ShardingIndexLocation::End => 0,
-        };
-
-        for (i, &[old_offset, size]) in shard_index.as_chunks::<2>().0.iter().enumerate() {
-            if old_offset != u64::MAX && size != u64::MAX {
-                let old_offset_usize = usize::try_from(old_offset).unwrap();
-                let size_usize = usize::try_from(size).unwrap();
-
-                // Validate bounds
-                if old_offset_usize + size_usize > bytes.len() {
-                    return Err(CodecError::Other(
-                        "The shard index references out-of-bounds bytes. The chunk may be corrupted."
-                            .to_string(),
-                    ));
-                }
-
-                // Copy chunk data
-                compact_shard[write_offset..write_offset + size_usize]
-                    .copy_from_slice(&bytes[old_offset_usize..old_offset_usize + size_usize]);
-
-                // Update index
-                new_index[i * 2] = u64::try_from(write_offset).unwrap();
-                new_index[i * 2 + 1] = size;
-
-                write_offset += size_usize;
-            }
-        }
-
-        // Encode and write index
-        let index_bytes = transmute_to_bytes_vec(new_index);
-        let encoded_index = self.index_codecs.encode(
-            ArrayBytes::from(index_bytes),
-            &index_shape,
-            &crate::array::data_type::uint64(),
-            &FillValue::from(u64::MAX),
-            options,
-        )?;
-
-        match self.index_location {
-            ShardingIndexLocation::Start => {
-                compact_shard[..encoded_index.len()].copy_from_slice(&encoded_index);
-            }
-            ShardingIndexLocation::End => {
-                let index_start = compact_size - encoded_index.len();
-                compact_shard[index_start..].copy_from_slice(&encoded_index);
-            }
-        }
-
-        Ok(Some(Cow::Owned(compact_shard)))
-    }
-
-    #[allow(clippy::too_many_lines)]
-    fn decode_into(
-        &self,
-        encoded_shard: ArrayBytesRaw<'_>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
-    ) -> Result<(), CodecError> {
-        // Sharding currently only supports non-optional data
-        let output_view = match output_target {
-            ArrayBytesDecodeIntoTarget::Fixed(data) => data,
-            ArrayBytesDecodeIntoTarget::Optional(..) => {
-                return Err(CodecError::UnsupportedDataType(
-                    data_type.clone(),
-                    Self::aliases_v3().default_name.to_string(),
-                ));
-            }
-        };
-        let chunks_per_shard = calculate_chunks_per_shard(shape, &self.subchunk_shape)?;
-        let num_chunks = chunks_per_shard
-            .as_slice()
-            .iter()
-            .map(|i| usize::try_from(i.get()).unwrap())
-            .product::<usize>();
-
-        let shard_index =
-            self.decode_index(&encoded_shard, chunks_per_shard.as_slice(), options)?;
-
-        // Calc self/internal concurrent limits
-        let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
-            options.concurrent_target(),
-            &self.recommended_concurrency(shape, data_type)?,
-            &self
-                .inner_codecs
-                .recommended_concurrency(&self.subchunk_shape, data_type)?,
-        );
-        let options = options.with_concurrent_target(concurrency_limit_subchunks);
-
-        let decode_chunk = |chunk_index: usize| {
-            let chunk_subset = self
-                .chunk_index_to_subset(chunk_index as u64, chunks_per_shard.as_slice())
-                .expect("inbounds chunk");
-
-            let output_subset_chunk = ArraySubset::new_with_start_shape(
-                std::iter::zip(
-                    output_view.subset().start().iter(),
-                    chunk_subset.start().iter(),
-                )
-                .map(|(o, s)| o + s)
-                .collect(),
-                chunk_subset.shape().to_vec(),
-            )
-            .unwrap();
-            let mut output_view_subchunk = unsafe {
-                // SAFETY: subchunks represent disjoint array subsets
-                output_view.subdivide(output_subset_chunk)?
-            };
-
-            // Read the offset/size
-            let offset = shard_index[chunk_index * 2];
-            let size = shard_index[chunk_index * 2 + 1];
-            if offset == u64::MAX && size == u64::MAX {
-                output_view_subchunk.fill(fill_value.as_ne_bytes())?;
-            } else if usize::try_from(offset + size).unwrap() > encoded_shard.len() {
-                return Err(CodecError::Other(
-                    "The shard index references out-of-bounds bytes. The chunk may be corrupted."
-                        .to_string(),
-                ));
-            } else {
-                let offset: usize = offset.try_into().unwrap();
-                let size: usize = size.try_into().unwrap();
-                let encoded_chunk = &encoded_shard[offset..offset + size];
-                self.inner_codecs.decode_into(
-                    Cow::Borrowed(encoded_chunk),
-                    &self.subchunk_shape,
-                    data_type,
-                    fill_value,
-                    ArrayBytesDecodeIntoTarget::Fixed(&mut output_view_subchunk),
-                    &options,
-                )?;
-            }
-
-            Ok::<_, CodecError>(())
-        };
-
-        crate::iter_concurrent_limit!(
-            shard_concurrent_limit,
-            (0..num_chunks),
-            try_for_each,
-            decode_chunk
-        )?;
-
-        Ok(())
-    }
-
-    fn partial_decoder(
-        self: Arc<Self>,
-        input_handle: Arc<dyn BytesPartialDecoderTraits>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-        Ok(Arc::new(ShardingPartialDecoder::new(
-            input_handle,
-            data_type.clone(),
-            fill_value.clone(),
-            ChunkShape::from(shape.to_vec()),
-            self.subchunk_shape.clone(),
-            self.inner_codecs.clone(),
-            &self.index_codecs,
-            self.index_location,
-            options,
-            self.options.clone(),
-        )?))
-    }
-
-    #[cfg(feature = "async")]
-    async fn async_partial_decoder(
-        self: Arc<Self>,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
-        Ok(Arc::new(
-            AsyncShardingPartialDecoder::new(
-                input_handle,
-                data_type.clone(),
-                fill_value.clone(),
-                ChunkShape::from(shape.to_vec()),
-                self.subchunk_shape.clone(),
-                self.inner_codecs.clone(),
-                &self.index_codecs,
-                self.index_location,
-                options,
-                self.options.clone(),
-            )
-            .await?,
-        ))
-    }
-
-    fn partial_encoder(
-        self: Arc<Self>,
-        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-        options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
-        Ok(Arc::new(
-            sharding_partial_encoder::ShardingPartialEncoder::new(
-                input_output_handle,
-                data_type.clone(),
-                fill_value.clone(),
-                ChunkShape::from(shape.to_vec()),
-                self.subchunk_shape.clone(),
-                self.inner_codecs.clone(),
-                self.index_codecs.clone(),
-                self.index_location,
-                options,
-                self.options.clone(),
-            )?,
-        ))
-    }
-
-    fn encoded_representation(
-        &self,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-    ) -> Result<BytesRepresentation, CodecError> {
-        // Get the maximum size of encoded chunks
-        let chunk_bytes_representation = self
-            .inner_codecs
-            .encoded_representation(shape, data_type, fill_value)?;
-
-        match chunk_bytes_representation {
-            BytesRepresentation::BoundedSize(size) | BytesRepresentation::FixedSize(size) => {
-                let chunks_per_shard =
-                    calculate_chunks_per_shard(shape, self.subchunk_shape.as_slice())?;
-                let index_encoded_size = compute_index_encoded_size(
-                    self.index_codecs.as_ref(),
-                    &sharding_index_shape(chunks_per_shard.as_slice()),
-                )?;
-                let shard_size = Self::encoded_shard_bounded_size(
-                    index_encoded_size,
-                    size,
-                    chunks_per_shard.as_slice(),
-                );
-                Ok(BytesRepresentation::BoundedSize(shard_size))
-            }
-            BytesRepresentation::UnboundedSize => Ok(BytesRepresentation::UnboundedSize),
-        }
-    }
 }
 
-impl ShardingCodec {
-    /// Convert a linearised chunk index to an array subset.
-    /// Returns [`None`] if `chunk_index` is out-of-bounds of `chunks_per_shard`.
-    fn chunk_index_to_subset(
-        &self,
-        chunk_index: u64,
-        chunks_per_shard: &[NonZeroU64],
-    ) -> Option<ArraySubset> {
-        let chunks_per_shard = chunk_shape_to_array_shape(chunks_per_shard);
-        let chunk_indices = unravel_index(chunk_index, chunks_per_shard.as_slice())?;
-        let chunk_start = std::iter::zip(&chunk_indices, self.subchunk_shape.as_slice())
-            .map(|(i, c)| i * c.get())
-            .collect::<Vec<_>>();
-        let shape = self.subchunk_shape.as_slice();
-        let ranges = shape
-            .iter()
-            .zip(&chunk_start)
-            .map(|(&sh, &st)| st..(st + sh.get()));
-        Some(ArraySubset::from(ranges))
-    }
-
+impl ShardingCodecBound {
     /// Computed the bounded size of an encoded shard from
     ///  - the chunk bytes representation, and
     ///  - the number of chunks per shard.
@@ -720,66 +213,17 @@ impl ShardingCodec {
         num_chunks * chunk_encoded_size + index_encoded_size
     }
 
-    /// Encode an inner chunk from the `decoded_value` or return None.
-    #[expect(clippy::too_many_arguments)]
-    fn encode_inner_by_chunk_index(
-        &self,
-        chunk_index: usize,
-        decoded_value: &ArrayBytes,
-        shard_shape: &[NonZeroU64],
-        chunks_per_shard: &[NonZeroU64],
-        fill_value: &FillValue,
-        data_type: &DataType,
-        subchunk_shape: &[NonZeroU64],
-        options_inner: &CodecOptions,
-    ) -> Option<Result<(usize, Vec<u8>), CodecError>> {
-        let chunk_subset = self
-            .chunk_index_to_subset(chunk_index as u64, chunks_per_shard)
-            .expect("inbounds chunk");
-
-        let bytes = decoded_value.extract_array_subset(
-            &chunk_subset,
-            bytemuck::must_cast_slice(shard_shape),
-            data_type,
-        );
-        let bytes = match bytes {
-            Ok(bytes) => bytes,
-            Err(err) => return Some(Err(err)),
-        };
-
-        let is_fill_value = bytes.is_fill_value(fill_value);
-        if is_fill_value {
-            None
-        } else {
-            let encoded_chunk = self.inner_codecs.encode(
-                bytes,
-                subchunk_shape,
-                data_type,
-                fill_value,
-                options_inner,
-            );
-            match encoded_chunk {
-                Ok(encoded_chunk) => Some(Ok((chunk_index, encoded_chunk.to_vec()))),
-                Err(err) => Some(Err(err)),
-            }
-        }
-    }
-
     /// Preallocate shard, encode and write chunks (in parallel), then truncate shard
     #[allow(clippy::too_many_lines)]
     #[expect(clippy::too_many_arguments)]
     fn encode_bounded(
         &self,
         decoded_value: &ArrayBytes,
-        data_type: &DataType,
-        fill_value: &FillValue,
         shard_shape: &[NonZeroU64],
         subchunk_shape: &[NonZeroU64],
         chunk_size_bounded: u64,
         options: &CodecOptions,
     ) -> Result<Vec<u8>, CodecError> {
-        decoded_value.validate(shard_shape.num_elements_u64(), data_type)?;
-
         // Calculate maximum possible shard size
         let chunks_per_shard = calculate_chunks_per_shard(shard_shape, subchunk_shape)?;
         let index_shape = sharding_index_shape(chunks_per_shard.as_slice());
@@ -807,10 +251,10 @@ impl ShardingCodec {
         // Calc self/internal concurrent limits
         let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
             options.concurrent_target(),
-            &self.recommended_concurrency(shard_shape, data_type)?,
+            &self.recommended_concurrency(shard_shape)?,
             &self
                 .inner_codecs
-                .recommended_concurrency(subchunk_shape, data_type)?,
+                .recommended_concurrency(subchunk_shape)?,
         );
         let options = options.with_concurrent_target(concurrency_limit_subchunks);
 
@@ -835,8 +279,6 @@ impl ShardingCodec {
                             decoded_value,
                             shard_shape,
                             chunks_per_shard.as_slice(),
-                            fill_value,
-                            data_type,
                             subchunk_shape,
                             &options,
                         );
@@ -886,8 +328,6 @@ impl ShardingCodec {
                                 decoded_value,
                                 shard_shape,
                                 chunks_per_shard.as_slice(),
-                                fill_value,
-                                data_type,
                                 subchunk_shape,
                                 &options,
                             )
@@ -939,8 +379,6 @@ impl ShardingCodec {
         let encoded_array_index = self.index_codecs.encode(
             shard_index_bytes.into(),
             &index_shape,
-            &crate::array::data_type::uint64(),
-            &FillValue::from(u64::MAX),
             &options,
         )?;
         {
@@ -968,14 +406,10 @@ impl ShardingCodec {
     fn encode_unbounded(
         &self,
         decoded_value: &ArrayBytes,
-        data_type: &DataType,
-        fill_value: &FillValue,
         shard_shape: &[NonZeroU64],
         subchunk_shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Vec<u8>, CodecError> {
-        decoded_value.validate(shard_shape.num_elements_u64(), data_type)?;
-
         let chunks_per_shard = calculate_chunks_per_shard(shard_shape, subchunk_shape)?;
         let index_shape = sharding_index_shape(chunks_per_shard.as_slice());
         let index_encoded_size =
@@ -992,10 +426,10 @@ impl ShardingCodec {
         // Calc self/internal concurrent limits
         let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
             options.concurrent_target(),
-            &self.recommended_concurrency(shard_shape, data_type)?,
+            &self.recommended_concurrency(shard_shape)?,
             &self
                 .inner_codecs
-                .recommended_concurrency(subchunk_shape, data_type)?,
+                .recommended_concurrency(subchunk_shape)?,
         );
         let options_inner = options.with_concurrent_target(concurrency_limit_subchunks);
 
@@ -1021,8 +455,6 @@ impl ShardingCodec {
                 decoded_value,
                 shard_shape,
                 chunks_per_shard.as_slice(),
-                fill_value,
-                data_type,
                 subchunk_shape,
                 &options_inner
             )
@@ -1110,8 +542,6 @@ impl ShardingCodec {
         let encoded_array_index = self.index_codecs.encode(
             ArrayBytes::from(transmute_to_bytes_vec(shard_index)),
             &index_shape,
-            &crate::array::data_type::uint64(),
-            &FillValue::from(u64::MAX),
             options,
         )?;
         {
@@ -1130,6 +560,571 @@ impl ShardingCodec {
         // SAFETY: all elements have been initialised
         unsafe { shard.set_len(shard_length) };
         Ok(shard)
+    }
+}
+
+impl ArrayCodecTraits for ShardingCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn data_type(&self) -> &DataType {
+        self.inner_codecs.data_type()
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        self.inner_codecs.fill_value()
+    }
+
+    fn recommended_concurrency(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        let chunks_per_shard = calculate_chunks_per_shard(shape, self.subchunk_shape.as_slice())?;
+        let num_elements = chunks_per_shard.num_elements_nonzero_usize();
+        Ok(RecommendedConcurrency::new_maximum(num_elements.into()))
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToBytesCodecTraits for ShardingCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self as Arc<dyn ArrayToBytesCodecTraits>
+    }
+
+    fn encoded_representation(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<BytesRepresentation, CodecError> {
+        // Get the maximum size of encoded chunks
+        let chunk_bytes_representation = self.inner_codecs.encoded_representation(shape)?;
+
+        match chunk_bytes_representation {
+            BytesRepresentation::BoundedSize(size) | BytesRepresentation::FixedSize(size) => {
+                let chunks_per_shard =
+                    calculate_chunks_per_shard(shape, self.subchunk_shape.as_slice())?;
+                let index_encoded_size = compute_index_encoded_size(
+                    self.index_codecs.as_ref(),
+                    &sharding_index_shape(chunks_per_shard.as_slice()),
+                )?;
+                let shard_size = Self::encoded_shard_bounded_size(
+                    index_encoded_size,
+                    size,
+                    chunks_per_shard.as_slice(),
+                );
+                Ok(BytesRepresentation::BoundedSize(shard_size))
+            }
+            BytesRepresentation::UnboundedSize => Ok(BytesRepresentation::UnboundedSize),
+        }
+    }
+
+    fn partial_decode_granularity(
+        &self,
+        _decoded_shape: &[NonZeroU64],
+    ) -> Result<ChunkShape, CodecError> {
+        Ok(self.subchunk_shape.clone())
+    }
+
+    fn encode<'a>(
+        &self,
+        bytes: ArrayBytes<'a>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<ArrayBytesRaw<'a>, CodecError> {
+        let data_type = self.data_type();
+        let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
+        bytes.validate(num_elements, data_type)?;
+
+        // Get chunk bytes representation, and choose implementation based on whether the size is unbounded or not
+        let chunk_bytes_representation = self
+            .inner_codecs
+            .encoded_representation(&self.subchunk_shape)?;
+
+        bytes.validate(shape.num_elements_u64(), data_type)?;
+        let bytes = match chunk_bytes_representation {
+            BytesRepresentation::BoundedSize(size) | BytesRepresentation::FixedSize(size) => {
+                self.encode_bounded(&bytes, shape, &self.subchunk_shape, size, options)
+            }
+            BytesRepresentation::UnboundedSize => {
+                self.encode_unbounded(&bytes, shape, &self.subchunk_shape, options)
+            }
+        }?;
+        Ok(ArrayBytesRaw::from(bytes))
+    }
+
+    fn decode<'a>(
+        &self,
+        encoded_shard: ArrayBytesRaw<'a>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<ArrayBytes<'a>, CodecError> {
+        let data_type = self.data_type();
+        let fill_value = self.fill_value();
+        let chunks_per_shard = calculate_chunks_per_shard(shape, &self.subchunk_shape)?;
+        let num_chunks = chunks_per_shard
+            .as_slice()
+            .iter()
+            .map(|i| usize::try_from(i.get()).unwrap())
+            .product::<usize>();
+
+        let shard_index =
+            self.decode_index(&encoded_shard, chunks_per_shard.as_slice(), options)?;
+
+        // Calc self/internal concurrent limits
+        let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
+            options.concurrent_target(),
+            &self.recommended_concurrency(shape)?,
+            &self
+                .inner_codecs
+                .recommended_concurrency(&self.subchunk_shape)?,
+        );
+        let options = options.with_concurrent_target(concurrency_limit_subchunks);
+
+        if data_type.is_optional() {
+            return Err(CodecError::UnsupportedDataType(
+                data_type.clone(),
+                ShardingCodec::aliases_v3().default_name.to_string(),
+            ));
+        }
+
+        let shard_shape_u64 = bytemuck::must_cast_slice(shape);
+        match data_type.size() {
+            DataTypeSize::Variable => {
+                let decode_subchunk = |chunk_index: usize| {
+                    let chunk_subset = self
+                        .chunk_index_to_subset(chunk_index as u64, chunks_per_shard.as_slice())
+                        .expect("inbounds chunk");
+
+                    // Read the offset/size
+                    let offset = shard_index[chunk_index * 2];
+                    let size = shard_index[chunk_index * 2 + 1];
+                    let chunk_bytes = if offset == u64::MAX && size == u64::MAX {
+                        ArrayBytes::new_fill_value(
+                            data_type,
+                            self.subchunk_shape.num_elements_u64(),
+                            fill_value,
+                        )?
+                        .into_variable()?
+                    } else if usize::try_from(offset + size).unwrap() > encoded_shard.len() {
+                        return Err(CodecError::Other(
+                            "The shard index references out-of-bounds bytes. The chunk may be corrupted."
+                                .to_string(),
+                        ));
+                    } else {
+                        let offset: usize = offset.try_into().unwrap();
+                        let size: usize = size.try_into().unwrap();
+                        let encoded_chunk = &encoded_shard[offset..offset + size];
+                        self.inner_codecs
+                            .decode(
+                                Cow::Borrowed(encoded_chunk),
+                                &self.subchunk_shape,
+                                &options,
+                            )?
+                            .into_variable()?
+                    };
+                    Ok((chunk_bytes, chunk_subset))
+                };
+
+                // Decode the subchunks
+                let chunk_bytes_and_subsets = crate::iter_concurrent_limit!(
+                    shard_concurrent_limit,
+                    (0..num_chunks),
+                    map,
+                    decode_subchunk
+                )
+                .collect::<Result<Vec<_>, _>>()?;
+
+                // Convert into an array
+                Ok(ArrayBytes::Variable(merge_chunks_vlen(
+                    chunk_bytes_and_subsets,
+                    shard_shape_u64,
+                )))
+            }
+            DataTypeSize::Fixed(data_type_size) => {
+                // Allocate an array for the output
+                let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
+                let size_output = usize::try_from(num_elements).unwrap() * data_type_size;
+                if size_output == 0 {
+                    return Ok(ArrayBytes::new_flen(vec![]));
+                }
+                let mut decoded_shard = Vec::<u8>::with_capacity(size_output);
+
+                {
+                    let output =
+                        UnsafeCellSlice::new_from_vec_with_spare_capacity(&mut decoded_shard);
+                    let decode_chunk = |chunk_index: usize| {
+                        let chunk_subset = self
+                            .chunk_index_to_subset(chunk_index as u64, chunks_per_shard.as_slice())
+                            .expect("inbounds chunk");
+                        let mut output_view_subchunk = unsafe {
+                            // SAFETY: chunks represent disjoint array subsets
+                            ArrayBytesFixedDisjointView::new(
+                                output,
+                                data_type_size,
+                                shard_shape_u64,
+                                chunk_subset,
+                            )?
+                        };
+
+                        // Read the offset/size
+                        let offset = shard_index[chunk_index * 2];
+                        let size = shard_index[chunk_index * 2 + 1];
+                        if offset == u64::MAX && size == u64::MAX {
+                            output_view_subchunk.fill(fill_value.as_ne_bytes())?;
+                        } else if usize::try_from(offset + size).unwrap() > encoded_shard.len() {
+                            return Err(CodecError::Other(
+                                "The shard index references out-of-bounds bytes. The chunk may be corrupted."
+                                    .to_string(),
+                            ));
+                        } else {
+                            let offset: usize = offset.try_into().unwrap();
+                            let size: usize = size.try_into().unwrap();
+                            let encoded_chunk = &encoded_shard[offset..offset + size];
+                            self.inner_codecs.decode_into(
+                                Cow::Borrowed(encoded_chunk),
+                                &self.subchunk_shape,
+                                ArrayBytesDecodeIntoTarget::Fixed(&mut output_view_subchunk),
+                                &options,
+                            )?;
+                        }
+
+                        Ok::<_, CodecError>(())
+                    };
+
+                    crate::iter_concurrent_limit!(
+                        shard_concurrent_limit,
+                        (0..num_chunks),
+                        try_for_each,
+                        decode_chunk
+                    )?;
+                }
+                unsafe { decoded_shard.set_len(decoded_shard.capacity()) };
+                Ok(ArrayBytes::from(decoded_shard))
+            }
+        }
+    }
+
+    fn compact<'a>(
+        &self,
+        bytes: ArrayBytesRaw<'a>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
+        // Calculate chunks per shard
+        let chunks_per_shard = calculate_chunks_per_shard(shape, self.subchunk_shape.as_slice())?;
+
+        // Decode the shard index
+        let shard_index = self.decode_index(&bytes, chunks_per_shard.as_slice(), options)?;
+
+        // Get index metadata
+        let index_shape = sharding_index_shape(chunks_per_shard.as_slice());
+        let index_encoded_size =
+            compute_index_encoded_size(self.index_codecs.as_ref(), &index_shape)?;
+
+        // Check if compaction is needed (no-op optimization)
+        let mut needs_compaction = false;
+        let mut chunks_size = 0;
+        for &[offset, size] in shard_index.as_chunks::<2>().0 {
+            if offset != u64::MAX && size != u64::MAX {
+                chunks_size += size;
+            }
+        }
+        if chunks_size != bytes.len() as u64 - index_encoded_size {
+            needs_compaction = true;
+        }
+
+        if !needs_compaction {
+            return Ok(None); // No compaction needed
+        }
+
+        // Calculate compact size
+        let data_size: usize = shard_index
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .filter(|chunk| chunk[0] != u64::MAX)
+            .map(|chunk| usize::try_from(chunk[1]).unwrap())
+            .sum();
+
+        let compact_size = data_size + usize::try_from(index_encoded_size).unwrap();
+
+        // Build compacted shard
+        let mut compact_shard = vec![0u8; compact_size];
+        let mut new_index = vec![u64::MAX; shard_index.len()];
+
+        let mut write_offset = match self.index_location {
+            ShardingIndexLocation::Start => usize::try_from(index_encoded_size).unwrap(),
+            ShardingIndexLocation::End => 0,
+        };
+
+        for (i, &[old_offset, size]) in shard_index.as_chunks::<2>().0.iter().enumerate() {
+            if old_offset != u64::MAX && size != u64::MAX {
+                let old_offset_usize = usize::try_from(old_offset).unwrap();
+                let size_usize = usize::try_from(size).unwrap();
+
+                // Validate bounds
+                if old_offset_usize + size_usize > bytes.len() {
+                    return Err(CodecError::Other(
+                        "The shard index references out-of-bounds bytes. The chunk may be corrupted."
+                            .to_string(),
+                    ));
+                }
+
+                // Copy chunk data
+                compact_shard[write_offset..write_offset + size_usize]
+                    .copy_from_slice(&bytes[old_offset_usize..old_offset_usize + size_usize]);
+
+                // Update index
+                new_index[i * 2] = u64::try_from(write_offset).unwrap();
+                new_index[i * 2 + 1] = size;
+
+                write_offset += size_usize;
+            }
+        }
+
+        // Encode and write index
+        let index_bytes = transmute_to_bytes_vec(new_index);
+        let encoded_index = self.index_codecs.encode(
+            ArrayBytes::from(index_bytes),
+            &index_shape,
+            options,
+        )?;
+
+        match self.index_location {
+            ShardingIndexLocation::Start => {
+                compact_shard[..encoded_index.len()].copy_from_slice(&encoded_index);
+            }
+            ShardingIndexLocation::End => {
+                let index_start = compact_size - encoded_index.len();
+                compact_shard[index_start..].copy_from_slice(&encoded_index);
+            }
+        }
+
+        Ok(Some(Cow::Owned(compact_shard)))
+    }
+
+    fn decode_into(
+        &self,
+        encoded_shard: ArrayBytesRaw<'_>,
+        shape: &[NonZeroU64],
+        output_target: ArrayBytesDecodeIntoTarget<'_>,
+        options: &CodecOptions,
+    ) -> Result<(), CodecError> {
+        let data_type = self.data_type();
+        let fill_value = self.fill_value();
+
+        // Sharding currently only supports non-optional data
+        let output_view = match output_target {
+            ArrayBytesDecodeIntoTarget::Fixed(data) => data,
+            ArrayBytesDecodeIntoTarget::Optional(..) => {
+                return Err(CodecError::UnsupportedDataType(
+                    data_type.clone(),
+                    ShardingCodec::aliases_v3().default_name.to_string(),
+                ));
+            }
+        };
+        let chunks_per_shard = calculate_chunks_per_shard(shape, &self.subchunk_shape)?;
+        let num_chunks = chunks_per_shard
+            .as_slice()
+            .iter()
+            .map(|i| usize::try_from(i.get()).unwrap())
+            .product::<usize>();
+
+        let shard_index =
+            self.decode_index(&encoded_shard, chunks_per_shard.as_slice(), options)?;
+
+        // Calc self/internal concurrent limits
+        let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
+            options.concurrent_target(),
+            &self.recommended_concurrency(shape)?,
+            &self
+                .inner_codecs
+                .recommended_concurrency(&self.subchunk_shape)?,
+        );
+        let options = options.with_concurrent_target(concurrency_limit_subchunks);
+
+        let decode_chunk = |chunk_index: usize| {
+            let chunk_subset = self
+                .chunk_index_to_subset(chunk_index as u64, chunks_per_shard.as_slice())
+                .expect("inbounds chunk");
+
+            let output_subset_chunk = ArraySubset::new_with_start_shape(
+                std::iter::zip(
+                    output_view.subset().start().iter(),
+                    chunk_subset.start().iter(),
+                )
+                .map(|(o, s)| o + s)
+                .collect(),
+                chunk_subset.shape().to_vec(),
+            )
+            .unwrap();
+            let mut output_view_subchunk = unsafe {
+                // SAFETY: subchunks represent disjoint array subsets
+                output_view.subdivide(output_subset_chunk)?
+            };
+
+            // Read the offset/size
+            let offset = shard_index[chunk_index * 2];
+            let size = shard_index[chunk_index * 2 + 1];
+            if offset == u64::MAX && size == u64::MAX {
+                output_view_subchunk.fill(fill_value.as_ne_bytes())?;
+            } else if usize::try_from(offset + size).unwrap() > encoded_shard.len() {
+                return Err(CodecError::Other(
+                    "The shard index references out-of-bounds bytes. The chunk may be corrupted."
+                        .to_string(),
+                ));
+            } else {
+                let offset: usize = offset.try_into().unwrap();
+                let size: usize = size.try_into().unwrap();
+                let encoded_chunk = &encoded_shard[offset..offset + size];
+                self.inner_codecs.decode_into(
+                    Cow::Borrowed(encoded_chunk),
+                    &self.subchunk_shape,
+                    ArrayBytesDecodeIntoTarget::Fixed(&mut output_view_subchunk),
+                    &options,
+                )?;
+            }
+
+            Ok::<_, CodecError>(())
+        };
+
+        crate::iter_concurrent_limit!(
+            shard_concurrent_limit,
+            (0..num_chunks),
+            try_for_each,
+            decode_chunk
+        )?;
+
+        Ok(())
+    }
+
+    fn partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn BytesPartialDecoderTraits>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
+        Ok(Arc::new(ShardingPartialDecoder::new(
+            input_handle,
+            ChunkShape::from(shape.to_vec()),
+            self.subchunk_shape.clone(),
+            self.inner_codecs.clone(),
+            &self.index_codecs,
+            self.index_location,
+            options,
+            self.options.clone(),
+        )?))
+    }
+
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(
+            sharding_partial_encoder::ShardingPartialEncoder::new(
+                input_output_handle,
+                ChunkShape::from(shape.to_vec()),
+                self.subchunk_shape.clone(),
+                self.inner_codecs.clone(),
+                self.index_codecs.clone(),
+                self.index_location,
+                options,
+                self.options.clone(),
+            )?,
+        ))
+    }
+
+    #[cfg(feature = "async")]
+    async fn async_partial_decoder(
+        self: Arc<Self>,
+        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
+        Ok(Arc::new(
+            AsyncShardingPartialDecoder::new(
+                input_handle,
+                ChunkShape::from(shape.to_vec()),
+                self.subchunk_shape.clone(),
+                self.inner_codecs.clone(),
+                &self.index_codecs,
+                self.index_location,
+                options,
+                self.options.clone(),
+            )
+            .await?,
+        ))
+    }
+}
+
+impl ShardingCodecBound {
+    /// Convert a linearised chunk index to an array subset.
+    /// Returns [`None`] if `chunk_index` is out-of-bounds of `chunks_per_shard`.
+    fn chunk_index_to_subset(
+        &self,
+        chunk_index: u64,
+        chunks_per_shard: &[NonZeroU64],
+    ) -> Option<ArraySubset> {
+        let chunks_per_shard = chunk_shape_to_array_shape(chunks_per_shard);
+        let chunk_indices = unravel_index(chunk_index, chunks_per_shard.as_slice())?;
+        let chunk_start = std::iter::zip(&chunk_indices, self.subchunk_shape.as_slice())
+            .map(|(i, c)| i * c.get())
+            .collect::<Vec<_>>();
+        let shape = self.subchunk_shape.as_slice();
+        let ranges = shape
+            .iter()
+            .zip(&chunk_start)
+            .map(|(&sh, &st)| st..(st + sh.get()));
+        Some(ArraySubset::from(ranges))
+    }
+
+    /// Encode an inner chunk from the `decoded_value` or return None.
+    #[expect(clippy::too_many_arguments)]
+    fn encode_inner_by_chunk_index(
+        &self,
+        chunk_index: usize,
+        decoded_value: &ArrayBytes,
+        shard_shape: &[NonZeroU64],
+        chunks_per_shard: &[NonZeroU64],
+        subchunk_shape: &[NonZeroU64],
+        options_inner: &CodecOptions,
+    ) -> Option<Result<(usize, Vec<u8>), CodecError>> {
+        let data_type = self.inner_codecs.data_type();
+        let fill_value = self.inner_codecs.fill_value();
+        let chunk_subset = self
+            .chunk_index_to_subset(chunk_index as u64, chunks_per_shard)
+            .expect("inbounds chunk");
+
+        let bytes = decoded_value.extract_array_subset(
+            &chunk_subset,
+            bytemuck::must_cast_slice(shard_shape),
+            data_type,
+        );
+        let bytes = match bytes {
+            Ok(bytes) => bytes,
+            Err(err) => return Some(Err(err)),
+        };
+
+        let is_fill_value = bytes.is_fill_value(fill_value);
+        if is_fill_value {
+            None
+        } else {
+            let encoded_chunk = self.inner_codecs.encode(
+                bytes,
+                subchunk_shape,
+                options_inner,
+            );
+            match encoded_chunk {
+                Ok(encoded_chunk) => Some(Ok((chunk_index, encoded_chunk.to_vec()))),
+                Err(err) => Some(Err(err)),
+            }
+        }
     }
 
     /// Decode the shard index inside the given encoded shard.

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -252,9 +252,7 @@ impl ShardingCodecBound {
         let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
             options.concurrent_target(),
             &self.recommended_concurrency(shard_shape)?,
-            &self
-                .inner_codecs
-                .recommended_concurrency(subchunk_shape)?,
+            &self.inner_codecs.recommended_concurrency(subchunk_shape)?,
         );
         let options = options.with_concurrent_target(concurrency_limit_subchunks);
 
@@ -376,11 +374,9 @@ impl ShardingCodecBound {
 
         // Encode and write array index
         let shard_index_bytes: ArrayBytesRaw = transmute_to_bytes_vec(shard_index).into();
-        let encoded_array_index = self.index_codecs.encode(
-            shard_index_bytes.into(),
-            &index_shape,
-            &options,
-        )?;
+        let encoded_array_index =
+            self.index_codecs
+                .encode(shard_index_bytes.into(), &index_shape, &options)?;
         {
             // SAFETY: `shard_slice` is not read from until it has been written
             let shard_slice = unsafe { crate::vec_spare_capacity_to_mut_slice(&mut shard) };
@@ -427,9 +423,7 @@ impl ShardingCodecBound {
         let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
             options.concurrent_target(),
             &self.recommended_concurrency(shard_shape)?,
-            &self
-                .inner_codecs
-                .recommended_concurrency(subchunk_shape)?,
+            &self.inner_codecs.recommended_concurrency(subchunk_shape)?,
         );
         let options_inner = options.with_concurrent_target(concurrency_limit_subchunks);
 
@@ -719,11 +713,7 @@ impl ArrayToBytesCodecTraits for ShardingCodecBound {
                         let size: usize = size.try_into().unwrap();
                         let encoded_chunk = &encoded_shard[offset..offset + size];
                         self.inner_codecs
-                            .decode(
-                                Cow::Borrowed(encoded_chunk),
-                                &self.subchunk_shape,
-                                &options,
-                            )?
+                            .decode(Cow::Borrowed(encoded_chunk), &self.subchunk_shape, &options)?
                             .into_variable()?
                     };
                     Ok((chunk_bytes, chunk_subset))
@@ -888,11 +878,9 @@ impl ArrayToBytesCodecTraits for ShardingCodecBound {
 
         // Encode and write index
         let index_bytes = transmute_to_bytes_vec(new_index);
-        let encoded_index = self.index_codecs.encode(
-            ArrayBytes::from(index_bytes),
-            &index_shape,
-            options,
-        )?;
+        let encoded_index =
+            self.index_codecs
+                .encode(ArrayBytes::from(index_bytes), &index_shape, options)?;
 
         match self.index_location {
             ShardingIndexLocation::Start => {
@@ -1115,11 +1103,9 @@ impl ShardingCodecBound {
         if is_fill_value {
             None
         } else {
-            let encoded_chunk = self.inner_codecs.encode(
-                bytes,
-                subchunk_shape,
-                options_inner,
-            );
+            let encoded_chunk = self
+                .inner_codecs
+                .encode(bytes, subchunk_shape, options_inner);
             match encoded_chunk {
                 Ok(encoded_chunk) => Some(Ok((chunk_index, encoded_chunk.to_vec()))),
                 Err(err) => Some(Err(err)),

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -26,7 +26,7 @@ use crate::array::{
 use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits,
     ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
-    BytesPartialEncoderTraits, CodecError, CodecMetadataOptions, CodecOptions,
+    BytesPartialEncoderTraits, CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions,
     CodecSpecificOptions, CodecTraits, PartialDecoderCapability, PartialEncoderCapability,
     RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
@@ -88,9 +88,14 @@ impl ShardingCodec {
     ) -> Result<Self, PluginCreateError> {
         match configuration {
             ShardingCodecConfiguration::V1(configuration) => {
-                let inner_codecs = Arc::new(CodecChain::from_metadata(&configuration.codecs)?);
-                let index_codecs =
-                    Arc::new(CodecChain::from_metadata(&configuration.index_codecs)?);
+                let inner_codecs = Arc::new(
+                    CodecChain::from_metadata(&configuration.codecs)
+                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
+                );
+                let index_codecs = Arc::new(
+                    CodecChain::from_metadata(&configuration.index_codecs)
+                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
+                );
                 Ok(Self::new(
                     configuration.chunk_shape.clone(),
                     inner_codecs,
@@ -162,7 +167,7 @@ impl UnboundArrayToBytesCodecTraits for ShardingCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         let inner_codecs = self
             .inner_codecs
             .clone()
@@ -183,7 +188,7 @@ impl UnboundArrayToBytesCodecTraits for ShardingCodec {
     fn with_codec_specific_options(
         self: Arc<Self>,
         opts: &CodecSpecificOptions,
-    ) -> Result<Arc<dyn UnboundArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn UnboundArrayToBytesCodecTraits>, CodecCreateError> {
         if let Some(sharding_opts) = opts.get_option::<ShardingCodecOptions>() {
             let mut codec = self;
             Arc::make_mut(&mut codec).options = sharding_opts.clone();

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -199,364 +199,6 @@ impl UnboundArrayToBytesCodecTraits for ShardingCodec {
     }
 }
 
-impl ShardingCodecBound {
-    /// Computed the bounded size of an encoded shard from
-    ///  - the chunk bytes representation, and
-    ///  - the number of chunks per shard.
-    ///
-    /// Equal to `num chunks * max chunk size + index size`
-    fn encoded_shard_bounded_size(
-        index_encoded_size: u64,
-        chunk_encoded_size: u64,
-        chunks_per_shard: &[NonZeroU64],
-    ) -> u64 {
-        let num_chunks = chunks_per_shard.iter().map(|i| i.get()).product::<u64>();
-        num_chunks * chunk_encoded_size + index_encoded_size
-    }
-
-    /// Preallocate shard, encode and write chunks (in parallel), then truncate shard
-    #[allow(clippy::too_many_lines)]
-    fn encode_bounded(
-        &self,
-        decoded_value: &ArrayBytes,
-        shard_shape: &[NonZeroU64],
-        subchunk_shape: &[NonZeroU64],
-        chunk_size_bounded: u64,
-        options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
-        // Calculate maximum possible shard size
-        let chunks_per_shard = calculate_chunks_per_shard(shard_shape, subchunk_shape)?;
-        let index_shape = sharding_index_shape(chunks_per_shard.as_slice());
-        let index_encoded_size =
-            compute_index_encoded_size(self.index_codecs.as_ref(), &index_shape)?;
-        let shard_size_bounded = Self::encoded_shard_bounded_size(
-            index_encoded_size,
-            chunk_size_bounded,
-            chunks_per_shard.as_slice(),
-        );
-
-        let shard_size_bounded = usize::try_from(shard_size_bounded).unwrap();
-        let index_encoded_size = usize::try_from(index_encoded_size).unwrap();
-
-        // Allocate an array for the shard
-        let mut shard = Vec::with_capacity(shard_size_bounded);
-
-        // Allocate the decoded shard index
-        let mut shard_index = vec![u64::MAX; index_shape.num_elements_usize()];
-        let encoded_shard_offset: usize = match self.index_location {
-            ShardingIndexLocation::Start => index_encoded_size,
-            ShardingIndexLocation::End => 0,
-        };
-
-        // Calc self/internal concurrent limits
-        let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
-            options.concurrent_target(),
-            &self.recommended_concurrency(shard_shape)?,
-            &self.inner_codecs.recommended_concurrency(subchunk_shape)?,
-        );
-        let options = options.with_concurrent_target(concurrency_limit_subchunks);
-
-        let n_chunks = chunks_per_shard
-            .as_slice()
-            .iter()
-            .map(|i| usize::try_from(i.get()).unwrap())
-            .product::<usize>();
-        let shard_slice = UnsafeCellSlice::new_from_vec_with_spare_capacity(&mut shard);
-        // Encode the shards and update the shard index
-        let encoded_shard_offset = match self.options.subchunk_write_order() {
-            SubchunkWriteOrder::Unordered | SubchunkWriteOrder::Random => {
-                let encoded_shard_offset_atomic: AtomicUsize = encoded_shard_offset.into();
-                let shard_index_slice = UnsafeCellSlice::new(&mut shard_index);
-                crate::iter_concurrent_limit!(
-                    shard_concurrent_limit,
-                    (0..n_chunks),
-                    try_for_each,
-                    |chunk_index: usize| {
-                        let maybe_chunk_encoded_with_id = self.encode_inner_by_chunk_index(
-                            chunk_index,
-                            decoded_value,
-                            shard_shape,
-                            chunks_per_shard.as_slice(),
-                            subchunk_shape,
-                            &options,
-                        );
-                        if let Some(chunk_encoded_with_id) = maybe_chunk_encoded_with_id {
-                            // We don't need to worry about the id because the order here is random.
-                            let chunk_encoded = chunk_encoded_with_id?.1;
-                            let chunk_offset = encoded_shard_offset_atomic.fetch_add(
-                                chunk_encoded.len(),
-                                std::sync::atomic::Ordering::Relaxed,
-                            );
-                            if chunk_offset + chunk_encoded.len() > shard_size_bounded {
-                                // This is a dev error, indicates the codec bounded size is not correct
-                                return Err(CodecError::from(
-                                    "Sharding did not allocate a large enough buffer",
-                                ));
-                            }
-
-                            unsafe {
-                                let shard_index_unsafe = shard_index_slice
-                                    .index_mut(chunk_index * 2..chunk_index * 2 + 2);
-                                shard_index_unsafe[0] = u64::try_from(chunk_offset).unwrap();
-                                shard_index_unsafe[1] = u64::try_from(chunk_encoded.len()).unwrap();
-
-                                shard_slice
-                                    .index_mut(chunk_offset..chunk_offset + chunk_encoded.len())
-                                    .copy_from_slice(&chunk_encoded);
-                            }
-                        }
-                        Ok(())
-                    }
-                )?;
-                Ok::<_, CodecError>(
-                    encoded_shard_offset_atomic.load(std::sync::atomic::Ordering::Relaxed),
-                )
-            }
-            SubchunkWriteOrder::C => {
-                // TODO: Replace this chunk order with the desired order i.e., a `Vec` of the ids i.e., for morton order.
-                let chunk_order = 0..n_chunks;
-                let encoded_chunk_ids_and_chunks: Vec<(usize, Vec<u8>)> =
-                    crate::iter_concurrent_limit!(
-                        shard_concurrent_limit,
-                        chunk_order,
-                        filter_map,
-                        |chunk_index: usize| {
-                            self.encode_inner_by_chunk_index(
-                                chunk_index,
-                                decoded_value,
-                                shard_shape,
-                                chunks_per_shard.as_slice(),
-                                subchunk_shape,
-                                &options,
-                            )
-                        }
-                    )
-                    .collect::<Result<Vec<_>, _>>()?;
-                let total_offset = encoded_chunk_ids_and_chunks.iter().fold(
-                    encoded_shard_offset,
-                    |acc: usize, (i, chunk)| {
-                        let chunk_len_usize = chunk.len();
-                        let chunk_length = u64::try_from(chunk_len_usize).unwrap();
-                        let chunk_offset = u64::try_from(acc).unwrap();
-                        let shard_index_unsafe = shard_index.index_mut(i * 2..i * 2 + 2);
-                        shard_index_unsafe[0] = chunk_offset;
-                        shard_index_unsafe[1] = chunk_length;
-                        acc + chunk_len_usize
-                    },
-                );
-                crate::iter_concurrent_limit!(
-                    shard_concurrent_limit,
-                    encoded_chunk_ids_and_chunks,
-                    for_each,
-                    |(chunk_index, chunk): (usize, Vec<u8>)| {
-                        unsafe {
-                            let shard_index_loc =
-                                &shard_index[chunk_index * 2..chunk_index * 2 + 2];
-                            let chunk_offset = usize::try_from(shard_index_loc[0]).unwrap();
-                            let chunk_encoded_len = usize::try_from(shard_index_loc[1]).unwrap();
-
-                            shard_slice
-                                .index_mut(chunk_offset..chunk_offset + chunk_encoded_len)
-                                .copy_from_slice(&chunk);
-                        }
-                    }
-                );
-                Ok(total_offset)
-            }
-        }?;
-
-        // Truncate shard
-        let shard_length = encoded_shard_offset
-            + match self.index_location {
-                ShardingIndexLocation::Start => 0,
-                ShardingIndexLocation::End => index_encoded_size,
-            };
-
-        // Encode and write array index
-        let shard_index_bytes: ArrayBytesRaw = transmute_to_bytes_vec(shard_index).into();
-        let encoded_array_index =
-            self.index_codecs
-                .encode(shard_index_bytes.into(), &index_shape, &options)?;
-        {
-            // SAFETY: `shard_slice` is not read from until it has been written
-            let shard_slice = unsafe { crate::vec_spare_capacity_to_mut_slice(&mut shard) };
-            match self.index_location {
-                ShardingIndexLocation::Start => {
-                    shard_slice[..encoded_array_index.len()].copy_from_slice(&encoded_array_index);
-                }
-                ShardingIndexLocation::End => {
-                    shard_slice[shard_length - encoded_array_index.len()..shard_length]
-                        .copy_from_slice(&encoded_array_index);
-                }
-            }
-        }
-        // SAFETY: all elements have been initialised
-        unsafe { shard.set_len(shard_length) };
-        Ok(shard)
-    }
-
-    /// Encode subchunks (in parallel), then allocate shard, then write to shard (in parallel)
-    // TODO: Collecting chunks then allocating shard can use a lot of memory, have a low memory variant
-    // TODO: Also benchmark performance with just performing an alloc like 1x decoded size and writing directly into it, growing if needed
-    #[allow(clippy::too_many_lines)]
-    fn encode_unbounded(
-        &self,
-        decoded_value: &ArrayBytes,
-        shard_shape: &[NonZeroU64],
-        subchunk_shape: &[NonZeroU64],
-        options: &CodecOptions,
-    ) -> Result<Vec<u8>, CodecError> {
-        let chunks_per_shard = calculate_chunks_per_shard(shard_shape, subchunk_shape)?;
-        let index_shape = sharding_index_shape(chunks_per_shard.as_slice());
-        let index_encoded_size =
-            compute_index_encoded_size(self.index_codecs.as_ref(), &index_shape)?;
-        let index_encoded_size = usize::try_from(index_encoded_size).unwrap();
-
-        // Find chunks that are not entirely the fill value and collect their decoded bytes
-        let n_chunks = chunks_per_shard
-            .as_slice()
-            .iter()
-            .map(|i| usize::try_from(i.get()).unwrap())
-            .product::<usize>();
-
-        // Calc self/internal concurrent limits
-        let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
-            options.concurrent_target(),
-            &self.recommended_concurrency(shard_shape)?,
-            &self.inner_codecs.recommended_concurrency(subchunk_shape)?,
-        );
-        let options_inner = options.with_concurrent_target(concurrency_limit_subchunks);
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let iterator = match self.options.subchunk_write_order() {
-            SubchunkWriteOrder::Unordered | SubchunkWriteOrder::Random | SubchunkWriteOrder::C => {
-                (0..n_chunks).into_par_iter()
-            }
-        };
-        #[cfg(target_arch = "wasm32")]
-        let iterator = match self.options.subchunk_write_order() {
-            SubchunkWriteOrder::Unordered | SubchunkWriteOrder::Random | SubchunkWriteOrder::C => {
-                0..n_chunks
-            }
-        };
-
-        let encoded_chunks: Vec<(usize, Vec<u8>)> = crate::iter_concurrent_limit!(
-            shard_concurrent_limit,
-            iterator,
-            filter_map,
-            |chunk_index| self.encode_inner_by_chunk_index(
-                chunk_index,
-                decoded_value,
-                shard_shape,
-                chunks_per_shard.as_slice(),
-                subchunk_shape,
-                &options_inner
-            )
-        )
-        .collect::<Result<Vec<_>, _>>()?;
-
-        // Allocate the shard
-        let encoded_chunk_length = encoded_chunks
-            .iter()
-            .map(|(_, bytes)| bytes.len())
-            .sum::<usize>();
-        let shard_length = encoded_chunk_length + index_encoded_size;
-        let mut shard = Vec::with_capacity(shard_length);
-
-        // Allocate the decoded shard index
-        let mut shard_index = vec![u64::MAX; index_shape.num_elements_usize()];
-        let encoded_shard_offset = match self.index_location {
-            ShardingIndexLocation::Start => index_encoded_size,
-            ShardingIndexLocation::End => 0,
-        };
-        let shard_slice = UnsafeCellSlice::new_from_vec_with_spare_capacity(&mut shard);
-
-        // Write shard and update shard index
-        if !encoded_chunks.is_empty() {
-            match self.options.subchunk_write_order() {
-                SubchunkWriteOrder::Unordered | SubchunkWriteOrder::Random => {
-                    let encoded_shard_offset_atomic: AtomicUsize = encoded_shard_offset.into();
-                    let shard_index_slice = UnsafeCellSlice::new(&mut shard_index);
-                    crate::iter_concurrent_limit!(
-                        options.concurrent_target(),
-                        encoded_chunks,
-                        for_each,
-                        |(chunk_index, chunk_encoded): (usize, Vec<u8>)| {
-                            let chunk_offset = encoded_shard_offset_atomic.fetch_add(
-                                chunk_encoded.len(),
-                                std::sync::atomic::Ordering::Relaxed,
-                            );
-                            unsafe {
-                                let shard_index_unsafe = shard_index_slice
-                                    .index_mut(chunk_index * 2..chunk_index * 2 + 2);
-                                shard_index_unsafe[0] = u64::try_from(chunk_offset).unwrap();
-                                shard_index_unsafe[1] = u64::try_from(chunk_encoded.len()).unwrap();
-
-                                shard_slice
-                                    .index_mut(chunk_offset..chunk_offset + chunk_encoded.len())
-                                    .copy_from_slice(&chunk_encoded);
-                            }
-                        }
-                    );
-                }
-                SubchunkWriteOrder::C => {
-                    let mut offset = encoded_shard_offset;
-                    for (i, chunk) in &encoded_chunks {
-                        let chunk_len_usize = chunk.len();
-                        let chunk_length = u64::try_from(chunk_len_usize).unwrap();
-                        let chunk_offset = u64::try_from(offset).unwrap();
-                        let shard_index_unsafe = shard_index.index_mut(i * 2..i * 2 + 2);
-                        shard_index_unsafe[0] = chunk_offset;
-                        shard_index_unsafe[1] = chunk_length;
-                        offset += chunk_len_usize;
-                    }
-                    crate::iter_concurrent_limit!(
-                        options.concurrent_target(),
-                        encoded_chunks,
-                        for_each,
-                        |(chunk_index, chunk): (usize, Vec<u8>)| {
-                            unsafe {
-                                let shard_index_loc =
-                                    &shard_index[chunk_index * 2..chunk_index * 2 + 2];
-                                let chunk_offset = usize::try_from(shard_index_loc[0]).unwrap();
-                                let chunk_encoded_len =
-                                    usize::try_from(shard_index_loc[1]).unwrap();
-
-                                shard_slice
-                                    .index_mut(chunk_offset..chunk_offset + chunk_encoded_len)
-                                    .copy_from_slice(&chunk);
-                            }
-                        }
-                    );
-                }
-            }
-        }
-
-        // Write shard index
-        let encoded_array_index = self.index_codecs.encode(
-            ArrayBytes::from(transmute_to_bytes_vec(shard_index)),
-            &index_shape,
-            options,
-        )?;
-        {
-            // SAFETY: `shard_slice` is not read from until it has been written
-            let shard_slice = unsafe { crate::vec_spare_capacity_to_mut_slice(&mut shard) };
-            match self.index_location {
-                ShardingIndexLocation::Start => {
-                    shard_slice[..encoded_array_index.len()].copy_from_slice(&encoded_array_index);
-                }
-                ShardingIndexLocation::End => {
-                    shard_slice[shard_length - encoded_array_index.len()..]
-                        .copy_from_slice(&encoded_array_index);
-                }
-            }
-        }
-        // SAFETY: all elements have been initialised
-        unsafe { shard.set_len(shard_length) };
-        Ok(shard)
-    }
-}
-
 impl ArrayCodecTraits for ShardingCodecBound {
     fn as_any(&self) -> &dyn std::any::Any {
         self
@@ -588,32 +230,6 @@ impl ArrayCodecTraits for ShardingCodecBound {
 impl ArrayToBytesCodecTraits for ShardingCodecBound {
     fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
         self as Arc<dyn ArrayToBytesCodecTraits>
-    }
-
-    fn encoded_representation(
-        &self,
-        shape: &[NonZeroU64],
-    ) -> Result<BytesRepresentation, CodecError> {
-        // Get the maximum size of encoded chunks
-        let chunk_bytes_representation = self.inner_codecs.encoded_representation(shape)?;
-
-        match chunk_bytes_representation {
-            BytesRepresentation::BoundedSize(size) | BytesRepresentation::FixedSize(size) => {
-                let chunks_per_shard =
-                    calculate_chunks_per_shard(shape, self.subchunk_shape.as_slice())?;
-                let index_encoded_size = compute_index_encoded_size(
-                    self.index_codecs.as_ref(),
-                    &sharding_index_shape(chunks_per_shard.as_slice()),
-                )?;
-                let shard_size = Self::encoded_shard_bounded_size(
-                    index_encoded_size,
-                    size,
-                    chunks_per_shard.as_slice(),
-                );
-                Ok(BytesRepresentation::BoundedSize(shard_size))
-            }
-            BytesRepresentation::UnboundedSize => Ok(BytesRepresentation::UnboundedSize),
-        }
     }
 
     fn partial_decode_granularity(
@@ -1008,26 +624,6 @@ impl ArrayToBytesCodecTraits for ShardingCodecBound {
         )?))
     }
 
-    fn partial_encoder(
-        self: Arc<Self>,
-        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
-        shape: &[NonZeroU64],
-        options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
-        Ok(Arc::new(
-            sharding_partial_encoder::ShardingPartialEncoder::new(
-                input_output_handle,
-                ChunkShape::from(shape.to_vec()),
-                self.subchunk_shape.clone(),
-                self.inner_codecs.clone(),
-                self.index_codecs.clone(),
-                self.index_location,
-                options,
-                self.options.clone(),
-            )?,
-        ))
-    }
-
     #[cfg(feature = "async")]
     async fn async_partial_decoder(
         self: Arc<Self>,
@@ -1048,6 +644,51 @@ impl ArrayToBytesCodecTraits for ShardingCodecBound {
             )
             .await?,
         ))
+    }
+    fn partial_encoder(
+        self: Arc<Self>,
+        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        Ok(Arc::new(
+            sharding_partial_encoder::ShardingPartialEncoder::new(
+                input_output_handle,
+                ChunkShape::from(shape.to_vec()),
+                self.subchunk_shape.clone(),
+                self.inner_codecs.clone(),
+                self.index_codecs.clone(),
+                self.index_location,
+                options,
+                self.options.clone(),
+            )?,
+        ))
+    }
+
+    fn encoded_representation(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<BytesRepresentation, CodecError> {
+        // Get the maximum size of encoded chunks
+        let chunk_bytes_representation = self.inner_codecs.encoded_representation(shape)?;
+
+        match chunk_bytes_representation {
+            BytesRepresentation::BoundedSize(size) | BytesRepresentation::FixedSize(size) => {
+                let chunks_per_shard =
+                    calculate_chunks_per_shard(shape, self.subchunk_shape.as_slice())?;
+                let index_encoded_size = compute_index_encoded_size(
+                    self.index_codecs.as_ref(),
+                    &sharding_index_shape(chunks_per_shard.as_slice()),
+                )?;
+                let shard_size = Self::encoded_shard_bounded_size(
+                    index_encoded_size,
+                    size,
+                    chunks_per_shard.as_slice(),
+                );
+                Ok(BytesRepresentation::BoundedSize(shard_size))
+            }
+            BytesRepresentation::UnboundedSize => Ok(BytesRepresentation::UnboundedSize),
+        }
     }
 }
 
@@ -1070,6 +711,20 @@ impl ShardingCodecBound {
             .zip(&chunk_start)
             .map(|(&sh, &st)| st..(st + sh.get()));
         Some(ArraySubset::from(ranges))
+    }
+
+    /// Computed the bounded size of an encoded shard from
+    ///  - the chunk bytes representation, and
+    ///  - the number of chunks per shard.
+    ///
+    /// Equal to `num chunks * max chunk size + index size`
+    fn encoded_shard_bounded_size(
+        index_encoded_size: u64,
+        chunk_encoded_size: u64,
+        chunks_per_shard: &[NonZeroU64],
+    ) -> u64 {
+        let num_chunks = chunks_per_shard.iter().map(|i| i.get()).product::<u64>();
+        num_chunks * chunk_encoded_size + index_encoded_size
     }
 
     /// Encode an inner chunk from the `decoded_value` or return None.
@@ -1110,6 +765,348 @@ impl ShardingCodecBound {
                 Err(err) => Some(Err(err)),
             }
         }
+    }
+
+    /// Preallocate shard, encode and write chunks (in parallel), then truncate shard
+    #[allow(clippy::too_many_lines)]
+    fn encode_bounded(
+        &self,
+        decoded_value: &ArrayBytes,
+        shard_shape: &[NonZeroU64],
+        subchunk_shape: &[NonZeroU64],
+        chunk_size_bounded: u64,
+        options: &CodecOptions,
+    ) -> Result<Vec<u8>, CodecError> {
+        // Calculate maximum possible shard size
+        let chunks_per_shard = calculate_chunks_per_shard(shard_shape, subchunk_shape)?;
+        let index_shape = sharding_index_shape(chunks_per_shard.as_slice());
+        let index_encoded_size =
+            compute_index_encoded_size(self.index_codecs.as_ref(), &index_shape)?;
+        let shard_size_bounded = Self::encoded_shard_bounded_size(
+            index_encoded_size,
+            chunk_size_bounded,
+            chunks_per_shard.as_slice(),
+        );
+
+        let shard_size_bounded = usize::try_from(shard_size_bounded).unwrap();
+        let index_encoded_size = usize::try_from(index_encoded_size).unwrap();
+
+        // Allocate an array for the shard
+        let mut shard = Vec::with_capacity(shard_size_bounded);
+
+        // Allocate the decoded shard index
+        let mut shard_index = vec![u64::MAX; index_shape.num_elements_usize()];
+        let encoded_shard_offset: usize = match self.index_location {
+            ShardingIndexLocation::Start => index_encoded_size,
+            ShardingIndexLocation::End => 0,
+        };
+
+        // Calc self/internal concurrent limits
+        let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
+            options.concurrent_target(),
+            &self.recommended_concurrency(shard_shape)?,
+            &self.inner_codecs.recommended_concurrency(subchunk_shape)?,
+        );
+        let options = options.with_concurrent_target(concurrency_limit_subchunks);
+
+        let n_chunks = chunks_per_shard
+            .as_slice()
+            .iter()
+            .map(|i| usize::try_from(i.get()).unwrap())
+            .product::<usize>();
+        let shard_slice = UnsafeCellSlice::new_from_vec_with_spare_capacity(&mut shard);
+        // Encode the shards and update the shard index
+        let encoded_shard_offset = match self.options.subchunk_write_order() {
+            SubchunkWriteOrder::Unordered | SubchunkWriteOrder::Random => {
+                let encoded_shard_offset_atomic: AtomicUsize = encoded_shard_offset.into();
+                let shard_index_slice = UnsafeCellSlice::new(&mut shard_index);
+                crate::iter_concurrent_limit!(
+                    shard_concurrent_limit,
+                    (0..n_chunks),
+                    try_for_each,
+                    |chunk_index: usize| {
+                        let maybe_chunk_encoded_with_id = self.encode_inner_by_chunk_index(
+                            chunk_index,
+                            decoded_value,
+                            shard_shape,
+                            chunks_per_shard.as_slice(),
+                            subchunk_shape,
+                            &options,
+                        );
+                        if let Some(chunk_encoded_with_id) = maybe_chunk_encoded_with_id {
+                            // We don't need to worry about the id because the order here is random.
+                            let chunk_encoded = chunk_encoded_with_id?.1;
+                            let chunk_offset = encoded_shard_offset_atomic.fetch_add(
+                                chunk_encoded.len(),
+                                std::sync::atomic::Ordering::Relaxed,
+                            );
+                            if chunk_offset + chunk_encoded.len() > shard_size_bounded {
+                                // This is a dev error, indicates the codec bounded size is not correct
+                                return Err(CodecError::from(
+                                    "Sharding did not allocate a large enough buffer",
+                                ));
+                            }
+
+                            unsafe {
+                                let shard_index_unsafe = shard_index_slice
+                                    .index_mut(chunk_index * 2..chunk_index * 2 + 2);
+                                shard_index_unsafe[0] = u64::try_from(chunk_offset).unwrap();
+                                shard_index_unsafe[1] = u64::try_from(chunk_encoded.len()).unwrap();
+
+                                shard_slice
+                                    .index_mut(chunk_offset..chunk_offset + chunk_encoded.len())
+                                    .copy_from_slice(&chunk_encoded);
+                            }
+                        }
+                        Ok(())
+                    }
+                )?;
+                Ok::<_, CodecError>(
+                    encoded_shard_offset_atomic.load(std::sync::atomic::Ordering::Relaxed),
+                )
+            }
+            SubchunkWriteOrder::C => {
+                // TODO: Replace this chunk order with the desired order i.e., a `Vec` of the ids i.e., for morton order.
+                let chunk_order = 0..n_chunks;
+                let encoded_chunk_ids_and_chunks: Vec<(usize, Vec<u8>)> =
+                    crate::iter_concurrent_limit!(
+                        shard_concurrent_limit,
+                        chunk_order,
+                        filter_map,
+                        |chunk_index: usize| {
+                            self.encode_inner_by_chunk_index(
+                                chunk_index,
+                                decoded_value,
+                                shard_shape,
+                                chunks_per_shard.as_slice(),
+                                subchunk_shape,
+                                &options,
+                            )
+                        }
+                    )
+                    .collect::<Result<Vec<_>, _>>()?;
+                let total_offset = encoded_chunk_ids_and_chunks.iter().fold(
+                    encoded_shard_offset,
+                    |acc: usize, (i, chunk)| {
+                        let chunk_len_usize = chunk.len();
+                        let chunk_length = u64::try_from(chunk_len_usize).unwrap();
+                        let chunk_offset = u64::try_from(acc).unwrap();
+                        let shard_index_unsafe = shard_index.index_mut(i * 2..i * 2 + 2);
+                        shard_index_unsafe[0] = chunk_offset;
+                        shard_index_unsafe[1] = chunk_length;
+                        acc + chunk_len_usize
+                    },
+                );
+                crate::iter_concurrent_limit!(
+                    shard_concurrent_limit,
+                    encoded_chunk_ids_and_chunks,
+                    for_each,
+                    |(chunk_index, chunk): (usize, Vec<u8>)| {
+                        unsafe {
+                            let shard_index_loc =
+                                &shard_index[chunk_index * 2..chunk_index * 2 + 2];
+                            let chunk_offset = usize::try_from(shard_index_loc[0]).unwrap();
+                            let chunk_encoded_len = usize::try_from(shard_index_loc[1]).unwrap();
+
+                            shard_slice
+                                .index_mut(chunk_offset..chunk_offset + chunk_encoded_len)
+                                .copy_from_slice(&chunk);
+                        }
+                    }
+                );
+                Ok(total_offset)
+            }
+        }?;
+
+        // Truncate shard
+        let shard_length = encoded_shard_offset
+            + match self.index_location {
+                ShardingIndexLocation::Start => 0,
+                ShardingIndexLocation::End => index_encoded_size,
+            };
+
+        // Encode and write array index
+        let shard_index_bytes: ArrayBytesRaw = transmute_to_bytes_vec(shard_index).into();
+        let encoded_array_index =
+            self.index_codecs
+                .encode(shard_index_bytes.into(), &index_shape, &options)?;
+        {
+            // SAFETY: `shard_slice` is not read from until it has been written
+            let shard_slice = unsafe { crate::vec_spare_capacity_to_mut_slice(&mut shard) };
+            match self.index_location {
+                ShardingIndexLocation::Start => {
+                    shard_slice[..encoded_array_index.len()].copy_from_slice(&encoded_array_index);
+                }
+                ShardingIndexLocation::End => {
+                    shard_slice[shard_length - encoded_array_index.len()..shard_length]
+                        .copy_from_slice(&encoded_array_index);
+                }
+            }
+        }
+        // SAFETY: all elements have been initialised
+        unsafe { shard.set_len(shard_length) };
+        Ok(shard)
+    }
+
+    /// Encode subchunks (in parallel), then allocate shard, then write to shard (in parallel)
+    // TODO: Collecting chunks then allocating shard can use a lot of memory, have a low memory variant
+    // TODO: Also benchmark performance with just performing an alloc like 1x decoded size and writing directly into it, growing if needed
+    #[allow(clippy::too_many_lines)]
+    fn encode_unbounded(
+        &self,
+        decoded_value: &ArrayBytes,
+        shard_shape: &[NonZeroU64],
+        subchunk_shape: &[NonZeroU64],
+        options: &CodecOptions,
+    ) -> Result<Vec<u8>, CodecError> {
+        let chunks_per_shard = calculate_chunks_per_shard(shard_shape, subchunk_shape)?;
+        let index_shape = sharding_index_shape(chunks_per_shard.as_slice());
+        let index_encoded_size =
+            compute_index_encoded_size(self.index_codecs.as_ref(), &index_shape)?;
+        let index_encoded_size = usize::try_from(index_encoded_size).unwrap();
+
+        // Find chunks that are not entirely the fill value and collect their decoded bytes
+        let n_chunks = chunks_per_shard
+            .as_slice()
+            .iter()
+            .map(|i| usize::try_from(i.get()).unwrap())
+            .product::<usize>();
+
+        // Calc self/internal concurrent limits
+        let (shard_concurrent_limit, concurrency_limit_subchunks) = calc_concurrency_outer_inner(
+            options.concurrent_target(),
+            &self.recommended_concurrency(shard_shape)?,
+            &self.inner_codecs.recommended_concurrency(subchunk_shape)?,
+        );
+        let options_inner = options.with_concurrent_target(concurrency_limit_subchunks);
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let iterator = match self.options.subchunk_write_order() {
+            SubchunkWriteOrder::Unordered | SubchunkWriteOrder::Random | SubchunkWriteOrder::C => {
+                (0..n_chunks).into_par_iter()
+            }
+        };
+        #[cfg(target_arch = "wasm32")]
+        let iterator = match self.options.subchunk_write_order() {
+            SubchunkWriteOrder::Unordered | SubchunkWriteOrder::Random | SubchunkWriteOrder::C => {
+                0..n_chunks
+            }
+        };
+
+        let encoded_chunks: Vec<(usize, Vec<u8>)> = crate::iter_concurrent_limit!(
+            shard_concurrent_limit,
+            iterator,
+            filter_map,
+            |chunk_index| self.encode_inner_by_chunk_index(
+                chunk_index,
+                decoded_value,
+                shard_shape,
+                chunks_per_shard.as_slice(),
+                subchunk_shape,
+                &options_inner
+            )
+        )
+        .collect::<Result<Vec<_>, _>>()?;
+
+        // Allocate the shard
+        let encoded_chunk_length = encoded_chunks
+            .iter()
+            .map(|(_, bytes)| bytes.len())
+            .sum::<usize>();
+        let shard_length = encoded_chunk_length + index_encoded_size;
+        let mut shard = Vec::with_capacity(shard_length);
+
+        // Allocate the decoded shard index
+        let mut shard_index = vec![u64::MAX; index_shape.num_elements_usize()];
+        let encoded_shard_offset = match self.index_location {
+            ShardingIndexLocation::Start => index_encoded_size,
+            ShardingIndexLocation::End => 0,
+        };
+        let shard_slice = UnsafeCellSlice::new_from_vec_with_spare_capacity(&mut shard);
+
+        // Write shard and update shard index
+        if !encoded_chunks.is_empty() {
+            match self.options.subchunk_write_order() {
+                SubchunkWriteOrder::Unordered | SubchunkWriteOrder::Random => {
+                    let encoded_shard_offset_atomic: AtomicUsize = encoded_shard_offset.into();
+                    let shard_index_slice = UnsafeCellSlice::new(&mut shard_index);
+                    crate::iter_concurrent_limit!(
+                        options.concurrent_target(),
+                        encoded_chunks,
+                        for_each,
+                        |(chunk_index, chunk_encoded): (usize, Vec<u8>)| {
+                            let chunk_offset = encoded_shard_offset_atomic.fetch_add(
+                                chunk_encoded.len(),
+                                std::sync::atomic::Ordering::Relaxed,
+                            );
+                            unsafe {
+                                let shard_index_unsafe = shard_index_slice
+                                    .index_mut(chunk_index * 2..chunk_index * 2 + 2);
+                                shard_index_unsafe[0] = u64::try_from(chunk_offset).unwrap();
+                                shard_index_unsafe[1] = u64::try_from(chunk_encoded.len()).unwrap();
+
+                                shard_slice
+                                    .index_mut(chunk_offset..chunk_offset + chunk_encoded.len())
+                                    .copy_from_slice(&chunk_encoded);
+                            }
+                        }
+                    );
+                }
+                SubchunkWriteOrder::C => {
+                    let mut offset = encoded_shard_offset;
+                    for (i, chunk) in &encoded_chunks {
+                        let chunk_len_usize = chunk.len();
+                        let chunk_length = u64::try_from(chunk_len_usize).unwrap();
+                        let chunk_offset = u64::try_from(offset).unwrap();
+                        let shard_index_unsafe = shard_index.index_mut(i * 2..i * 2 + 2);
+                        shard_index_unsafe[0] = chunk_offset;
+                        shard_index_unsafe[1] = chunk_length;
+                        offset += chunk_len_usize;
+                    }
+                    crate::iter_concurrent_limit!(
+                        options.concurrent_target(),
+                        encoded_chunks,
+                        for_each,
+                        |(chunk_index, chunk): (usize, Vec<u8>)| {
+                            unsafe {
+                                let shard_index_loc =
+                                    &shard_index[chunk_index * 2..chunk_index * 2 + 2];
+                                let chunk_offset = usize::try_from(shard_index_loc[0]).unwrap();
+                                let chunk_encoded_len =
+                                    usize::try_from(shard_index_loc[1]).unwrap();
+
+                                shard_slice
+                                    .index_mut(chunk_offset..chunk_offset + chunk_encoded_len)
+                                    .copy_from_slice(&chunk);
+                            }
+                        }
+                    );
+                }
+            }
+        }
+
+        // Write shard index
+        let encoded_array_index = self.index_codecs.encode(
+            ArrayBytes::from(transmute_to_bytes_vec(shard_index)),
+            &index_shape,
+            options,
+        )?;
+        {
+            // SAFETY: `shard_slice` is not read from until it has been written
+            let shard_slice = unsafe { crate::vec_spare_capacity_to_mut_slice(&mut shard) };
+            match self.index_location {
+                ShardingIndexLocation::Start => {
+                    shard_slice[..encoded_array_index.len()].copy_from_slice(&encoded_array_index);
+                }
+                ShardingIndexLocation::End => {
+                    shard_slice[shard_length - encoded_array_index.len()..]
+                        .copy_from_slice(&encoded_array_index);
+                }
+            }
+        }
+        // SAFETY: all elements have been initialised
+        unsafe { shard.set_len(shard_length) };
+        Ok(shard)
     }
 
     /// Decode the shard index inside the given encoded shard.

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -179,7 +179,7 @@ impl UnboundArrayToBytesCodecTraits for ShardingCodec {
             subchunk_shape: self.subchunk_shape.clone(),
             inner_codecs,
             index_codecs,
-            index_location: self.index_location.clone(),
+            index_location: self.index_location,
             options: self.options.clone(),
         }))
     }
@@ -215,7 +215,6 @@ impl ShardingCodecBound {
 
     /// Preallocate shard, encode and write chunks (in parallel), then truncate shard
     #[allow(clippy::too_many_lines)]
-    #[expect(clippy::too_many_arguments)]
     fn encode_bounded(
         &self,
         decoded_value: &ArrayBytes,
@@ -1073,7 +1072,6 @@ impl ShardingCodecBound {
     }
 
     /// Encode an inner chunk from the `decoded_value` or return None.
-    #[expect(clippy::too_many_arguments)]
     fn encode_inner_by_chunk_index(
         &self,
         chunk_index: usize,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -53,11 +53,11 @@ pub struct ShardingCodec {
 /// A `sharding` codec implementation bound to a data type and fill value.
 #[derive(Clone, Debug)]
 pub(crate) struct ShardingCodecBound {
-    subchunk_shape: ChunkShape,
-    inner_codecs: Arc<CodecChainBound>,
-    index_codecs: Arc<CodecChainBound>,
-    index_location: ShardingIndexLocation,
-    options: ShardingCodecOptions,
+    pub(crate) subchunk_shape: ChunkShape,
+    pub(crate) inner_codecs: Arc<CodecChainBound>,
+    pub(crate) index_codecs: Arc<CodecChainBound>,
+    pub(crate) index_location: ShardingIndexLocation,
+    pub(crate) options: ShardingCodecOptions,
 }
 
 impl ShardingCodec {
@@ -1120,7 +1120,7 @@ impl ShardingCodecBound {
     ///
     /// # Panics
     /// Panics if the encoded index size or the encoded shard minux its index length exceeds [`usize::MAX`].
-    pub fn decode_index(
+    pub(crate) fn decode_index(
         &self,
         encoded_shard: &[u8],
         chunks_per_shard: &[NonZeroU64],

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -120,10 +120,6 @@ impl ShardingCodec {
 }
 
 impl CodecTraits for ShardingCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec_builder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec_builder.rs
@@ -5,7 +5,9 @@ use super::{ShardingCodec, ShardingIndexLocation};
 use crate::array::codec::Crc32cCodec;
 use crate::array::codec::{BytesCodec, CodecChain, default_array_to_bytes_codec};
 use crate::array::{ChunkShape, DataType};
-use zarrs_codec::{ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, BytesToBytesCodecTraits};
+use zarrs_codec::{
+    BytesToBytesCodecTraits, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
+};
 
 /// A [`ShardingCodec`] builder.
 ///
@@ -16,10 +18,10 @@ use zarrs_codec::{ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, BytesToBytes
 #[derive(Debug)]
 pub struct ShardingCodecBuilder {
     subchunk_shape: ChunkShape,
-    index_array_to_bytes_codec: Arc<dyn ArrayToBytesCodecTraits>,
+    index_array_to_bytes_codec: Arc<dyn UnboundArrayToBytesCodecTraits>,
     index_bytes_to_bytes_codecs: Vec<Arc<dyn BytesToBytesCodecTraits>>,
-    array_to_array_codecs: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
-    array_to_bytes_codec: Arc<dyn ArrayToBytesCodecTraits>,
+    array_to_array_codecs: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>>,
+    array_to_bytes_codec: Arc<dyn UnboundArrayToBytesCodecTraits>,
     bytes_to_bytes_codecs: Vec<Arc<dyn BytesToBytesCodecTraits>>,
     index_location: ShardingIndexLocation,
 }
@@ -50,7 +52,7 @@ impl ShardingCodecBuilder {
     /// If left unmodified, the index will be encoded with the `bytes` codec with native endian encoding.
     pub fn index_array_to_bytes_codec(
         &mut self,
-        index_array_to_bytes_codec: Arc<dyn ArrayToBytesCodecTraits>,
+        index_array_to_bytes_codec: Arc<dyn UnboundArrayToBytesCodecTraits>,
     ) -> &mut Self {
         self.index_array_to_bytes_codec = index_array_to_bytes_codec;
         self
@@ -72,7 +74,7 @@ impl ShardingCodecBuilder {
     /// If left unmodified, no array to array codecs will be applied for the subchunks.
     pub fn array_to_array_codecs(
         &mut self,
-        array_to_array_codecs: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
+        array_to_array_codecs: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>>,
     ) -> &mut Self {
         self.array_to_array_codecs = array_to_array_codecs;
         self
@@ -84,7 +86,7 @@ impl ShardingCodecBuilder {
     /// (see [`default_array_to_bytes_codec`]).
     pub fn array_to_bytes_codec(
         &mut self,
-        array_to_bytes_codec: Arc<dyn ArrayToBytesCodecTraits>,
+        array_to_bytes_codec: Arc<dyn UnboundArrayToBytesCodecTraits>,
     ) -> &mut Self {
         self.array_to_bytes_codec = array_to_bytes_codec;
         self

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -101,7 +101,6 @@ impl AsyncShardingPartialDecoder {
     }
 }
 
-#[expect(clippy::too_many_arguments)]
 pub(crate) async fn partial_decode(
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     shard_shape: &[NonZeroU64],
@@ -190,7 +189,7 @@ pub(crate) async fn partial_decode(
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder {
     fn data_type(&self) -> &DataType {
-        &self.inner_codecs.data_type()
+        self.inner_codecs.data_type()
     }
 
     async fn exists(&self) -> Result<bool, StorageError> {
@@ -224,7 +223,6 @@ impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder {
     }
 }
 
-#[expect(clippy::too_many_arguments)]
 async fn get_subchunk_partial_decoder(
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     subchunk_shape: &[NonZeroU64],
@@ -258,7 +256,6 @@ async fn get_subchunk_partial_decoder(
 }
 
 #[allow(clippy::too_many_lines)]
-#[expect(clippy::too_many_arguments)]
 async fn partial_decode_fixed_array_subset(
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     shard_shape: &[NonZeroU64],
@@ -532,7 +529,6 @@ async fn partial_decode_variable_array_subset(
     Ok(ArrayBytes::Variable(out_array_subset))
 }
 
-#[expect(clippy::too_many_arguments)]
 async fn partial_decode_fixed_indexer(
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     shard_shape: &[NonZeroU64],

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -6,12 +6,10 @@ use rayon::prelude::*;
 use unsafe_cell_slice::UnsafeCellSlice;
 use zarrs_chunk_grid::ChunkGridTraits;
 use zarrs_data_type::FillValue;
-use zarrs_metadata_ext::data_type;
 
 use super::{ShardingCodecOptions, ShardingIndexLocation, calculate_chunks_per_shard};
 use crate::array::array_bytes_internal::merge_chunks_vlen;
 use crate::array::chunk_grid::RegularChunkGrid;
-use crate::array::codec::CodecChain;
 use crate::array::{
     ArrayBytes, ArrayBytesFixedDisjointView, ArrayBytesOffsets, ArrayBytesRaw, ArrayIndices,
     ArrayIndicesTinyVec, ArraySubset, ArraySubsetTraits, ChunkShape, ChunkShapeTraits,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -6,6 +6,7 @@ use rayon::prelude::*;
 use unsafe_cell_slice::UnsafeCellSlice;
 use zarrs_chunk_grid::ChunkGridTraits;
 use zarrs_data_type::FillValue;
+use zarrs_metadata_ext::data_type;
 
 use super::{ShardingCodecOptions, ShardingIndexLocation, calculate_chunks_per_shard};
 use crate::array::array_bytes_internal::merge_chunks_vlen;
@@ -13,12 +14,12 @@ use crate::array::chunk_grid::RegularChunkGrid;
 use crate::array::codec::CodecChain;
 use crate::array::{
     ArrayBytes, ArrayBytesFixedDisjointView, ArrayBytesOffsets, ArrayBytesRaw, ArrayIndices,
-    ArrayIndicesTinyVec, ArraySubset, ArraySubsetTraits, ChunkShape, ChunkShapeTraits, DataType,
-    DataTypeSize, IncompatibleDimensionalityError, Indexer, IndexerError, ravel_indices,
+    ArrayIndicesTinyVec, ArraySubset, ArraySubsetTraits, ChunkShape, ChunkShapeTraits,
+    CodecChainBound, DataType, DataTypeSize, IncompatibleDimensionalityError, Indexer,
+    IndexerError, ravel_indices,
 };
 use zarrs_codec::{
-    AsyncArrayPartialDecoderTraits, AsyncByteIntervalPartialDecoder,
-    AsyncBytesPartialDecoderTraits, CodecError, CodecOptions, UnboundArrayToBytesCodecTraits,
+    ArrayCodecTraits, ArrayToBytesCodecTraits, AsyncArrayPartialDecoderTraits, AsyncByteIntervalPartialDecoder, AsyncBytesPartialDecoderTraits, CodecError, CodecOptions
 };
 use zarrs_plugin::ExtensionAliasesV3;
 use zarrs_storage::StorageError;
@@ -27,11 +28,9 @@ use zarrs_storage::byte_range::{ByteLength, ByteOffset, ByteRange};
 /// Asynchronous partial decoder for the sharding codec.
 pub(crate) struct AsyncShardingPartialDecoder {
     input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-    data_type: DataType,
-    fill_value: FillValue,
     shard_shape: ChunkShape,
     subchunk_shape: ChunkShape,
-    inner_codecs: Arc<CodecChain>,
+    inner_codecs: Arc<CodecChainBound>,
     shard_index: Option<Vec<u64>>,
     #[expect(dead_code)] // TODO: Remove when sharding-specific options are added
     sharding_options: ShardingCodecOptions,
@@ -42,12 +41,10 @@ impl AsyncShardingPartialDecoder {
     #[expect(clippy::too_many_arguments)]
     pub(crate) async fn new(
         input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-        data_type: DataType,
-        fill_value: FillValue,
         shard_shape: ChunkShape,
         subchunk_shape: ChunkShape,
-        inner_codecs: Arc<CodecChain>,
-        index_codecs: &CodecChain,
+        inner_codecs: Arc<CodecChainBound>,
+        index_codecs: &CodecChainBound,
         index_location: ShardingIndexLocation,
         options: &CodecOptions,
         sharding_options: ShardingCodecOptions,
@@ -64,8 +61,6 @@ impl AsyncShardingPartialDecoder {
 
         Ok(Self {
             input_handle,
-            data_type,
-            fill_value,
             shard_shape,
             subchunk_shape,
             inner_codecs,
@@ -110,11 +105,9 @@ impl AsyncShardingPartialDecoder {
 #[expect(clippy::too_many_arguments)]
 pub(crate) async fn partial_decode(
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     indexer: &dyn crate::array::Indexer,
     options: &CodecOptions,
@@ -127,6 +120,8 @@ pub(crate) async fn partial_decode(
         .into());
     }
 
+    let data_type = inner_codecs.data_type();
+    let fill_value = inner_codecs.fill_value();
     if data_type.is_optional() {
         return Err(CodecError::UnsupportedDataType(
             data_type.clone(),
@@ -139,8 +134,6 @@ pub(crate) async fn partial_decode(
             if let Some(subset) = indexer.as_array_subset() {
                 partial_decode_fixed_array_subset(
                     input_handle,
-                    data_type,
-                    fill_value,
                     shard_shape,
                     subchunk_shape,
                     inner_codecs,
@@ -152,8 +145,6 @@ pub(crate) async fn partial_decode(
             } else {
                 partial_decode_fixed_indexer(
                     input_handle,
-                    data_type,
-                    fill_value,
                     shard_shape,
                     subchunk_shape,
                     inner_codecs,
@@ -200,7 +191,7 @@ pub(crate) async fn partial_decode(
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder {
     fn data_type(&self) -> &DataType {
-        &self.data_type
+        &self.inner_codecs.data_type()
     }
 
     async fn exists(&self) -> Result<bool, StorageError> {
@@ -219,8 +210,6 @@ impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder {
     ) -> Result<ArrayBytes<'_>, CodecError> {
         partial_decode(
             &self.input_handle,
-            &self.data_type,
-            &self.fill_value,
             &self.shard_shape,
             &self.subchunk_shape,
             &self.inner_codecs,
@@ -239,10 +228,8 @@ impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder {
 #[expect(clippy::too_many_arguments)]
 async fn get_subchunk_partial_decoder(
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     options: &CodecOptions,
     byte_offset: ByteOffset,
     byte_length: ByteLength,
@@ -256,8 +243,6 @@ async fn get_subchunk_partial_decoder(
                 byte_length,
             )),
             subchunk_shape,
-            data_type,
-            fill_value,
             options,
         )
         .await
@@ -277,15 +262,15 @@ async fn get_subchunk_partial_decoder(
 #[expect(clippy::too_many_arguments)]
 async fn partial_decode_fixed_array_subset(
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     array_subset: &dyn ArraySubsetTraits,
     options: &CodecOptions,
 ) -> Result<ArrayBytes<'static>, CodecError> {
+    let data_type = inner_codecs.data_type();
+    let fill_value = inner_codecs.fill_value();
     let data_type_size = data_type.fixed_size().expect("called on fixed data type");
     let Some(shard_index) = shard_index else {
         return super::partial_decode_empty_shard(data_type, fill_value, array_subset);
@@ -343,8 +328,6 @@ async fn partial_decode_fixed_array_subset(
                 async move {
                     let inner_partial_decoder = get_subchunk_partial_decoder(
                         input_handle,
-                        data_type,
-                        fill_value,
                         subchunk_shape,
                         inner_codecs,
                         options,
@@ -462,7 +445,7 @@ async fn partial_decode_variable_array_subset(
     fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     array_subset: &dyn ArraySubsetTraits,
     options: &CodecOptions,
@@ -503,8 +486,6 @@ async fn partial_decode_variable_array_subset(
                 // Partially decode the subchunk
                 let inner_partial_decoder = get_subchunk_partial_decoder(
                     input_handle,
-                    data_type,
-                    fill_value,
                     subchunk_shape,
                     inner_codecs,
                     options,
@@ -555,15 +536,15 @@ async fn partial_decode_variable_array_subset(
 #[expect(clippy::too_many_arguments)]
 async fn partial_decode_fixed_indexer(
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     indexer: &dyn Indexer,
     options: &CodecOptions,
 ) -> Result<ArrayBytes<'static>, CodecError> {
+    let data_type = inner_codecs.data_type();
+    let fill_value = inner_codecs.fill_value();
     let data_type_size = data_type.fixed_size().expect("called on fixed data type");
     let Some(shard_index) = shard_index else {
         return super::partial_decode_empty_shard(data_type, fill_value, indexer);
@@ -615,8 +596,6 @@ async fn partial_decode_fixed_indexer(
             .entry(chunk_index_1d)
             .or_try_insert_with(get_subchunk_partial_decoder(
                 input_handle,
-                data_type,
-                fill_value,
                 subchunk_shape,
                 inner_codecs,
                 options,
@@ -670,7 +649,7 @@ async fn partial_decode_variable_indexer(
     fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     indexer: &dyn Indexer,
     options: &CodecOptions,
@@ -727,8 +706,6 @@ async fn partial_decode_variable_indexer(
             .entry(chunk_index_1d)
             .or_try_insert_with(get_subchunk_partial_decoder(
                 input_handle,
-                data_type,
-                fill_value,
                 subchunk_shape,
                 inner_codecs,
                 options,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -17,8 +17,8 @@ use crate::array::{
     DataTypeSize, IncompatibleDimensionalityError, Indexer, IndexerError, ravel_indices,
 };
 use zarrs_codec::{
-    ArrayToBytesCodecTraits, AsyncArrayPartialDecoderTraits, AsyncByteIntervalPartialDecoder,
-    AsyncBytesPartialDecoderTraits, CodecError, CodecOptions,
+    AsyncArrayPartialDecoderTraits, AsyncByteIntervalPartialDecoder,
+    AsyncBytesPartialDecoderTraits, CodecError, CodecOptions, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_plugin::ExtensionAliasesV3;
 use zarrs_storage::StorageError;

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -19,7 +19,8 @@ use crate::array::{
     IndexerError, ravel_indices,
 };
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayToBytesCodecTraits, AsyncArrayPartialDecoderTraits, AsyncByteIntervalPartialDecoder, AsyncBytesPartialDecoderTraits, CodecError, CodecOptions
+    ArrayCodecTraits, ArrayToBytesCodecTraits, AsyncArrayPartialDecoderTraits,
+    AsyncByteIntervalPartialDecoder, AsyncBytesPartialDecoderTraits, CodecError, CodecOptions,
 };
 use zarrs_plugin::ExtensionAliasesV3;
 use zarrs_storage::StorageError;

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -605,8 +605,6 @@ async fn partial_decode_fixed_indexer(
             .get_or_insert_async(&chunk_index_1d, async {
                 get_subchunk_partial_decoder(
                     input_handle,
-                    data_type,
-                    fill_value,
                     subchunk_shape,
                     inner_codecs,
                     options,
@@ -715,8 +713,6 @@ async fn partial_decode_variable_indexer(
             .get_or_insert_async(&chunk_index_1d, async {
                 get_subchunk_partial_decoder(
                     input_handle,
-                    data_type,
-                    fill_value,
                     subchunk_shape,
                     inner_codecs,
                     options,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -5,13 +5,10 @@ use std::sync::Arc;
 use rayon::prelude::*;
 use unsafe_cell_slice::UnsafeCellSlice;
 use zarrs_chunk_grid::{ArraySubset, ChunkGridTraits};
-use zarrs_data_type::FillValue;
-use zarrs_metadata_ext::data_type;
 
 use super::{ShardingCodecOptions, ShardingIndexLocation, calculate_chunks_per_shard};
 use crate::array::array_bytes_internal::merge_chunks_vlen;
 use crate::array::chunk_grid::RegularChunkGrid;
-use crate::array::codec::CodecChain;
 use crate::array::{
     ArrayBytes, ArrayBytesFixedDisjointView, ArrayBytesOffsets, ArrayBytesRaw, ArrayIndices,
     ArrayIndicesTinyVec, ArraySubsetTraits, ChunkShape, ChunkShapeTraits, CodecChainBound,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -98,7 +98,6 @@ impl ShardingPartialDecoder {
     }
 }
 
-#[expect(clippy::too_many_arguments)]
 pub(crate) fn partial_decode(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     shard_shape: &[NonZeroU64],
@@ -256,7 +255,6 @@ impl ArrayPartialDecoderTraits for ShardingPartialDecoder {
     }
 }
 
-#[expect(clippy::too_many_arguments)]
 fn get_subchunk_partial_decoder(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     subchunk_shape: &[NonZeroU64],
@@ -382,7 +380,6 @@ fn partial_decode_fixed_array_subset_into(
     Ok(())
 }
 
-#[expect(clippy::too_many_arguments)]
 fn partial_decode_variable_array_subset(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     shard_shape: &[NonZeroU64],
@@ -475,7 +472,6 @@ fn partial_decode_variable_array_subset(
     Ok(ArrayBytes::Variable(out_array_subset))
 }
 
-#[expect(clippy::too_many_arguments)]
 fn partial_decode_fixed_indexer(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     shard_shape: &[NonZeroU64],
@@ -582,7 +578,6 @@ fn partial_decode_fixed_indexer(
     Ok(output.into())
 }
 
-#[expect(clippy::too_many_arguments)]
 fn partial_decode_variable_indexer(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     shard_shape: &[NonZeroU64],

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -6,20 +6,17 @@ use rayon::prelude::*;
 use unsafe_cell_slice::UnsafeCellSlice;
 use zarrs_chunk_grid::{ArraySubset, ChunkGridTraits};
 use zarrs_data_type::FillValue;
+use zarrs_metadata_ext::data_type;
 
 use super::{ShardingCodecOptions, ShardingIndexLocation, calculate_chunks_per_shard};
 use crate::array::array_bytes_internal::merge_chunks_vlen;
 use crate::array::chunk_grid::RegularChunkGrid;
 use crate::array::codec::CodecChain;
 use crate::array::{
-    ArrayBytes, ArrayBytesFixedDisjointView, ArrayBytesOffsets, ArrayBytesRaw, ArrayIndices,
-    ArrayIndicesTinyVec, ArraySubsetTraits, ChunkShape, ChunkShapeTraits, DataType, DataTypeSize,
-    IncompatibleDimensionalityError, Indexer, IndexerError, ravel_indices,
+    ArrayBytes, ArrayBytesFixedDisjointView, ArrayBytesOffsets, ArrayBytesRaw, ArrayIndices, ArrayIndicesTinyVec, ArraySubsetTraits, ChunkShape, ChunkShapeTraits, CodecChainBound, DataType, DataTypeSize, IncompatibleDimensionalityError, Indexer, IndexerError, ravel_indices
 };
 use zarrs_codec::{
-    ArrayBytesDecodeIntoTarget, ArrayPartialDecoderTraits, ByteIntervalPartialDecoder,
-    BytesPartialDecoderTraits, CodecError, CodecOptions, InvalidNumberOfElementsError,
-    UnboundArrayToBytesCodecTraits, decode_into_array_bytes_target,
+    ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, ByteIntervalPartialDecoder, BytesPartialDecoderTraits, CodecError, CodecOptions, InvalidNumberOfElementsError, decode_into_array_bytes_target
 };
 use zarrs_plugin::ExtensionAliasesV3;
 use zarrs_storage::StorageError;
@@ -28,11 +25,9 @@ use zarrs_storage::byte_range::{ByteLength, ByteOffset, ByteRange};
 /// Partial decoder for the sharding codec.
 pub(crate) struct ShardingPartialDecoder {
     input_handle: Arc<dyn BytesPartialDecoderTraits>,
-    data_type: DataType,
-    fill_value: FillValue,
     shard_shape: ChunkShape,
     subchunk_shape: ChunkShape,
-    inner_codecs: Arc<CodecChain>,
+    inner_codecs: Arc<CodecChainBound>,
     shard_index: Option<Vec<u64>>,
     #[expect(dead_code)] // TODO: Remove when sharding-specific options are added
     sharding_options: ShardingCodecOptions,
@@ -43,12 +38,10 @@ impl ShardingPartialDecoder {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         input_handle: Arc<dyn BytesPartialDecoderTraits>,
-        data_type: DataType,
-        fill_value: FillValue,
         shard_shape: ChunkShape,
         subchunk_shape: ChunkShape,
-        inner_codecs: Arc<CodecChain>,
-        index_codecs: &CodecChain,
+        inner_codecs: Arc<CodecChainBound>,
+        index_codecs: &CodecChainBound,
         index_location: ShardingIndexLocation,
         options: &CodecOptions,
         sharding_options: ShardingCodecOptions,
@@ -64,8 +57,6 @@ impl ShardingPartialDecoder {
 
         Ok(Self {
             input_handle,
-            data_type,
-            fill_value,
             shard_shape,
             subchunk_shape,
             inner_codecs,
@@ -109,15 +100,14 @@ impl ShardingPartialDecoder {
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn partial_decode(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     indexer: &dyn crate::array::Indexer,
     options: &CodecOptions,
 ) -> Result<ArrayBytes<'static>, CodecError> {
+    let data_type = inner_codecs.data_type();
     if indexer.dimensionality() != shard_shape.len() {
         return Err(IndexerError::new_incompatible_dimensionality(
             indexer.dimensionality(),
@@ -150,8 +140,6 @@ pub(crate) fn partial_decode(
                 };
                 partial_decode_fixed_array_subset_into(
                     input_handle,
-                    data_type,
-                    fill_value,
                     shard_shape,
                     subchunk_shape,
                     inner_codecs,
@@ -164,8 +152,6 @@ pub(crate) fn partial_decode(
             } else {
                 partial_decode_fixed_indexer(
                     input_handle,
-                    data_type,
-                    fill_value,
                     shard_shape,
                     subchunk_shape,
                     inner_codecs,
@@ -179,8 +165,6 @@ pub(crate) fn partial_decode(
             if let Some(subset) = indexer.as_array_subset() {
                 partial_decode_variable_array_subset(
                     input_handle,
-                    data_type,
-                    fill_value,
                     shard_shape,
                     subchunk_shape,
                     inner_codecs,
@@ -191,8 +175,6 @@ pub(crate) fn partial_decode(
             } else {
                 partial_decode_variable_indexer(
                     input_handle,
-                    data_type,
-                    fill_value,
                     shard_shape,
                     subchunk_shape,
                     inner_codecs,
@@ -207,7 +189,7 @@ pub(crate) fn partial_decode(
 
 impl ArrayPartialDecoderTraits for ShardingPartialDecoder {
     fn data_type(&self) -> &DataType {
-        &self.data_type
+        self.inner_codecs.data_type()
     }
 
     fn exists(&self) -> Result<bool, StorageError> {
@@ -226,8 +208,6 @@ impl ArrayPartialDecoderTraits for ShardingPartialDecoder {
     ) -> Result<ArrayBytes<'_>, CodecError> {
         partial_decode(
             &self.input_handle,
-            &self.data_type,
-            &self.fill_value,
             &self.shard_shape,
             &self.subchunk_shape,
             &self.inner_codecs,
@@ -250,14 +230,12 @@ impl ArrayPartialDecoderTraits for ShardingPartialDecoder {
             )
             .into());
         }
-        if let DataTypeSize::Fixed(_data_type_size) = &self.data_type.size()
+        if let DataTypeSize::Fixed(_data_type_size) = self.inner_codecs.data_type().size()
             && let Some(subset) = indexer.as_array_subset()
             && let ArrayBytesDecodeIntoTarget::Fixed(output_view) = output_target
         {
             partial_decode_fixed_array_subset_into(
                 &self.input_handle,
-                &self.data_type,
-                &self.fill_value,
                 &self.shard_shape,
                 &self.subchunk_shape,
                 &self.inner_codecs,
@@ -280,10 +258,8 @@ impl ArrayPartialDecoderTraits for ShardingPartialDecoder {
 #[expect(clippy::too_many_arguments)]
 fn get_subchunk_partial_decoder(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     options: &CodecOptions,
     byte_offset: ByteOffset,
     byte_length: ByteLength,
@@ -297,8 +273,6 @@ fn get_subchunk_partial_decoder(
                 byte_length,
             )),
             subchunk_shape,
-            data_type,
-            fill_value,
             options,
         )
         .map_err(|err| {
@@ -316,16 +290,15 @@ fn get_subchunk_partial_decoder(
 #[expect(clippy::too_many_arguments)]
 fn partial_decode_fixed_array_subset_into(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     array_subset: &dyn ArraySubsetTraits,
     options: &CodecOptions,
     output_view: &mut ArrayBytesFixedDisjointView<'_>,
 ) -> Result<(), CodecError> {
+    let fill_value = inner_codecs.fill_value();
     if array_subset.len() != output_view.num_elements() {
         return Err(InvalidNumberOfElementsError::new(
             array_subset.len(),
@@ -342,7 +315,6 @@ fn partial_decode_fixed_array_subset_into(
         calculate_chunks_per_shard(shard_shape, subchunk_shape)?.to_array_shape();
     let (subchunk_concurrent_limit, options) = super::get_concurrent_target_and_codec_options(
         inner_codecs,
-        data_type,
         subchunk_shape,
         &chunks_per_shard,
         options,
@@ -381,8 +353,6 @@ fn partial_decode_fixed_array_subset_into(
             // Partially decode the subchunk
             let inner_partial_decoder = get_subchunk_partial_decoder(
                 input_handle,
-                data_type,
-                fill_value,
                 subchunk_shape,
                 inner_codecs,
                 &options,
@@ -414,15 +384,15 @@ fn partial_decode_fixed_array_subset_into(
 #[expect(clippy::too_many_arguments)]
 fn partial_decode_variable_array_subset(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     array_subset: &dyn ArraySubsetTraits,
     options: &CodecOptions,
 ) -> Result<ArrayBytes<'static>, CodecError> {
+    let data_type = inner_codecs.data_type();
+    let fill_value = inner_codecs.fill_value();
     let Some(shard_index) = &shard_index else {
         return super::partial_decode_empty_shard(data_type, fill_value, array_subset);
     };
@@ -430,7 +400,6 @@ fn partial_decode_variable_array_subset(
         calculate_chunks_per_shard(shard_shape, subchunk_shape)?.to_array_shape();
     let (subchunk_concurrent_limit, options) = super::get_concurrent_target_and_codec_options(
         inner_codecs,
-        data_type,
         subchunk_shape,
         &chunks_per_shard,
         options,
@@ -465,8 +434,6 @@ fn partial_decode_variable_array_subset(
             // Partially decode the subchunk
             let inner_partial_decoder = get_subchunk_partial_decoder(
                 input_handle,
-                data_type,
-                fill_value,
                 subchunk_shape,
                 inner_codecs,
                 options,
@@ -510,15 +477,15 @@ fn partial_decode_variable_array_subset(
 #[expect(clippy::too_many_arguments)]
 fn partial_decode_fixed_indexer(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     indexer: &dyn Indexer,
     options: &CodecOptions,
 ) -> Result<ArrayBytes<'static>, CodecError> {
+    let data_type = inner_codecs.data_type();
+    let fill_value = inner_codecs.fill_value();
     let data_type_size = data_type.fixed_size().expect("called on fixed data type");
     let Some(shard_index) = &shard_index else {
         return super::partial_decode_empty_shard(data_type, fill_value, indexer);
@@ -571,8 +538,6 @@ fn partial_decode_fixed_indexer(
             .or_try_insert_with(|| {
                 get_subchunk_partial_decoder(
                     input_handle,
-                    data_type,
-                    fill_value,
                     subchunk_shape,
                     inner_codecs,
                     options,
@@ -619,15 +584,15 @@ fn partial_decode_fixed_indexer(
 #[expect(clippy::too_many_arguments)]
 fn partial_decode_variable_indexer(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
-    data_type: &DataType,
-    fill_value: &FillValue,
     shard_shape: &[NonZeroU64],
     subchunk_shape: &[NonZeroU64],
-    inner_codecs: &Arc<CodecChain>,
+    inner_codecs: &Arc<CodecChainBound>,
     shard_index: Option<&[u64]>,
     indexer: &dyn Indexer,
     options: &CodecOptions,
 ) -> Result<ArrayBytes<'static>, CodecError> {
+    let data_type = inner_codecs.data_type();
+    let fill_value = inner_codecs.fill_value();
     let Some(shard_index) = &shard_index else {
         return super::partial_decode_empty_shard(data_type, fill_value, indexer);
     };
@@ -681,8 +646,6 @@ fn partial_decode_variable_indexer(
             .or_try_insert_with(|| {
                 get_subchunk_partial_decoder(
                     input_handle,
-                    data_type,
-                    fill_value,
                     subchunk_shape,
                     inner_codecs,
                     options,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -549,8 +549,6 @@ fn partial_decode_fixed_indexer(
             subchunk_partial_decoders.get_or_insert_with(&chunk_index_1d, || {
                 get_subchunk_partial_decoder(
                     input_handle,
-                    data_type,
-                    fill_value,
                     subchunk_shape,
                     inner_codecs,
                     options,
@@ -656,8 +654,6 @@ fn partial_decode_variable_indexer(
             subchunk_partial_decoders.get_or_insert_with(&chunk_index_1d, || {
                 get_subchunk_partial_decoder(
                     input_handle,
-                    data_type,
-                    fill_value,
                     subchunk_shape,
                     inner_codecs,
                     options,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -17,9 +17,9 @@ use crate::array::{
     IncompatibleDimensionalityError, Indexer, IndexerError, ravel_indices,
 };
 use zarrs_codec::{
-    ArrayBytesDecodeIntoTarget, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-    ByteIntervalPartialDecoder, BytesPartialDecoderTraits, CodecError, CodecOptions,
-    InvalidNumberOfElementsError, decode_into_array_bytes_target,
+    ArrayBytesDecodeIntoTarget, ArrayPartialDecoderTraits, ByteIntervalPartialDecoder,
+    BytesPartialDecoderTraits, CodecError, CodecOptions, InvalidNumberOfElementsError,
+    UnboundArrayToBytesCodecTraits, decode_into_array_bytes_target,
 };
 use zarrs_plugin::ExtensionAliasesV3;
 use zarrs_storage::StorageError;

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -13,10 +13,14 @@ use crate::array::array_bytes_internal::merge_chunks_vlen;
 use crate::array::chunk_grid::RegularChunkGrid;
 use crate::array::codec::CodecChain;
 use crate::array::{
-    ArrayBytes, ArrayBytesFixedDisjointView, ArrayBytesOffsets, ArrayBytesRaw, ArrayIndices, ArrayIndicesTinyVec, ArraySubsetTraits, ChunkShape, ChunkShapeTraits, CodecChainBound, DataType, DataTypeSize, IncompatibleDimensionalityError, Indexer, IndexerError, ravel_indices
+    ArrayBytes, ArrayBytesFixedDisjointView, ArrayBytesOffsets, ArrayBytesRaw, ArrayIndices,
+    ArrayIndicesTinyVec, ArraySubsetTraits, ChunkShape, ChunkShapeTraits, CodecChainBound,
+    DataType, DataTypeSize, IncompatibleDimensionalityError, Indexer, IndexerError, ravel_indices,
 };
 use zarrs_codec::{
-    ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, ByteIntervalPartialDecoder, BytesPartialDecoderTraits, CodecError, CodecOptions, InvalidNumberOfElementsError, decode_into_array_bytes_target
+    ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits,
+    ArrayToBytesCodecTraits, ByteIntervalPartialDecoder, BytesPartialDecoderTraits, CodecError,
+    CodecOptions, InvalidNumberOfElementsError, decode_into_array_bytes_target,
 };
 use zarrs_plugin::ExtensionAliasesV3;
 use zarrs_storage::StorageError;

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -7,8 +7,6 @@ use itertools::Itertools;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use zarrs_chunk_grid::ChunkGridTraits;
-use zarrs_data_type::FillValue;
-use zarrs_metadata_ext::data_type;
 
 use super::{ShardingCodecOptions, ShardingIndexLocation, sharding_index_shape};
 use crate::array::chunk_grid::RegularChunkGrid;
@@ -16,8 +14,8 @@ use crate::array::codec::array_to_bytes::sharding::{
     calculate_chunks_per_shard, compute_index_encoded_size,
 };
 use crate::array::{
-    ArrayBytes, ArrayBytesRaw, ArrayIndicesTinyVec, ChunkShape, ChunkShapeTraits, CodecChain,
-    CodecChainBound, DataType, IndexerError, ravel_indices, transmute_to_bytes,
+    ArrayBytes, ArrayBytesRaw, ArrayIndicesTinyVec, ChunkShape, ChunkShapeTraits, CodecChainBound,
+    DataType, IndexerError, ravel_indices, transmute_to_bytes,
 };
 use zarrs_codec::{
     ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -19,8 +19,8 @@ use crate::array::{
     DataType, IndexerError, ravel_indices, transmute_to_bytes,
 };
 use zarrs_codec::{
-    ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, ArrayToBytesCodecTraits,
-    BytesPartialEncoderTraits, CodecError, CodecOptions, update_array_bytes,
+    ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, BytesPartialEncoderTraits, CodecError,
+    CodecOptions, UnboundArrayToBytesCodecTraits, update_array_bytes,
 };
 use zarrs_storage::StorageError;
 use zarrs_storage::byte_range::ByteRange;

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -16,10 +16,13 @@ use crate::array::codec::array_to_bytes::sharding::{
     calculate_chunks_per_shard, compute_index_encoded_size,
 };
 use crate::array::{
-    ArrayBytes, ArrayBytesRaw, ArrayIndicesTinyVec, ChunkShape, ChunkShapeTraits, CodecChain, CodecChainBound, DataType, IndexerError, ravel_indices, transmute_to_bytes
+    ArrayBytes, ArrayBytesRaw, ArrayIndicesTinyVec, ChunkShape, ChunkShapeTraits, CodecChain,
+    CodecChainBound, DataType, IndexerError, ravel_indices, transmute_to_bytes,
 };
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialEncoderTraits, CodecError, CodecOptions, update_array_bytes
+    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+    ArrayToBytesCodecTraits, BytesPartialEncoderTraits, CodecError, CodecOptions,
+    update_array_bytes,
 };
 use zarrs_storage::StorageError;
 use zarrs_storage::byte_range::ByteRange;
@@ -140,7 +143,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
         chunk_subset_bytes: &ArrayBytes<'_>,
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
-        let data_type   = self.inner_codecs.data_type();
+        let data_type = self.inner_codecs.data_type();
         let fill_value = self.inner_codecs.fill_value();
         let mut shard_index = self.shard_index.lock().unwrap();
 
@@ -368,11 +371,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
                 } else {
                     let subchunk_encoded = self
                         .inner_codecs
-                        .encode(
-                            subchunk_decoded,
-                            &self.subchunk_shape,
-                            options,
-                        )?
+                        .encode(subchunk_decoded, &self.subchunk_shape, options)?
                         .into_owned();
                     Ok((subchunk_index, Some(subchunk_encoded)))
                 }
@@ -425,11 +424,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
                 transmute_to_bytes(shard_index.as_slice()).into();
             let encoded_array_index = self
                 .index_codecs
-                .encode(
-                    shard_index_bytes.into(),
-                    &self.index_shape,
-                    options,
-                )?
+                .encode(shard_index_bytes.into(), &self.index_shape, options)?
                 .into_owned();
 
             // Get the total size of the encoded subchunks

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -8,6 +8,7 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelIterator};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use zarrs_chunk_grid::ChunkGridTraits;
 use zarrs_data_type::FillValue;
+use zarrs_metadata_ext::data_type;
 
 use super::{ShardingCodecOptions, ShardingIndexLocation, sharding_index_shape};
 use crate::array::chunk_grid::RegularChunkGrid;
@@ -15,12 +16,10 @@ use crate::array::codec::array_to_bytes::sharding::{
     calculate_chunks_per_shard, compute_index_encoded_size,
 };
 use crate::array::{
-    ArrayBytes, ArrayBytesRaw, ArrayIndicesTinyVec, ChunkShape, ChunkShapeTraits, CodecChain,
-    DataType, IndexerError, ravel_indices, transmute_to_bytes,
+    ArrayBytes, ArrayBytesRaw, ArrayIndicesTinyVec, ChunkShape, ChunkShapeTraits, CodecChain, CodecChainBound, DataType, IndexerError, ravel_indices, transmute_to_bytes
 };
 use zarrs_codec::{
-    ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, BytesPartialEncoderTraits, CodecError,
-    CodecOptions, UnboundArrayToBytesCodecTraits, update_array_bytes,
+    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialEncoderTraits, CodecError, CodecOptions, update_array_bytes
 };
 use zarrs_storage::StorageError;
 use zarrs_storage::byte_range::ByteRange;
@@ -28,12 +27,10 @@ use zarrs_storage::byte_range::ByteRange;
 pub(crate) struct ShardingPartialEncoder {
     input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
     shard_shape: ChunkShape,
-    data_type: DataType,
-    fill_value: FillValue,
     subchunk_shape: ChunkShape,
     chunk_grid: RegularChunkGrid,
-    inner_codecs: Arc<CodecChain>,
-    index_codecs: Arc<CodecChain>,
+    inner_codecs: Arc<CodecChainBound>,
+    index_codecs: Arc<CodecChainBound>,
     index_location: ShardingIndexLocation,
     index_shape: ChunkShape,
     shard_index: Arc<Mutex<Vec<u64>>>,
@@ -46,12 +43,10 @@ impl ShardingPartialEncoder {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
-        data_type: DataType,
-        fill_value: FillValue,
         shard_shape: ChunkShape,
         subchunk_shape: ChunkShape,
-        inner_codecs: Arc<CodecChain>,
-        index_codecs: Arc<CodecChain>,
+        inner_codecs: Arc<CodecChainBound>,
+        index_codecs: Arc<CodecChainBound>,
         index_location: ShardingIndexLocation,
         options: &CodecOptions,
         sharding_options: ShardingCodecOptions,
@@ -82,8 +77,6 @@ impl ShardingPartialEncoder {
         Ok(Self {
             input_output_handle,
             shard_shape,
-            data_type,
-            fill_value,
             subchunk_shape,
             chunk_grid,
             inner_codecs,
@@ -98,7 +91,7 @@ impl ShardingPartialEncoder {
 
 impl ArrayPartialDecoderTraits for ShardingPartialEncoder {
     fn data_type(&self) -> &DataType {
-        &self.data_type
+        self.inner_codecs.data_type()
     }
 
     fn exists(&self) -> Result<bool, StorageError> {
@@ -116,8 +109,6 @@ impl ArrayPartialDecoderTraits for ShardingPartialEncoder {
     ) -> Result<ArrayBytes<'_>, CodecError> {
         super::sharding_partial_decoder_sync::partial_decode(
             &self.input_output_handle.clone().into_dyn_decoder(),
-            &self.data_type,
-            &self.fill_value,
             &self.shard_shape,
             &self.subchunk_shape,
             &self.inner_codecs,
@@ -149,6 +140,8 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
         chunk_subset_bytes: &ArrayBytes<'_>,
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
+        let data_type   = self.inner_codecs.data_type();
+        let fill_value = self.inner_codecs.fill_value();
         let mut shard_index = self.shard_index.lock().unwrap();
 
         let chunks_per_shard = calculate_chunks_per_shard(&self.shard_shape, &self.subchunk_shape)?;
@@ -174,9 +167,9 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
         };
         let subchunk_fill_value = || {
             ArrayBytes::new_fill_value(
-                &self.data_type,
+                &self.inner_codecs.data_type(),
                 self.subchunk_shape.num_elements_u64(),
-                &self.fill_value,
+                &self.inner_codecs.fill_value(),
             )
         };
 
@@ -292,8 +285,6 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
                         self.inner_codecs.decode(
                             Cow::Owned(subchunk_encoded),
                             &self.subchunk_shape,
-                            &self.data_type,
-                            &self.fill_value,
                             options,
                         )?,
                     ))
@@ -330,7 +321,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
                     .relative_to(&chunk_subset_start)
                     .unwrap(),
                 &chunk_subset_shape,
-                &self.data_type,
+                data_type,
             )?;
 
             // Decode the subchunk
@@ -350,7 +341,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
                     .relative_to(subchunk_subset.start())
                     .unwrap(),
                 &subchunk_bytes,
-                self.data_type.size(),
+                data_type.size(),
             )?;
             subchunks_decoded
                 .lock()
@@ -372,7 +363,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
 
         let updated_subchunks = iterator
             .map(|(subchunk_index, subchunk_decoded)| {
-                if subchunk_decoded.is_fill_value(&self.fill_value) {
+                if subchunk_decoded.is_fill_value(&fill_value) {
                     Ok((subchunk_index, None))
                 } else {
                     let subchunk_encoded = self
@@ -380,8 +371,6 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
                         .encode(
                             subchunk_decoded,
                             &self.subchunk_shape,
-                            &self.data_type,
-                            &self.fill_value,
                             options,
                         )?
                         .into_owned();
@@ -439,8 +428,6 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
                 .encode(
                     shard_index_bytes.into(),
                     &self.index_shape,
-                    &crate::array::data_type::uint64(),
-                    &FillValue::from(u64::MAX),
                     options,
                 )?
                 .into_owned();

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -168,9 +168,9 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
         };
         let subchunk_fill_value = || {
             ArrayBytes::new_fill_value(
-                &self.inner_codecs.data_type(),
+                self.inner_codecs.data_type(),
                 self.subchunk_shape.num_elements_u64(),
-                &self.inner_codecs.fill_value(),
+                self.inner_codecs.fill_value(),
             )
         };
 
@@ -364,7 +364,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
 
         let updated_subchunks = iterator
             .map(|(subchunk_index, subchunk_decoded)| {
-                if subchunk_decoded.is_fill_value(&fill_value) {
+                if subchunk_decoded.is_fill_value(fill_value) {
                     Ok((subchunk_index, None))
                 } else {
                     let subchunk_encoded = self

--- a/zarrs/src/array/codec/array_to_bytes/vlen.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen.rs
@@ -117,7 +117,6 @@ use zarrs_metadata_ext::codec::vlen::VlenIndexLocation;
 pub use zarrs_metadata_ext::codec::vlen::{
     VlenCodecConfiguration, VlenCodecConfigurationV0, VlenCodecConfigurationV0_1,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(VlenCodec,
     v3: "zarrs.vlen", ["https://codec.zarrs.dev/array_to_bytes/vlen"]
@@ -129,7 +128,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for VlenCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         crate::warn_experimental_extension(metadata.name(), "codec");
         let configuration: VlenCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(VlenCodec::new_with_configuration(&configuration)?);

--- a/zarrs/src/array/codec/array_to_bytes/vlen.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen.rs
@@ -109,8 +109,8 @@ use crate::array::{
 use itertools::Itertools;
 pub use vlen_codec::VlenCodec;
 use zarrs_codec::{
-    ArrayToBytesCodecTraits, Codec, CodecError, CodecOptions, CodecPluginV3, CodecTraitsV3,
-    InvalidBytesLengthError,
+    Codec, CodecError, CodecOptions, CodecPluginV3, CodecTraitsV3, InvalidBytesLengthError,
+    UnboundArrayToBytesCodecTraits,
 };
 use zarrs_data_type::FillValue;
 use zarrs_metadata::v3::MetadataV3;

--- a/zarrs/src/array/codec/array_to_bytes/vlen.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen.rs
@@ -103,21 +103,20 @@ use std::sync::Arc;
 
 use super::bytes::reverse_endianness;
 use crate::array::{
-    ArrayBytesRaw, ChunkShape, ChunkShapeTraits, CodecChain, Endianness, convert_from_bytes_slice,
-    data_type,
+    ArrayBytesRaw, ChunkShape, ChunkShapeTraits, CodecChainBound, Endianness,
+    convert_from_bytes_slice, data_type,
 };
 use itertools::Itertools;
 pub use vlen_codec::VlenCodec;
 use zarrs_codec::{
-    ArrayToBytesCodecTraits, Codec, CodecError, CodecOptions, CodecPluginV3, CodecTraitsV3,
-    InvalidBytesLengthError,
+    ArrayCodecTraits, ArrayToBytesCodecTraits, Codec, CodecError, CodecOptions, CodecPluginV3,
+    CodecTraitsV3, InvalidBytesLengthError,
 };
-use zarrs_data_type::FillValue;
 use zarrs_metadata::v3::MetadataV3;
+use zarrs_metadata_ext::codec::vlen::VlenIndexLocation;
 pub use zarrs_metadata_ext::codec::vlen::{
     VlenCodecConfiguration, VlenCodecConfigurationV0, VlenCodecConfigurationV0_1,
 };
-use zarrs_metadata_ext::codec::vlen::{VlenIndexDataType, VlenIndexLocation};
 use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(VlenCodec,
@@ -141,20 +140,14 @@ impl CodecTraitsV3 for VlenCodec {
 fn get_vlen_bytes_and_offsets(
     bytes: &ArrayBytesRaw,
     shape: &[NonZeroU64],
-    index_data_type: VlenIndexDataType,
-    index_codecs: &CodecChain,
-    data_codecs: &CodecChain,
+    index_codecs: &CodecChainBound,
+    data_codecs: &CodecChainBound,
     index_location: VlenIndexLocation,
     options: &CodecOptions,
 ) -> Result<(Vec<u8>, Vec<usize>), CodecError> {
     let index_shape = ChunkShape::from(vec![
         NonZeroU64::try_from(shape.num_elements_u64() + 1).unwrap(),
     ]);
-    let (data_type, fill_value) = match index_data_type {
-        VlenIndexDataType::UInt32 => (data_type::uint32(), FillValue::from(0u32)),
-        VlenIndexDataType::UInt64 => (data_type::uint64(), FillValue::from(0u64)),
-    };
-
     // Get the index length
     if bytes.len() < size_of::<u64>() {
         return Err(InvalidBytesLengthError::new(bytes.len(), size_of::<u64>()).into());
@@ -180,22 +173,23 @@ fn get_vlen_bytes_and_offsets(
     };
 
     // Decode the index
-    let mut index = Arc::new(index_codecs.clone())
-        .with_context(data_type.clone(), fill_value.clone())?
+    let mut index = index_codecs
         .decode(index_enc.into(), &index_shape, options)?
         .into_fixed()?;
+    let index_data_type = index_codecs.data_type();
     if Endianness::Big.is_native() {
-        reverse_endianness(index.to_mut(), &data_type::uint64());
+        reverse_endianness(index.to_mut(), index_data_type);
     }
-    let index = match index_data_type {
-        VlenIndexDataType::UInt32 => {
-            let index = convert_from_bytes_slice::<u32>(&index);
-            offsets_u32_to_usize(index)
-        }
-        VlenIndexDataType::UInt64 => {
-            let index = convert_from_bytes_slice::<u64>(&index);
-            offsets_u64_to_usize(index)
-        }
+    let index = if *index_data_type == data_type::uint32() {
+        let index = convert_from_bytes_slice::<u32>(&index);
+        offsets_u32_to_usize(index)
+    } else if *index_data_type == data_type::uint64() {
+        let index = convert_from_bytes_slice::<u64>(&index);
+        offsets_u64_to_usize(index)
+    } else {
+        return Err(CodecError::Other(
+            "unsupported vlen index data type, expected uint32 or uint64".to_string(),
+        ));
     };
 
     // Get the data length
@@ -207,8 +201,7 @@ fn get_vlen_bytes_and_offsets(
 
     // Decode the data
     let data = if let Ok(data_len_expected) = NonZeroU64::try_from(data_len_expected as u64) {
-        Arc::new(data_codecs.clone())
-            .with_context(data_type::uint8(), 0u8.into())?
+        data_codecs
             .decode(data_enc.into(), &[data_len_expected], options)?
             .into_fixed()?
             .into_owned()

--- a/zarrs/src/array/codec/array_to_bytes/vlen.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen.rs
@@ -109,8 +109,8 @@ use crate::array::{
 use itertools::Itertools;
 pub use vlen_codec::VlenCodec;
 use zarrs_codec::{
-    Codec, CodecError, CodecOptions, CodecPluginV3, CodecTraitsV3, InvalidBytesLengthError,
-    UnboundArrayToBytesCodecTraits,
+    ArrayToBytesCodecTraits, Codec, CodecError, CodecOptions, CodecPluginV3, CodecTraitsV3,
+    InvalidBytesLengthError,
 };
 use zarrs_data_type::FillValue;
 use zarrs_metadata::v3::MetadataV3;
@@ -180,14 +180,9 @@ fn get_vlen_bytes_and_offsets(
     };
 
     // Decode the index
-    let mut index = index_codecs
-        .decode(
-            index_enc.into(),
-            &index_shape,
-            &data_type,
-            &fill_value,
-            options,
-        )?
+    let mut index = Arc::new(index_codecs.clone())
+        .with_context(data_type.clone(), fill_value.clone())?
+        .decode(index_enc.into(), &index_shape, options)?
         .into_fixed()?;
     if Endianness::Big.is_native() {
         reverse_endianness(index.to_mut(), &data_type::uint64());
@@ -212,14 +207,9 @@ fn get_vlen_bytes_and_offsets(
 
     // Decode the data
     let data = if let Ok(data_len_expected) = NonZeroU64::try_from(data_len_expected as u64) {
-        data_codecs
-            .decode(
-                data_enc.into(),
-                &[data_len_expected],
-                &data_type::uint8(),
-                &0u8.into(),
-                options,
-            )?
+        Arc::new(data_codecs.clone())
+            .with_context(data_type::uint8(), 0u8.into())?
+            .decode(data_enc.into(), &[data_len_expected], options)?
             .into_fixed()?
             .into_owned()
     } else {

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use super::{VlenCodecConfiguration, VlenCodecConfigurationV0_1, vlen_partial_decoder};
 use crate::array::codec::BytesCodec;
 use crate::array::{
-    ArrayBytes, ArrayBytesOffsets, ArrayBytesRaw, BytesRepresentation, CodecChain, DataType,
-    DataTypeSize, Endianness, FillValue, transmute_to_bytes_vec,
+    ArrayBytes, ArrayBytesOffsets, ArrayBytesRaw, BytesRepresentation, CodecChain, CodecChainBound,
+    DataType, DataTypeSize, Endianness, FillValue, transmute_to_bytes_vec,
 };
 use zarrs_codec::{
     ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
@@ -31,7 +31,9 @@ pub struct VlenCodec {
 /// A `vlen` codec implementation bound to a data type and fill value.
 #[derive(Debug, Clone)]
 struct VlenCodecBound {
-    codec: Arc<VlenCodec>,
+    index_codecs: Arc<CodecChainBound>,
+    data_codecs: Arc<CodecChainBound>,
+    index_location: VlenIndexLocation,
     data_type: DataType,
     fill_value: FillValue,
 }
@@ -178,8 +180,24 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
                 Self::aliases_v3().default_name.to_string(),
             ));
         }
+        let index_codecs = match self.index_data_type {
+            VlenIndexDataType::UInt32 => self
+                .index_codecs
+                .clone()
+                .with_context(crate::array::data_type::uint32(), FillValue::from(0u32))?,
+            VlenIndexDataType::UInt64 => self
+                .index_codecs
+                .clone()
+                .with_context(crate::array::data_type::uint64(), FillValue::from(0u64))?,
+        };
+        let data_codecs = self
+            .data_codecs
+            .clone()
+            .with_context(crate::array::data_type::uint8(), FillValue::from(0u8))?;
         Ok(Arc::new(VlenCodecBound {
-            codec: self,
+            index_codecs,
+            data_codecs,
+            index_location: self.index_location,
             data_type,
             fill_value,
         }))
@@ -187,6 +205,10 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
 }
 
 impl ArrayCodecTraits for VlenCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }
@@ -227,48 +249,39 @@ impl ArrayToBytesCodecTraits for VlenCodecBound {
         // Encode offsets
         let num_offsets =
             NonZeroU64::try_from(usize::try_from(num_elements).unwrap() as u64 + 1).unwrap();
-        let offsets = match self.codec.index_data_type {
-            VlenIndexDataType::UInt32 => {
-                let offsets = offsets
-                    .iter()
-                    .map(|offset| u32::try_from(*offset))
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(|_| {
-                        CodecError::Other(
-                            "index offsets are too large for a uint32 index_data_type".to_string(),
-                        )
-                    })?;
-                let offsets = transmute_to_bytes_vec(offsets);
-                let index_shape = vec![num_offsets];
-                self.codec
-                    .index_codecs
-                    .clone()
-                    .with_context(crate::array::data_type::uint32(), FillValue::from(0u32))?
-                    .encode(offsets.into(), &index_shape, options)?
-            }
-            VlenIndexDataType::UInt64 => {
-                let offsets = offsets
-                    .iter()
-                    .map(|offset| u64::try_from(*offset).unwrap())
-                    .collect::<Vec<u64>>();
-                let offsets = transmute_to_bytes_vec(offsets);
-                let index_shape = vec![num_offsets];
-                self.codec
-                    .index_codecs
-                    .clone()
-                    .with_context(crate::array::data_type::uint64(), FillValue::from(0u64))?
-                    .encode(offsets.into(), &index_shape, options)?
-            }
+        let offsets = if *self.index_codecs.data_type() == crate::array::data_type::uint32() {
+            let offsets = offsets
+                .iter()
+                .map(|offset| u32::try_from(*offset))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| {
+                    CodecError::Other(
+                        "index offsets are too large for a uint32 index_data_type".to_string(),
+                    )
+                })?;
+            let offsets = transmute_to_bytes_vec(offsets);
+            let index_shape = vec![num_offsets];
+            self.index_codecs
+                .encode(offsets.into(), &index_shape, options)?
+        } else if *self.index_codecs.data_type() == crate::array::data_type::uint64() {
+            let offsets = offsets
+                .iter()
+                .map(|offset| u64::try_from(*offset).unwrap())
+                .collect::<Vec<u64>>();
+            let offsets = transmute_to_bytes_vec(offsets);
+            let index_shape = vec![num_offsets];
+            self.index_codecs
+                .encode(offsets.into(), &index_shape, options)?
+        } else {
+            return Err(CodecError::Other(
+                "unsupported bound vlen index data type, expected uint32 or uint64".to_string(),
+            ));
         };
 
         // Encode data
         let data = if let Ok(data_len) = NonZeroU64::try_from(data.len() as u64) {
             let data_shape = vec![data_len];
-            self.codec
-                .data_codecs
-                .clone()
-                .with_context(crate::array::data_type::uint8(), FillValue::from(0u8))?
-                .encode(data.into(), &data_shape, options)?
+            self.data_codecs.encode(data.into(), &data_shape, options)?
         } else {
             vec![].into()
         };
@@ -276,7 +289,7 @@ impl ArrayToBytesCodecTraits for VlenCodecBound {
         // Pack encoded offsets length, encoded offsets, and encoded data
         let mut bytes = Vec::with_capacity(size_of::<u64>() + offsets.len() + data.len());
 
-        match self.codec.index_location {
+        match self.index_location {
             VlenIndexLocation::Start => {
                 bytes.extend_from_slice(&u64::try_from(offsets.len()).unwrap().to_le_bytes()); // offsets length as u64 little endian
                 bytes.extend_from_slice(&offsets);
@@ -301,10 +314,9 @@ impl ArrayToBytesCodecTraits for VlenCodecBound {
         let (bytes, offsets) = super::get_vlen_bytes_and_offsets(
             &bytes,
             shape,
-            self.codec.index_data_type,
-            &self.codec.index_codecs,
-            &self.codec.data_codecs,
-            self.codec.index_location,
+            &self.index_codecs,
+            &self.data_codecs,
+            self.index_location,
             options,
         )?;
         let offsets = ArrayBytesOffsets::new(offsets)?;
@@ -323,10 +335,9 @@ impl ArrayToBytesCodecTraits for VlenCodecBound {
             shape.to_vec(),
             self.data_type.clone(),
             self.fill_value.clone(),
-            self.codec.index_codecs.clone(),
-            self.codec.data_codecs.clone(),
-            self.codec.index_data_type,
-            self.codec.index_location,
+            self.index_codecs.clone(),
+            self.data_codecs.clone(),
+            self.index_location,
         )))
     }
 
@@ -343,10 +354,9 @@ impl ArrayToBytesCodecTraits for VlenCodecBound {
                 shape.to_vec(),
                 self.data_type.clone(),
                 self.fill_value.clone(),
-                self.codec.index_codecs.clone(),
-                self.codec.data_codecs.clone(),
-                self.codec.index_data_type,
-                self.codec.index_location,
+                self.index_codecs.clone(),
+                self.data_codecs.clone(),
+                self.index_location,
             ),
         ))
     }

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
@@ -8,9 +8,9 @@ use crate::array::{
     DataTypeSize, Endianness, FillValue, transmute_to_bytes_vec,
 };
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-    BytesPartialDecoderTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayCodecTraits, ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
@@ -157,9 +157,9 @@ impl ArrayCodecTraits for VlenCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for VlenCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for VlenCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
@@ -9,8 +9,8 @@ use crate::array::{
 };
 use zarrs_codec::{
     ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-    BytesPartialDecoderTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    BytesPartialDecoderTraits, CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
     UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
@@ -92,9 +92,14 @@ impl VlenCodec {
     ) -> Result<Self, PluginCreateError> {
         match configuration {
             VlenCodecConfiguration::V0_1(configuration) => {
-                let index_codecs =
-                    Arc::new(CodecChain::from_metadata(&configuration.index_codecs)?);
-                let data_codecs = Arc::new(CodecChain::from_metadata(&configuration.data_codecs)?);
+                let index_codecs = Arc::new(
+                    CodecChain::from_metadata(&configuration.index_codecs)
+                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
+                );
+                let data_codecs = Arc::new(
+                    CodecChain::from_metadata(&configuration.data_codecs)
+                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
+                );
                 Ok(Self::new(
                     index_codecs,
                     data_codecs,
@@ -103,9 +108,14 @@ impl VlenCodec {
                 ))
             }
             VlenCodecConfiguration::V0(configuration) => {
-                let index_codecs =
-                    Arc::new(CodecChain::from_metadata(&configuration.index_codecs)?);
-                let data_codecs = Arc::new(CodecChain::from_metadata(&configuration.data_codecs)?);
+                let index_codecs = Arc::new(
+                    CodecChain::from_metadata(&configuration.index_codecs)
+                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
+                );
+                let data_codecs = Arc::new(
+                    CodecChain::from_metadata(&configuration.data_codecs)
+                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
+                );
                 Ok(Self::new(
                     index_codecs,
                     data_codecs,
@@ -163,15 +173,15 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         if data_type.is_optional() {
-            return Err(CodecError::UnsupportedDataType(
+            return Err(CodecCreateError::UnsupportedDataType(
                 data_type,
                 Self::aliases_v3().default_name.to_string(),
             ));
         }
         if !matches!(data_type.size(), DataTypeSize::Variable) {
-            return Err(CodecError::UnsupportedDataType(
+            return Err(CodecCreateError::UnsupportedDataType(
                 data_type,
                 Self::aliases_v3().default_name.to_string(),
             ));

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
@@ -121,10 +121,6 @@ impl VlenCodec {
 }
 
 impl CodecTraits for VlenCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
@@ -17,7 +17,7 @@ use zarrs_codec::{
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
 use zarrs_metadata::Configuration;
 use zarrs_metadata_ext::codec::vlen::{VlenIndexDataType, VlenIndexLocation};
-use zarrs_plugin::{ExtensionAliasesV3, PluginCreateError, ZarrVersion};
+use zarrs_plugin::{ExtensionAliasesV3, ZarrVersion};
 
 /// A `vlen` codec implementation.
 #[derive(Debug, Clone)]
@@ -86,20 +86,15 @@ impl VlenCodec {
     /// Create a new `vlen` codec from configuration.
     ///
     /// # Errors
-    /// Returns a [`PluginCreateError`] if the codecs cannot be constructed from the codec metadata.
+    /// Returns a [`CodecCreateError`] if the codecs cannot be constructed from the codec metadata.
     pub fn new_with_configuration(
         configuration: &VlenCodecConfiguration,
-    ) -> Result<Self, PluginCreateError> {
+    ) -> Result<Self, CodecCreateError> {
         match configuration {
             VlenCodecConfiguration::V0_1(configuration) => {
-                let index_codecs = Arc::new(
-                    CodecChain::from_metadata(&configuration.index_codecs)
-                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
-                );
-                let data_codecs = Arc::new(
-                    CodecChain::from_metadata(&configuration.data_codecs)
-                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
-                );
+                let index_codecs =
+                    Arc::new(CodecChain::from_metadata(&configuration.index_codecs)?);
+                let data_codecs = Arc::new(CodecChain::from_metadata(&configuration.data_codecs)?);
                 Ok(Self::new(
                     index_codecs,
                     data_codecs,
@@ -108,14 +103,9 @@ impl VlenCodec {
                 ))
             }
             VlenCodecConfiguration::V0(configuration) => {
-                let index_codecs = Arc::new(
-                    CodecChain::from_metadata(&configuration.index_codecs)
-                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
-                );
-                let data_codecs = Arc::new(
-                    CodecChain::from_metadata(&configuration.data_codecs)
-                        .map_err(|err| PluginCreateError::Other(err.to_string()))?,
-                );
+                let index_codecs =
+                    Arc::new(CodecChain::from_metadata(&configuration.index_codecs)?);
+                let data_codecs = Arc::new(CodecChain::from_metadata(&configuration.data_codecs)?);
                 Ok(Self::new(
                     index_codecs,
                     data_codecs,
@@ -123,7 +113,7 @@ impl VlenCodec {
                     VlenIndexLocation::Start,
                 ))
             }
-            _ => Err(PluginCreateError::Other(
+            _ => Err(CodecCreateError::Other(
                 "this vlen codec configuration variant is unsupported".to_string(),
             )),
         }

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
@@ -8,9 +8,10 @@ use crate::array::{
     DataTypeSize, Endianness, FillValue, transmute_to_bytes_vec,
 };
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
+    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
+    BytesPartialDecoderTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
@@ -25,6 +26,14 @@ pub struct VlenCodec {
     data_codecs: Arc<CodecChain>,
     index_data_type: VlenIndexDataType,
     index_location: VlenIndexLocation,
+}
+
+/// A `vlen` codec implementation bound to a data type and fill value.
+#[derive(Debug, Clone)]
+struct VlenCodecBound {
+    codec: Arc<VlenCodec>,
+    data_type: DataType,
+    fill_value: FillValue,
 }
 
 impl Default for VlenCodec {
@@ -142,16 +151,6 @@ impl CodecTraits for VlenCodec {
     }
 }
 
-impl ArrayCodecTraits for VlenCodec {
-    fn recommended_concurrency(
-        &self,
-        _shape: &[NonZeroU64],
-        _data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        Ok(RecommendedConcurrency::new_maximum(1))
-    }
-}
-
 #[cfg_attr(
     all(feature = "async", not(target_arch = "wasm32")),
     async_trait::async_trait
@@ -162,23 +161,73 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
         self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        if data_type.is_optional() {
+            return Err(CodecError::UnsupportedDataType(
+                data_type,
+                Self::aliases_v3().default_name.to_string(),
+            ));
+        }
+        if !matches!(data_type.size(), DataTypeSize::Variable) {
+            return Err(CodecError::UnsupportedDataType(
+                data_type,
+                Self::aliases_v3().default_name.to_string(),
+            ));
+        }
+        Ok(Arc::new(VlenCodecBound {
+            codec: self,
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for VlenCodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn recommended_concurrency(
+        &self,
+        _shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        Ok(RecommendedConcurrency::new_maximum(1))
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToBytesCodecTraits for VlenCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self as Arc<dyn ArrayToBytesCodecTraits>
+    }
+
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
         let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
-        bytes.validate(num_elements, data_type)?;
+        bytes.validate(num_elements, &self.data_type)?;
         let (data, offsets) = bytes.into_variable()?.into_parts();
         assert_eq!(offsets.len(), usize::try_from(num_elements).unwrap() + 1);
 
         // Encode offsets
         let num_offsets =
             NonZeroU64::try_from(usize::try_from(num_elements).unwrap() as u64 + 1).unwrap();
-        let offsets = match self.index_data_type {
+        let offsets = match self.codec.index_data_type {
             VlenIndexDataType::UInt32 => {
                 let offsets = offsets
                     .iter()
@@ -191,13 +240,11 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
                     })?;
                 let offsets = transmute_to_bytes_vec(offsets);
                 let index_shape = vec![num_offsets];
-                self.index_codecs.encode(
-                    offsets.into(),
-                    &index_shape,
-                    &crate::array::data_type::uint32(),
-                    &FillValue::from(0u32),
-                    options,
-                )?
+                self.codec
+                    .index_codecs
+                    .clone()
+                    .with_context(crate::array::data_type::uint32(), FillValue::from(0u32))?
+                    .encode(offsets.into(), &index_shape, options)?
             }
             VlenIndexDataType::UInt64 => {
                 let offsets = offsets
@@ -206,26 +253,22 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
                     .collect::<Vec<u64>>();
                 let offsets = transmute_to_bytes_vec(offsets);
                 let index_shape = vec![num_offsets];
-                self.index_codecs.encode(
-                    offsets.into(),
-                    &index_shape,
-                    &crate::array::data_type::uint64(),
-                    &FillValue::from(0u64),
-                    options,
-                )?
+                self.codec
+                    .index_codecs
+                    .clone()
+                    .with_context(crate::array::data_type::uint64(), FillValue::from(0u64))?
+                    .encode(offsets.into(), &index_shape, options)?
             }
         };
 
         // Encode data
         let data = if let Ok(data_len) = NonZeroU64::try_from(data.len() as u64) {
             let data_shape = vec![data_len];
-            self.data_codecs.encode(
-                data.into(),
-                &data_shape,
-                &crate::array::data_type::uint8(),
-                &FillValue::from(0u8),
-                options,
-            )?
+            self.codec
+                .data_codecs
+                .clone()
+                .with_context(crate::array::data_type::uint8(), FillValue::from(0u8))?
+                .encode(data.into(), &data_shape, options)?
         } else {
             vec![].into()
         };
@@ -233,7 +276,7 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
         // Pack encoded offsets length, encoded offsets, and encoded data
         let mut bytes = Vec::with_capacity(size_of::<u64>() + offsets.len() + data.len());
 
-        match self.index_location {
+        match self.codec.index_location {
             VlenIndexLocation::Start => {
                 bytes.extend_from_slice(&u64::try_from(offsets.len()).unwrap().to_le_bytes()); // offsets length as u64 little endian
                 bytes.extend_from_slice(&offsets);
@@ -253,17 +296,15 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
         &self,
         bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        _data_type: &DataType,
-        _fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         let (bytes, offsets) = super::get_vlen_bytes_and_offsets(
             &bytes,
             shape,
-            self.index_data_type,
-            &self.index_codecs,
-            &self.data_codecs,
-            self.index_location,
+            self.codec.index_data_type,
+            &self.codec.index_codecs,
+            &self.codec.data_codecs,
+            self.codec.index_location,
             options,
         )?;
         let offsets = ArrayBytesOffsets::new(offsets)?;
@@ -275,19 +316,17 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(vlen_partial_decoder::VlenPartialDecoder::new(
             input_handle,
             shape.to_vec(),
-            data_type.clone(),
-            fill_value.clone(),
-            self.index_codecs.clone(),
-            self.data_codecs.clone(),
-            self.index_data_type,
-            self.index_location,
+            self.data_type.clone(),
+            self.fill_value.clone(),
+            self.codec.index_codecs.clone(),
+            self.codec.data_codecs.clone(),
+            self.codec.index_data_type,
+            self.codec.index_location,
         )))
     }
 
@@ -296,20 +335,18 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             vlen_partial_decoder::AsyncVlenPartialDecoder::new(
                 input_handle,
                 shape.to_vec(),
-                data_type.clone(),
-                fill_value.clone(),
-                self.index_codecs.clone(),
-                self.data_codecs.clone(),
-                self.index_data_type,
-                self.index_location,
+                self.data_type.clone(),
+                self.fill_value.clone(),
+                self.codec.index_codecs.clone(),
+                self.codec.data_codecs.clone(),
+                self.codec.index_data_type,
+                self.codec.index_location,
             ),
         ))
     }
@@ -317,21 +354,12 @@ impl UnboundArrayToBytesCodecTraits for VlenCodec {
     fn encoded_representation(
         &self,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
     ) -> Result<BytesRepresentation, CodecError> {
-        if data_type.is_optional() {
-            return Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
-            ));
-        }
-
-        match data_type.size() {
+        match self.data_type.size() {
             DataTypeSize::Variable => Ok(BytesRepresentation::UnboundedSize),
             DataTypeSize::Fixed(_) => Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
+                self.data_type.clone(),
+                VlenCodec::aliases_v3().default_name.to_string(),
             )),
         }
     }

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
@@ -4,11 +4,11 @@ use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use crate::array::array_bytes_internal::extract_decoded_regions_vlen;
-use crate::array::{ArrayBytes, ArrayBytesRaw, CodecChain, DataType, FillValue};
+use crate::array::{ArrayBytes, ArrayBytesRaw, CodecChainBound, DataType, FillValue};
 use zarrs_codec::{ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError, CodecOptions};
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
-use zarrs_metadata_ext::codec::vlen::{VlenIndexDataType, VlenIndexLocation};
+use zarrs_metadata_ext::codec::vlen::VlenIndexLocation;
 use zarrs_storage::StorageError;
 
 /// Partial decoder for the `bytes` codec.
@@ -17,9 +17,8 @@ pub(crate) struct VlenPartialDecoder {
     shape: Vec<NonZeroU64>,
     data_type: DataType,
     fill_value: FillValue,
-    index_codecs: Arc<CodecChain>,
-    data_codecs: Arc<CodecChain>,
-    index_data_type: VlenIndexDataType,
+    index_codecs: Arc<CodecChainBound>,
+    data_codecs: Arc<CodecChainBound>,
     index_location: VlenIndexLocation,
 }
 
@@ -31,9 +30,8 @@ impl VlenPartialDecoder {
         shape: Vec<NonZeroU64>,
         data_type: DataType,
         fill_value: FillValue,
-        index_codecs: Arc<CodecChain>,
-        data_codecs: Arc<CodecChain>,
-        index_data_type: VlenIndexDataType,
+        index_codecs: Arc<CodecChainBound>,
+        data_codecs: Arc<CodecChainBound>,
         index_location: VlenIndexLocation,
     ) -> Self {
         Self {
@@ -43,7 +41,6 @@ impl VlenPartialDecoder {
             fill_value,
             index_codecs,
             data_codecs,
-            index_data_type,
             index_location,
         }
     }
@@ -51,9 +48,8 @@ impl VlenPartialDecoder {
 
 #[allow(clippy::too_many_arguments)]
 fn decode_vlen_bytes<'a>(
-    index_codecs: &CodecChain,
-    data_codecs: &CodecChain,
-    index_data_type: VlenIndexDataType,
+    index_codecs: &CodecChainBound,
+    data_codecs: &CodecChainBound,
     index_location: VlenIndexLocation,
     bytes: Option<ArrayBytesRaw>,
     indexer: &dyn crate::array::Indexer,
@@ -66,7 +62,6 @@ fn decode_vlen_bytes<'a>(
         let (data, index) = super::get_vlen_bytes_and_offsets(
             &bytes,
             shape,
-            index_data_type,
             index_codecs,
             data_codecs,
             index_location,
@@ -104,7 +99,6 @@ impl ArrayPartialDecoderTraits for VlenPartialDecoder {
         decode_vlen_bytes(
             &self.index_codecs,
             &self.data_codecs,
-            self.index_data_type,
             self.index_location,
             bytes,
             indexer,
@@ -127,9 +121,8 @@ pub(crate) struct AsyncVlenPartialDecoder {
     shape: Vec<NonZeroU64>,
     data_type: DataType,
     fill_value: FillValue,
-    index_codecs: Arc<CodecChain>,
-    data_codecs: Arc<CodecChain>,
-    index_data_type: VlenIndexDataType,
+    index_codecs: Arc<CodecChainBound>,
+    data_codecs: Arc<CodecChainBound>,
     index_location: VlenIndexLocation,
 }
 
@@ -142,9 +135,8 @@ impl AsyncVlenPartialDecoder {
         shape: Vec<NonZeroU64>,
         data_type: DataType,
         fill_value: FillValue,
-        index_codecs: Arc<CodecChain>,
-        data_codecs: Arc<CodecChain>,
-        index_data_type: VlenIndexDataType,
+        index_codecs: Arc<CodecChainBound>,
+        data_codecs: Arc<CodecChainBound>,
         index_location: VlenIndexLocation,
     ) -> Self {
         Self {
@@ -154,7 +146,6 @@ impl AsyncVlenPartialDecoder {
             fill_value,
             index_codecs,
             data_codecs,
-            index_data_type,
             index_location,
         }
     }
@@ -186,7 +177,6 @@ impl AsyncArrayPartialDecoderTraits for AsyncVlenPartialDecoder {
         decode_vlen_bytes(
             &self.index_codecs,
             &self.data_codecs,
-            self.index_data_type,
             self.index_location,
             bytes,
             indexer,

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2.rs
@@ -39,7 +39,6 @@ use zarrs_metadata::v3::MetadataV3;
 use crate::array::ArrayBytesRaw;
 use zarrs_codec::{Codec, CodecError, CodecPluginV3, CodecTraitsV3, InvalidBytesLengthError};
 use zarrs_metadata_ext::codec::vlen_v2::{self};
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(VlenV2Codec,
     v3: "zarrs.vlen_v2", ["https://codec.zarrs.dev/array_to_bytes/vlen_v2"]
@@ -51,7 +50,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for VlenV2Codec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         crate::warn_experimental_extension(metadata.name(), "codec");
 
         if metadata.configuration().is_none_or(|c| c.is_empty()) {

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
@@ -93,6 +93,10 @@ impl UnboundArrayToBytesCodecTraits for VlenV2Codec {
 }
 
 impl ArrayCodecTraits for VlenV2CodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
@@ -8,9 +8,9 @@ use crate::array::{
     FillValue,
 };
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-    BytesPartialDecoderTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    ArrayCodecTraits, ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
@@ -71,9 +71,9 @@ impl ArrayCodecTraits for VlenV2Codec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for VlenV2Codec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for VlenV2Codec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
@@ -8,9 +8,10 @@ use crate::array::{
     FillValue,
 };
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
+    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
+    BytesPartialDecoderTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
@@ -20,6 +21,13 @@ use zarrs_plugin::{ExtensionAliasesV3, ZarrVersion};
 /// The `vlen_v2` codec implementation.
 #[derive(Debug, Clone, Default)]
 pub struct VlenV2Codec {}
+
+/// The `vlen_v2` codec implementation bound to a data type and fill value.
+#[derive(Debug, Clone)]
+struct VlenV2CodecBound {
+    data_type: DataType,
+    fill_value: FillValue,
+}
 
 impl VlenV2Codec {
     /// Create a new `vlen_v2` codec.
@@ -56,16 +64,6 @@ impl CodecTraits for VlenV2Codec {
     }
 }
 
-impl ArrayCodecTraits for VlenV2Codec {
-    fn recommended_concurrency(
-        &self,
-        _shape: &[NonZeroU64],
-        _data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        Ok(RecommendedConcurrency::new_maximum(1))
-    }
-}
-
 #[cfg_attr(
     all(feature = "async", not(target_arch = "wasm32")),
     async_trait::async_trait
@@ -76,16 +74,59 @@ impl UnboundArrayToBytesCodecTraits for VlenV2Codec {
         self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        if data_type.is_optional() || !matches!(data_type.size(), DataTypeSize::Variable) {
+            return Err(CodecError::UnsupportedDataType(
+                data_type,
+                Self::aliases_v3().default_name.to_string(),
+            ));
+        }
+        Ok(Arc::new(VlenV2CodecBound {
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for VlenV2CodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn recommended_concurrency(
+        &self,
+        _shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        Ok(RecommendedConcurrency::new_maximum(1))
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToBytesCodecTraits for VlenV2CodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self as Arc<dyn ArrayToBytesCodecTraits>
+    }
+
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
         let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
-        bytes.validate(num_elements, data_type)?;
+        bytes.validate(num_elements, &self.data_type)?;
         let (bytes, offsets) = bytes.into_variable()?.into_parts();
 
         debug_assert_eq!(1 + num_elements, offsets.len() as u64);
@@ -111,8 +152,6 @@ impl UnboundArrayToBytesCodecTraits for VlenV2Codec {
         &self,
         bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        _data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         let num_elements = shape.iter().map(|d| d.get()).product::<u64>();
@@ -128,16 +167,14 @@ impl UnboundArrayToBytesCodecTraits for VlenV2Codec {
         self: Arc<Self>,
         input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::vlen_v2_partial_decoder::VlenV2PartialDecoder::new(
                 input_handle,
                 shape.to_vec(),
-                data_type.clone(),
-                fill_value.clone(),
+                self.data_type.clone(),
+                self.fill_value.clone(),
             ),
         ))
     }
@@ -147,16 +184,14 @@ impl UnboundArrayToBytesCodecTraits for VlenV2Codec {
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
         Ok(Arc::new(
             super::vlen_v2_partial_decoder::AsyncVlenV2PartialDecoder::new(
                 input_handle,
                 shape.to_vec(),
-                data_type.clone(),
-                fill_value.clone(),
+                self.data_type.clone(),
+                self.fill_value.clone(),
             ),
         ))
     }
@@ -164,21 +199,12 @@ impl UnboundArrayToBytesCodecTraits for VlenV2Codec {
     fn encoded_representation(
         &self,
         _shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
     ) -> Result<BytesRepresentation, CodecError> {
-        if data_type.is_optional() {
-            return Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
-            ));
-        }
-
-        match data_type.size() {
+        match self.data_type.size() {
             DataTypeSize::Variable => Ok(BytesRepresentation::UnboundedSize),
             DataTypeSize::Fixed(_) => Err(CodecError::UnsupportedDataType(
-                data_type.clone(),
-                Self::aliases_v3().default_name.to_string(),
+                self.data_type.clone(),
+                VlenV2Codec::aliases_v3().default_name.to_string(),
             )),
         }
     }

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
@@ -38,10 +38,6 @@ impl VlenV2Codec {
 }
 
 impl CodecTraits for VlenV2Codec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_codec.rs
@@ -9,8 +9,8 @@ use crate::array::{
 };
 use zarrs_codec::{
     ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayToBytesCodecTraits,
-    BytesPartialDecoderTraits, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
-    PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    BytesPartialDecoderTraits, CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
     UnboundArrayToBytesCodecTraits,
 };
 #[cfg(feature = "async")]
@@ -74,9 +74,9 @@ impl UnboundArrayToBytesCodecTraits for VlenV2Codec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         if data_type.is_optional() || !matches!(data_type.size(), DataTypeSize::Variable) {
-            return Err(CodecError::UnsupportedDataType(
+            return Err(CodecCreateError::UnsupportedDataType(
                 data_type,
                 Self::aliases_v3().default_name.to_string(),
             ));

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
@@ -53,7 +53,7 @@ macro_rules! vlen_v2_codec {
         use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
         use zarrs_codec::{
             ArrayCodecTraits,
-            ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, ArrayToBytesCodecTraits,
+            ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, UnboundArrayToBytesCodecTraits,
             BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError,
             CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
             PartialEncoderCapability,
@@ -128,9 +128,9 @@ macro_rules! vlen_v2_codec {
             async_trait::async_trait
         )]
         #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-        impl ArrayToBytesCodecTraits for $struct {
-            fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-                self as Arc<dyn ArrayToBytesCodecTraits>
+        impl UnboundArrayToBytesCodecTraits for $struct {
+            fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+                self as Arc<dyn UnboundArrayToBytesCodecTraits>
             }
 
             fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
@@ -99,10 +99,6 @@ macro_rules! vlen_v2_codec {
         }
 
         impl CodecTraits for $struct {
-            fn as_any(&self) -> &dyn std::any::Any {
-                self
-            }
-
             fn configuration(
                 &self,
                 version: zarrs_plugin::ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
@@ -9,7 +9,6 @@ macro_rules! vlen_v2_module {
         use zarrs_codec::{Codec, CodecPluginV2, CodecPluginV3, CodecTraitsV2, CodecTraitsV3};
         use zarrs_metadata::v2::MetadataV2;
         use zarrs_metadata::v3::MetadataV3;
-        use zarrs_plugin::PluginCreateError;
 
         // Register the V3 codec.
         inventory::submit! {
@@ -21,7 +20,7 @@ macro_rules! vlen_v2_module {
         }
 
         impl CodecTraitsV3 for $struct {
-            fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+            fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
                 if metadata.configuration().is_none_or(|c| c.is_empty()) {
                     let codec = Arc::new($struct::new());
                     Ok(Codec::ArrayToBytes(codec))
@@ -32,7 +31,7 @@ macro_rules! vlen_v2_module {
         }
 
         impl CodecTraitsV2 for $struct {
-            fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+            fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
                 if metadata.configuration().is_empty() {
                     let codec = Arc::new($struct::new());
                     Ok(Codec::ArrayToBytes(codec))

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
@@ -131,7 +131,7 @@ macro_rules! vlen_v2_codec {
             }
 
             fn with_context(
-                self: Arc<Self>,
+                &self,
                 data_type: crate::array::DataType,
                 fill_value: crate::array::FillValue,
             ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
@@ -145,6 +145,10 @@ macro_rules! vlen_v2_codec {
 
         paste::paste! {
         impl ArrayCodecTraits for [<$struct Bound>] {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+
             fn data_type(&self) -> &crate::array::DataType {
                 self.inner.data_type()
             }

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
@@ -54,7 +54,7 @@ macro_rules! vlen_v2_codec {
         use zarrs_codec::{
             ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
             ArrayToBytesCodecTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits,
-            CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+            CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
             PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
             UnboundArrayToBytesCodecTraits,
         };
@@ -130,7 +130,7 @@ macro_rules! vlen_v2_codec {
                 &self,
                 data_type: crate::array::DataType,
                 fill_value: crate::array::FillValue,
-            ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+            ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
                 paste::paste! {
                     Ok(Arc::new([<$struct Bound>] {
                         inner: self.inner.clone().with_context(data_type, fill_value)?,

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
@@ -52,16 +52,15 @@ macro_rules! vlen_v2_codec {
         #[cfg(feature = "async")]
         use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
         use zarrs_codec::{
-            ArrayCodecTraits,
-            ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, UnboundArrayToBytesCodecTraits,
-            BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError,
-            CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-            PartialEncoderCapability,
+            ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+            ArrayToBytesCodecTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits,
+            CodecError, CodecMetadataOptions, CodecOptions, CodecTraits,
+            PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+            UnboundArrayToBytesCodecTraits,
         };
         use crate::array::{
             codec::VlenV2Codec,
             ArrayBytes, ArrayBytesRaw, BytesRepresentation,
-            RecommendedConcurrency,
         };
         use zarrs_metadata::Configuration;
         use zarrs_plugin::{
@@ -73,6 +72,14 @@ macro_rules! vlen_v2_codec {
         #[derive(Debug, Clone)]
         pub struct $struct {
             inner: Arc<VlenV2Codec>,
+        }
+
+        paste::paste! {
+            #[doc = concat!("The `", $default_name, "` codec implementation bound to a data type and fill value.")]
+            #[derive(Debug, Clone)]
+            struct [<$struct Bound>] {
+                inner: Arc<dyn ArrayToBytesCodecTraits>,
+            }
         }
 
         impl $struct {
@@ -113,16 +120,6 @@ macro_rules! vlen_v2_codec {
             }
         }
 
-        impl ArrayCodecTraits for $struct {
-            fn recommended_concurrency(
-                &self,
-                shape: &[std::num::NonZeroU64],
-                data_type: &crate::array::DataType,
-            ) -> Result<RecommendedConcurrency, CodecError> {
-                self.inner.recommended_concurrency(shape, data_type)
-            }
-        }
-
         #[cfg_attr(
             all(feature = "async", not(target_arch = "wasm32")),
             async_trait::async_trait
@@ -133,62 +130,81 @@ macro_rules! vlen_v2_codec {
                 self as Arc<dyn UnboundArrayToBytesCodecTraits>
             }
 
+            fn with_context(
+                self: Arc<Self>,
+                data_type: crate::array::DataType,
+                fill_value: crate::array::FillValue,
+            ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+                paste::paste! {
+                    Ok(Arc::new([<$struct Bound>] {
+                        inner: self.inner.clone().with_context(data_type, fill_value)?,
+                    }))
+                }
+            }
+        }
+
+        paste::paste! {
+        impl ArrayCodecTraits for [<$struct Bound>] {
+            fn data_type(&self) -> &crate::array::DataType {
+                self.inner.data_type()
+            }
+
+            fn fill_value(&self) -> &crate::array::FillValue {
+                self.inner.fill_value()
+            }
+
+            fn recommended_concurrency(
+                &self,
+                shape: &[std::num::NonZeroU64],
+            ) -> Result<RecommendedConcurrency, CodecError> {
+                self.inner.recommended_concurrency(shape)
+            }
+        }
+
+        #[cfg_attr(
+            all(feature = "async", not(target_arch = "wasm32")),
+            async_trait::async_trait
+        )]
+        #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+        impl ArrayToBytesCodecTraits for [<$struct Bound>] {
+            fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+                self as Arc<dyn ArrayToBytesCodecTraits>
+            }
+
             fn encode<'a>(
                 &self,
                 bytes: ArrayBytes<'a>,
                 shape: &[std::num::NonZeroU64],
-                data_type: &crate::array::DataType,
-                fill_value: &crate::array::FillValue,
                 options: &CodecOptions,
             ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-                self.inner
-                    .encode(bytes, shape, data_type, fill_value, options)
+                self.inner.encode(bytes, shape, options)
             }
 
             fn decode<'a>(
                 &self,
                 bytes: ArrayBytesRaw<'a>,
                 shape: &[std::num::NonZeroU64],
-                data_type: &crate::array::DataType,
-                fill_value: &crate::array::FillValue,
                 options: &CodecOptions,
             ) -> Result<ArrayBytes<'a>, CodecError> {
-                self.inner
-                    .decode(bytes, shape, data_type, fill_value, options)
+                self.inner.decode(bytes, shape, options)
             }
 
             fn partial_decoder(
                 self: Arc<Self>,
                 input_handle: Arc<dyn BytesPartialDecoderTraits>,
                 shape: &[std::num::NonZeroU64],
-                data_type: &crate::array::DataType,
-                fill_value: &crate::array::FillValue,
                 options: &CodecOptions,
             ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-                self.inner.clone().partial_decoder(
-                    input_handle,
-                    shape,
-                    data_type,
-                    fill_value,
-                    options,
-                )
+                self.inner.clone().partial_decoder(input_handle, shape, options)
             }
 
             fn partial_encoder(
                 self: Arc<Self>,
                 input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
                 shape: &[std::num::NonZeroU64],
-                data_type: &crate::array::DataType,
-                fill_value: &crate::array::FillValue,
                 options: &CodecOptions,
             ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
-                self.inner.clone().partial_encoder(
-                    input_output_handle,
-                    shape,
-                    data_type,
-                    fill_value,
-                    options,
-                )
+                self.inner.clone().partial_encoder(input_output_handle, shape, options)
             }
 
             #[cfg(feature = "async")]
@@ -196,25 +212,21 @@ macro_rules! vlen_v2_codec {
                 self: Arc<Self>,
                 input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
                 shape: &[std::num::NonZeroU64],
-                data_type: &crate::array::DataType,
-                fill_value: &crate::array::FillValue,
                 options: &CodecOptions,
             ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
                 self.inner
                     .clone()
-                    .async_partial_decoder(input_handle, shape, data_type, fill_value, options)
+                    .async_partial_decoder(input_handle, shape, options)
                     .await
             }
 
             fn encoded_representation(
                 &self,
                 shape: &[std::num::NonZeroU64],
-                data_type: &crate::array::DataType,
-                fill_value: &crate::array::FillValue,
             ) -> Result<BytesRepresentation, CodecError> {
-                self.inner
-                    .encoded_representation(shape, data_type, fill_value)
+                self.inner.encoded_representation(shape)
             }
+        }
         }
 
         paste::paste! {

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -284,7 +284,7 @@ mod tests {
     use crate::array::{
         ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, CodecChain, FillValue, data_type,
     };
-    use zarrs_codec::{ArrayToBytesCodecTraits, BytesPartialDecoderTraits, CodecOptions};
+    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
 
     const JSON_REVERSIBLE: &str = r#"{
         "mode": "reversible"

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -284,7 +284,10 @@ mod tests {
     use crate::array::{
         ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, CodecChain, FillValue, data_type,
     };
-    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
+    use zarrs_codec::{
+        ArrayToBytesCodecTraits, BytesPartialDecoderTraits, CodecOptions,
+        UnboundArrayToBytesCodecTraits,
+    };
 
     const JSON_REVERSIBLE: &str = r#"{
         "mode": "reversible"
@@ -326,29 +329,19 @@ mod tests {
         let bytes = T::to_array_bytes(data_type, &elements).unwrap();
 
         let configuration: ZfpCodecConfiguration = serde_json::from_str(configuration).unwrap();
-        let codec = CodecChain::new(
+        let codec = Arc::new(CodecChain::new(
             vec![Arc::new(SqueezeCodec::new())],
             Arc::new(ZfpCodec::new_with_configuration(&configuration).unwrap()),
             vec![],
-        );
+        ))
+        .with_context(data_type.clone(), fill_value.clone())
+        .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                chunk_shape,
-                data_type,
-                fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded = codec
-            .decode(
-                encoded.clone(),
-                chunk_shape,
-                data_type,
-                fill_value,
-                &CodecOptions::default(),
-            )
+            .decode(encoded.clone(), chunk_shape, &CodecOptions::default())
             .unwrap()
             .into_owned();
         let decoded_elements = T::from_array_bytes(data_type, decoded).unwrap();

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -111,7 +111,7 @@ use self::zfp_array::ZfpArray;
 use self::zfp_bitstream::ZfpBitstream;
 use self::zfp_field::ZfpField;
 use self::zfp_stream::ZfpStream;
-use crate::array::{ChunkShapeTraits, DataType, convert_from_bytes_slice};
+use crate::array::{ChunkShapeTraits, convert_from_bytes_slice};
 use zarrs_codec::{Codec, CodecError, CodecPluginV3, CodecTraitsV3};
 pub use zarrs_metadata_ext::codec::zfp::{ZfpCodecConfiguration, ZfpCodecConfigurationV1, ZfpMode};
 use zarrs_plugin::PluginCreateError;
@@ -276,7 +276,8 @@ mod tests {
     use crate::array::codec::array_to_array::squeeze::SqueezeCodec;
     use crate::array::element::ElementOwned;
     use crate::array::{
-        ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, CodecChain, FillValue, data_type,
+        ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, CodecChain, DataType, FillValue,
+        data_type,
     };
     use zarrs_codec::{
         ArrayToBytesCodecTraits, BytesPartialDecoderTraits, CodecOptions,

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -151,10 +151,8 @@ fn zfp_native_type_to_sys(native_type: ZfpNativeType) -> zfp_sys::zfp_type {
 #[allow(clippy::cast_possible_wrap)]
 fn promote_before_zfp_encoding(
     decoded_value: &[u8],
-    data_type: &DataType,
+    encoding: ZfpEncoding,
 ) -> Result<ZfpArray, zarrs_data_type::DataTypeCodecError> {
-    let encoding = data_type.codec_zfp()?.zfp_encoding();
-
     Ok(match encoding {
         ZfpEncoding::Int32 => ZfpArray::Int32(convert_from_bytes_slice::<i32>(decoded_value)),
         ZfpEncoding::Int64 => ZfpArray::Int64(convert_from_bytes_slice::<i64>(decoded_value)),
@@ -207,13 +205,9 @@ fn promote_before_zfp_encoding(
     })
 }
 
-fn init_zfp_decoding_output(
-    shape: &[NonZeroU64],
-    data_type: &DataType,
-) -> Result<ZfpArray, zarrs_data_type::DataTypeCodecError> {
-    let encoding = data_type.codec_zfp()?.zfp_encoding();
+fn init_zfp_decoding_output(shape: &[NonZeroU64], encoding: ZfpEncoding) -> ZfpArray {
     let num_elements = shape.num_elements_usize();
-    Ok(ZfpArray::new_zeroed(encoding, num_elements))
+    ZfpArray::new_zeroed(encoding, num_elements)
 }
 
 fn zfp_decode(
@@ -221,10 +215,10 @@ fn zfp_decode(
     write_header: bool,
     encoded_value: &mut [u8],
     shape: &[NonZeroU64],
-    data_type: &DataType,
+    encoding: ZfpEncoding,
     parallel: bool,
 ) -> Result<Vec<u8>, CodecError> {
-    let mut array = init_zfp_decoding_output(shape, data_type)?;
+    let mut array = init_zfp_decoding_output(shape, encoding);
     let zfp_type = array.zfp_type();
     let stream = ZfpStream::new(zfp_mode, zfp_type)
         .ok_or_else(|| CodecError::from("failed to create zfp stream"))?;

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -284,7 +284,7 @@ mod tests {
     use crate::array::{
         ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, CodecChain, FillValue, data_type,
     };
-    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions};
+    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
 
     const JSON_REVERSIBLE: &str = r#"{
         "mode": "reversible"
@@ -516,16 +516,12 @@ mod tests {
         let bytes: ArrayBytes = bytes.into();
 
         let configuration: ZfpCodecConfiguration = serde_json::from_str(JSON_REVERSIBLE).unwrap();
-        let codec = Arc::new(ZfpCodec::new_with_configuration(&configuration).unwrap());
+        let codec = Arc::new(ZfpCodec::new_with_configuration(&configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
+            .unwrap();
 
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         let decoded_regions = [
             ArraySubset::new_with_shape(vec![1, 2, 3]),
@@ -534,13 +530,7 @@ mod tests {
 
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .partial_decoder(
-                input_handle.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(input_handle.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // zfp partial decoder does not hold bytes
 
@@ -580,31 +570,19 @@ mod tests {
         let bytes: ArrayBytes = bytes.into();
 
         let configuration: ZfpCodecConfiguration = serde_json::from_str(JSON_REVERSIBLE).unwrap();
-        let codec = Arc::new(ZfpCodec::new_with_configuration(&configuration).unwrap());
-
-        let max_encoded_size = codec
-            .encoded_representation(&chunk_shape, &data_type, &fill_value)
+        let codec = Arc::new(ZfpCodec::new_with_configuration(&configuration).unwrap())
+            .with_context(data_type.clone(), fill_value.clone())
             .unwrap();
+
+        let max_encoded_size = codec.encoded_representation(&chunk_shape).unwrap();
         let encoded = codec
-            .encode(
-                bytes.clone(),
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .encode(bytes.clone(), &chunk_shape, &CodecOptions::default())
             .unwrap();
         assert!((encoded.len() as u64) <= max_encoded_size.size().unwrap());
 
         let input_handle = Arc::new(encoded);
         let partial_decoder = codec
-            .async_partial_decoder(
-                input_handle,
-                &chunk_shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+            .async_partial_decoder(input_handle, &chunk_shape, &CodecOptions::default())
             .await
             .unwrap();
 

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -114,7 +114,6 @@ use self::zfp_stream::ZfpStream;
 use crate::array::{ChunkShapeTraits, convert_from_bytes_slice};
 use zarrs_codec::{Codec, CodecError, CodecPluginV3, CodecTraitsV3};
 pub use zarrs_metadata_ext::codec::zfp::{ZfpCodecConfiguration, ZfpCodecConfigurationV1, ZfpMode};
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(ZfpCodec,
     v3: "zfp", ["zarrs.zfp", "https://codec.zarrs.dev/array_to_bytes/zfp"]
@@ -126,7 +125,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for ZfpCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: ZfpCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(ZfpCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToBytes(codec))

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -148,11 +148,8 @@ fn zfp_native_type_to_sys(native_type: ZfpNativeType) -> zfp_sys::zfp_type {
 }
 
 #[allow(clippy::cast_possible_wrap)]
-fn promote_before_zfp_encoding(
-    decoded_value: &[u8],
-    encoding: ZfpEncoding,
-) -> Result<ZfpArray, zarrs_data_type::DataTypeCodecError> {
-    Ok(match encoding {
+fn promote_before_zfp_encoding(decoded_value: &[u8], encoding: ZfpEncoding) -> ZfpArray {
+    match encoding {
         ZfpEncoding::Int32 => ZfpArray::Int32(convert_from_bytes_slice::<i32>(decoded_value)),
         ZfpEncoding::Int64 => ZfpArray::Int64(convert_from_bytes_slice::<i64>(decoded_value)),
         ZfpEncoding::Float32 => ZfpArray::Float32(convert_from_bytes_slice::<f32>(decoded_value)),
@@ -201,7 +198,7 @@ fn promote_before_zfp_encoding(
                     .collect(),
             )
         }
-    })
+    }
 }
 
 fn init_zfp_decoding_output(shape: &[NonZeroU64], encoding: ZfpEncoding) -> ZfpArray {

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -284,7 +284,7 @@ mod tests {
     use crate::array::{
         ArrayBytes, ArraySubset, ChunkShape, ChunkShapeTraits, CodecChain, FillValue, data_type,
     };
-    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions, UnboundArrayToBytesCodecTraits};
+    use zarrs_codec::{BytesPartialDecoderTraits, CodecOptions};
 
     const JSON_REVERSIBLE: &str = r#"{
         "mode": "reversible"

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -138,10 +138,6 @@ impl ZfpCodec {
 }
 
 impl CodecTraits for ZfpCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -21,9 +21,9 @@ use super::{
 use crate::array::{BytesRepresentation, DataType, FillValue};
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions,
-    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
-    UnboundArrayToBytesCodecTraits,
+    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata_ext::codec::zfp::ZfpMode;
@@ -31,6 +31,15 @@ use zarrs_metadata_ext::codec::zfp::ZfpMode;
 /// A `zfp` codec implementation.
 #[derive(Clone, Copy, Debug)]
 pub struct ZfpCodec {
+    mode: ZfpMode,
+    write_header: bool,
+}
+
+/// A `zfp` codec implementation.
+#[derive(Clone, Debug)]
+pub(crate) struct ZfpCodecBound {
+    data_type: DataType,
+    fill_value: FillValue,
     mode: ZfpMode,
     write_header: bool,
 }
@@ -155,17 +164,6 @@ impl CodecTraits for ZfpCodec {
     }
 }
 
-impl ArrayCodecTraits for ZfpCodec {
-    fn recommended_concurrency(
-        &self,
-        _shape: &[NonZeroU64],
-        _data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        // TODO: zfp supports multi thread, when is it optimal to kick in?
-        Ok(RecommendedConcurrency::new_maximum(1))
-    }
-}
-
 #[cfg_attr(
     all(feature = "async", not(target_arch = "wasm32")),
     async_trait::async_trait
@@ -176,16 +174,52 @@ impl UnboundArrayToBytesCodecTraits for ZfpCodec {
         self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        data_type.codec_zfp()?; // Check that the data type is supported by zfp
+        Ok(Arc::new(ZfpCodecBound {
+            data_type,
+            fill_value,
+            mode: self.mode,
+            write_header: self.write_header,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for ZfpCodecBound {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn recommended_concurrency(
+        &self,
+        _shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        // TODO: zfp supports multi thread, when is it optimal to kick in?
+        Ok(RecommendedConcurrency::new_maximum(1))
+    }
+}
+
+impl ArrayToBytesCodecTraits for ZfpCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self as Arc<dyn ArrayToBytesCodecTraits>
+    }
+
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
         let bytes = bytes.into_fixed()?;
-        let mut bytes_promoted = promote_before_zfp_encoding(&bytes, data_type)?;
+        let mut bytes_promoted = promote_before_zfp_encoding(&bytes, &self.data_type)?;
         let zfp_type = bytes_promoted.zfp_type();
         let field = ZfpField::new(
             &mut bytes_promoted,
@@ -248,8 +282,6 @@ impl UnboundArrayToBytesCodecTraits for ZfpCodec {
         &self,
         bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         zfp_decode(
@@ -257,7 +289,7 @@ impl UnboundArrayToBytesCodecTraits for ZfpCodec {
             self.write_header,
             &mut bytes.to_vec(), // FIXME: Does zfp **really** need the encoded value as mutable?
             shape,
-            data_type,
+            &self.data_type,
             false, // FIXME
         )
         .map(ArrayBytes::from)
@@ -266,10 +298,8 @@ impl UnboundArrayToBytesCodecTraits for ZfpCodec {
     fn encoded_representation(
         &self,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        _fill_value: &FillValue,
     ) -> Result<BytesRepresentation, CodecError> {
-        let encoding = data_type.codec_zfp()?.zfp_encoding();
+        let encoding = self.data_type.codec_zfp()?.zfp_encoding();
         let zfp_type = zfp_native_type_to_sys(encoding.native_type());
 
         let bufsize = {

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -21,8 +21,8 @@ use super::{
 use crate::array::{BytesRepresentation, DataType, FillValue};
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, CodecCreateError,
+    CodecError, CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
     PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::Configuration;
@@ -176,7 +176,7 @@ impl UnboundArrayToBytesCodecTraits for ZfpCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         let encoding = data_type.codec_zfp()?.zfp_encoding();
         let zfp_type = zfp_native_type_to_sys(encoding.native_type());
         Ok(Arc::new(ZfpCodecBound {

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -21,9 +21,9 @@ use super::{
 use crate::array::{BytesRepresentation, DataType, FillValue};
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency,
+    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata_ext::codec::zfp::ZfpMode;
@@ -171,9 +171,9 @@ impl ArrayCodecTraits for ZfpCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for ZfpCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for ZfpCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -15,8 +15,8 @@ use super::zfp_bitstream::ZfpBitstream;
 use super::zfp_field::ZfpField;
 use super::zfp_stream::ZfpStream;
 use super::{
-    ZfpCodecConfiguration, ZfpCodecConfigurationV1, ZfpDataTypeExt, promote_before_zfp_encoding,
-    zfp_decode, zfp_native_type_to_sys,
+    ZfpCodecConfiguration, ZfpCodecConfigurationV1, ZfpDataTypeExt, ZfpEncoding,
+    promote_before_zfp_encoding, zfp_decode, zfp_native_type_to_sys,
 };
 use crate::array::{BytesRepresentation, DataType, FillValue};
 use std::num::NonZeroU64;
@@ -40,6 +40,8 @@ pub struct ZfpCodec {
 pub(crate) struct ZfpCodecBound {
     data_type: DataType,
     fill_value: FillValue,
+    encoding: ZfpEncoding,
+    zfp_type: zfp_sys::zfp_type,
     mode: ZfpMode,
     write_header: bool,
 }
@@ -175,10 +177,13 @@ impl UnboundArrayToBytesCodecTraits for ZfpCodec {
         data_type: DataType,
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
-        data_type.codec_zfp()?; // Check that the data type is supported by zfp
+        let encoding = data_type.codec_zfp()?.zfp_encoding();
+        let zfp_type = zfp_native_type_to_sys(encoding.native_type());
         Ok(Arc::new(ZfpCodecBound {
             data_type,
             fill_value,
+            encoding,
+            zfp_type,
             mode: self.mode,
             write_header: self.write_header,
         }))
@@ -219,7 +224,7 @@ impl ArrayToBytesCodecTraits for ZfpCodecBound {
         _options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
         let bytes = bytes.into_fixed()?;
-        let mut bytes_promoted = promote_before_zfp_encoding(&bytes, &self.data_type)?;
+        let mut bytes_promoted = promote_before_zfp_encoding(&bytes, self.encoding)?;
         let zfp_type = bytes_promoted.zfp_type();
         let field = ZfpField::new(
             &mut bytes_promoted,
@@ -289,7 +294,7 @@ impl ArrayToBytesCodecTraits for ZfpCodecBound {
             self.write_header,
             &mut bytes.to_vec(), // FIXME: Does zfp **really** need the encoded value as mutable?
             shape,
-            &self.data_type,
+            self.encoding,
             false, // FIXME
         )
         .map(ArrayBytes::from)
@@ -299,14 +304,11 @@ impl ArrayToBytesCodecTraits for ZfpCodecBound {
         &self,
         shape: &[NonZeroU64],
     ) -> Result<BytesRepresentation, CodecError> {
-        let encoding = self.data_type.codec_zfp()?.zfp_encoding();
-        let zfp_type = zfp_native_type_to_sys(encoding.native_type());
-
         let bufsize = {
             let field = unsafe {
                 // SAFETY: zfp_stream_maximum_size does not use the data in the field, so it can be empty
                 ZfpField::new_empty(
-                    zfp_type,
+                    self.zfp_type,
                     &shape
                         .iter()
                         .map(|u| usize::try_from(u.get()).unwrap())
@@ -315,7 +317,7 @@ impl ArrayToBytesCodecTraits for ZfpCodecBound {
             }
             .ok_or_else(|| CodecError::from("failed to create zfp field"))?;
 
-            let stream = ZfpStream::new(&self.mode, zfp_type)
+            let stream = ZfpStream::new(&self.mode, self.zfp_type)
                 .ok_or_else(|| CodecError::from("failed to create zfp stream"))?;
 
             unsafe {

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -190,6 +190,10 @@ impl UnboundArrayToBytesCodecTraits for ZfpCodec {
 }
 
 impl ArrayCodecTraits for ZfpCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         &self.data_type
     }

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_codec.rs
@@ -224,7 +224,7 @@ impl ArrayToBytesCodecTraits for ZfpCodecBound {
         _options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
         let bytes = bytes.into_fixed()?;
-        let mut bytes_promoted = promote_before_zfp_encoding(&bytes, self.encoding)?;
+        let mut bytes_promoted = promote_before_zfp_encoding(&bytes, self.encoding);
         let zfp_type = bytes_promoted.zfp_type();
         let field = ZfpField::new(
             &mut bytes_promoted,

--- a/zarrs/src/array/codec/array_to_bytes/zfpy.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfpy.rs
@@ -66,7 +66,6 @@ use std::sync::Arc;
 
 use zarrs_metadata::v2::MetadataV2;
 use zarrs_metadata::v3::MetadataV3;
-use zarrs_plugin::PluginCreateError;
 
 use zarrs_codec::{Codec, CodecPluginV2, CodecPluginV3, CodecTraitsV2, CodecTraitsV3};
 pub use zarrs_metadata_ext::codec::zfpy::{
@@ -89,7 +88,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for ZfpyCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: ZfpyCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(ZfpyCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToBytes(codec))
@@ -97,7 +96,7 @@ impl CodecTraitsV3 for ZfpyCodec {
 }
 
 impl CodecTraitsV2 for ZfpyCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: ZfpyCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(ZfpyCodec::new_with_configuration(&configuration)?);
         Ok(Codec::ArrayToBytes(codec))

--- a/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
@@ -6,9 +6,9 @@ use zarrs_plugin::{PluginCreateError, ZarrVersion};
 use super::super::zfp::ZfpCodec;
 use crate::array::{BytesRepresentation, DataType, FillValue};
 use zarrs_codec::{
-    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
-    PartialEncoderCapability, RecommendedConcurrency,
+    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
+    UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata_ext::codec::zfp::ZfpMode;
@@ -135,9 +135,9 @@ impl ArrayCodecTraits for ZfpyCodec {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-impl ArrayToBytesCodecTraits for ZfpyCodec {
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self as Arc<dyn ArrayToBytesCodecTraits>
+impl UnboundArrayToBytesCodecTraits for ZfpyCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits> {
+        self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
     fn encode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
@@ -6,8 +6,8 @@ use zarrs_plugin::{PluginCreateError, ZarrVersion};
 use super::super::zfp::ZfpCodec;
 use crate::array::{BytesRepresentation, DataType, FillValue};
 use zarrs_codec::{
-    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError,
-    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, CodecCreateError,
+    CodecError, CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
     PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::Configuration;
@@ -135,7 +135,7 @@ impl UnboundArrayToBytesCodecTraits for ZfpyCodec {
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError> {
         let inner_bound = Arc::new(self.inner).with_context(data_type, fill_value)?;
         Ok(Arc::new(ZfpyCodecBound { inner: inner_bound }))
     }

--- a/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use zarrs_plugin::{PluginCreateError, ZarrVersion};
 
-use super::super::zfp::{ZfpCodec};
+use super::super::zfp::ZfpCodec;
 use crate::array::{BytesRepresentation, DataType, FillValue};
 use zarrs_codec::{
     ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError,
@@ -153,7 +153,7 @@ impl ArrayCodecTraits for ZfpyCodecBound {
     fn fill_value(&self) -> &FillValue {
         self.inner.fill_value()
     }
-    
+
     fn recommended_concurrency(
         &self,
         shape: &[NonZeroU64],
@@ -196,7 +196,9 @@ impl ArrayToBytesCodecTraits for ZfpyCodecBound {
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-        self.inner.clone().partial_decoder(input_handle, shape, options)
+        self.inner
+            .clone()
+            .partial_decoder(input_handle, shape, options)
     }
 
     #[cfg(feature = "async")]
@@ -206,7 +208,8 @@ impl ArrayToBytesCodecTraits for ZfpyCodecBound {
         shape: &[NonZeroU64],
         options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
-        self.inner.clone()
+        self.inner
+            .clone()
             .async_partial_decoder(input_handle, shape, options)
             .await
     }

--- a/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
@@ -140,7 +140,7 @@ impl UnboundArrayToBytesCodecTraits for ZfpyCodec {
         data_type: DataType,
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
-        let inner_bound = Arc::new(self.inner.clone()).with_context(data_type, fill_value)?;
+        let inner_bound = Arc::new(self.inner).with_context(data_type, fill_value)?;
         Ok(Arc::new(ZfpyCodecBound { inner: inner_bound }))
     }
 }

--- a/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 
 use zarrs_plugin::{PluginCreateError, ZarrVersion};
 
-use super::super::zfp::ZfpCodec;
+use super::super::zfp::{ZfpCodec};
 use crate::array::{BytesRepresentation, DataType, FillValue};
 use zarrs_codec::{
-    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, CodecError, CodecMetadataOptions, CodecOptions,
-    CodecTraits, PartialDecoderCapability, PartialEncoderCapability, RecommendedConcurrency,
-    UnboundArrayToBytesCodecTraits,
+    ArrayBytes, ArrayBytesRaw, ArrayCodecTraits, ArrayToBytesCodecTraits, CodecError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, PartialDecoderCapability,
+    PartialEncoderCapability, RecommendedConcurrency, UnboundArrayToBytesCodecTraits,
 };
 use zarrs_metadata::Configuration;
 use zarrs_metadata_ext::codec::zfp::ZfpMode;
@@ -27,6 +27,11 @@ use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits
 #[derive(Clone, Copy, Debug)]
 pub struct ZfpyCodec {
     inner: ZfpCodec,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ZfpyCodecBound {
+    inner: Arc<dyn ArrayToBytesCodecTraits>,
 }
 
 impl ZfpyCodec {
@@ -120,16 +125,6 @@ impl CodecTraits for ZfpyCodec {
     }
 }
 
-impl ArrayCodecTraits for ZfpyCodec {
-    fn recommended_concurrency(
-        &self,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-    ) -> Result<RecommendedConcurrency, CodecError> {
-        self.inner.recommended_concurrency(shape, data_type)
-    }
-}
-
 #[cfg_attr(
     all(feature = "async", not(target_arch = "wasm32")),
     async_trait::async_trait
@@ -140,39 +135,68 @@ impl UnboundArrayToBytesCodecTraits for ZfpyCodec {
         self as Arc<dyn UnboundArrayToBytesCodecTraits>
     }
 
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError> {
+        let inner_bound = Arc::new(self.inner.clone()).with_context(data_type, fill_value)?;
+        Ok(Arc::new(ZfpyCodecBound { inner: inner_bound }))
+    }
+}
+
+impl ArrayCodecTraits for ZfpyCodecBound {
+    fn data_type(&self) -> &DataType {
+        self.inner.data_type()
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        self.inner.fill_value()
+    }
+    
+    fn recommended_concurrency(
+        &self,
+        shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        self.inner.recommended_concurrency(shape)
+    }
+}
+
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+impl ArrayToBytesCodecTraits for ZfpyCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits> {
+        self as Arc<dyn ArrayToBytesCodecTraits>
+    }
+
     fn encode<'a>(
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError> {
-        self.inner
-            .encode(bytes, shape, data_type, fill_value, options)
+        self.inner.encode(bytes, shape, options)
     }
 
     fn decode<'a>(
         &self,
         bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
-        self.inner
-            .decode(bytes, shape, data_type, fill_value, options)
+        self.inner.decode(bytes, shape, options)
     }
 
     fn partial_decoder(
         self: Arc<Self>,
         input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-        Arc::new(self.inner).partial_decoder(input_handle, shape, data_type, fill_value, options)
+        self.inner.clone().partial_decoder(input_handle, shape, options)
     }
 
     #[cfg(feature = "async")]
@@ -180,22 +204,17 @@ impl UnboundArrayToBytesCodecTraits for ZfpyCodec {
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
-        Arc::new(self.inner)
-            .async_partial_decoder(input_handle, shape, data_type, fill_value, options)
+        self.inner.clone()
+            .async_partial_decoder(input_handle, shape, options)
             .await
     }
 
     fn encoded_representation(
         &self,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
     ) -> Result<BytesRepresentation, CodecError> {
-        self.inner
-            .encoded_representation(shape, data_type, fill_value)
+        self.inner.encoded_representation(shape)
     }
 }

--- a/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
@@ -93,10 +93,6 @@ impl ZfpyCodec {
 }
 
 impl CodecTraits for ZfpyCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfpy/zfpy_codec.rs
@@ -146,6 +146,10 @@ impl UnboundArrayToBytesCodecTraits for ZfpyCodec {
 }
 
 impl ArrayCodecTraits for ZfpyCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn data_type(&self) -> &DataType {
         self.inner.data_type()
     }

--- a/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
@@ -41,7 +41,6 @@ use zarrs_codec::{Codec, CodecPluginV2, CodecPluginV3, CodecTraitsV2, CodecTrait
 pub use zarrs_metadata_ext::codec::adler32::{
     Adler32CodecConfiguration, Adler32CodecConfigurationV1,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(Adler32Codec,
     v3: "numcodecs.adler32", [],
@@ -58,7 +57,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for Adler32Codec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration = metadata.to_typed_configuration()?;
         let codec = Arc::new(Adler32Codec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))
@@ -66,7 +65,7 @@ impl CodecTraitsV3 for Adler32Codec {
 }
 
 impl CodecTraitsV2 for Adler32Codec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: Adler32CodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(Adler32Codec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))

--- a/zarrs/src/array/codec/bytes_to_bytes/adler32/adler32_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/adler32/adler32_codec.rs
@@ -54,10 +54,6 @@ impl Adler32Codec {
 }
 
 impl CodecTraits for Adler32Codec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_codec_via_blosc_src.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_codec_via_blosc_src.rs
@@ -141,10 +141,6 @@ impl BloscCodec {
 }
 
 impl CodecTraits for BloscCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_codec_via_blusc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_codec_via_blusc.rs
@@ -136,10 +136,6 @@ impl BloscCodec {
 }
 
 impl CodecTraits for BloscCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_via_blosc_src.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_via_blosc_src.rs
@@ -21,10 +21,9 @@ pub use zarrs_metadata_ext::codec::blosc::{
     BloscCodecConfiguration, BloscCodecConfigurationNumcodecs, BloscCodecConfigurationV1,
     BloscCompressionLevel, BloscCompressor, BloscShuffleMode, BloscShuffleModeNumcodecs,
 };
-use zarrs_plugin::PluginCreateError;
 
 impl CodecTraitsV3 for BloscCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: BloscCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(BloscCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))
@@ -32,7 +31,7 @@ impl CodecTraitsV3 for BloscCodec {
 }
 
 impl CodecTraitsV2 for BloscCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: BloscCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(BloscCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_via_blusc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_via_blusc.rs
@@ -31,10 +31,9 @@ pub use zarrs_metadata_ext::codec::blosc::{
     BloscCodecConfiguration, BloscCodecConfigurationNumcodecs, BloscCodecConfigurationV1,
     BloscCompressionLevel, BloscCompressor, BloscShuffleMode, BloscShuffleModeNumcodecs,
 };
-use zarrs_plugin::PluginCreateError;
 
 impl CodecTraitsV3 for BloscCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: BloscCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(BloscCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))
@@ -42,7 +41,7 @@ impl CodecTraitsV3 for BloscCodec {
 }
 
 impl CodecTraitsV2 for BloscCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: BloscCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(BloscCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
@@ -43,7 +43,6 @@ use zarrs_codec::{Codec, CodecPluginV2, CodecPluginV3, CodecTraitsV2, CodecTrait
 pub use zarrs_metadata_ext::codec::bz2::{
     Bz2CodecConfiguration, Bz2CodecConfigurationV1, Bz2CompressionLevel,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(Bz2Codec,
     v3: "numcodecs.bz2", [],
@@ -61,7 +60,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for Bz2Codec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: Bz2CodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(Bz2Codec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))
@@ -69,7 +68,7 @@ impl CodecTraitsV3 for Bz2Codec {
 }
 
 impl CodecTraitsV2 for Bz2Codec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: Bz2CodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(Bz2Codec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2/bz2_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2/bz2_codec.rs
@@ -43,10 +43,6 @@ impl Bz2Codec {
 }
 
 impl CodecTraits for Bz2Codec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
@@ -36,7 +36,6 @@ use zarrs_codec::Codec;
 pub use zarrs_metadata_ext::codec::crc32c::{
     Crc32cCodecConfiguration, Crc32cCodecConfigurationNumcodecs, Crc32cCodecConfigurationV1,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(Crc32cCodec, v3: "crc32c", v2: "crc32c");
 
@@ -46,7 +45,7 @@ inventory::submit! {
 }
 
 impl zarrs_codec::CodecTraitsV3 for Crc32cCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration = if metadata.name() == "numcodecs.crc32c" {
             Crc32cCodecConfiguration::Numcodecs(
                 metadata.to_typed_configuration::<Crc32cCodecConfigurationNumcodecs>()?,
@@ -62,7 +61,7 @@ impl zarrs_codec::CodecTraitsV3 for Crc32cCodec {
 }
 
 impl zarrs_codec::CodecTraitsV2 for Crc32cCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration = Crc32cCodecConfiguration::Numcodecs(
             metadata.to_typed_configuration::<Crc32cCodecConfigurationNumcodecs>()?,
         );

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c/crc32c_codec.rs
@@ -45,10 +45,6 @@ impl Crc32cCodec {
 }
 
 impl CodecTraits for Crc32cCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
@@ -43,7 +43,6 @@ use zarrs_codec::{Codec, CodecPluginV2, CodecPluginV3, CodecTraitsV2, CodecTrait
 pub use zarrs_metadata_ext::codec::fletcher32::{
     Fletcher32CodecConfiguration, Fletcher32CodecConfigurationV1,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(Fletcher32Codec,
     v3: "numcodecs.fletcher32", ["numcodecs.fletcher32", "https://codec.zarrs.dev/bytes_to_bytes/fletcher32"],
@@ -60,7 +59,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for Fletcher32Codec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration = metadata.to_typed_configuration()?;
         let codec = Arc::new(Fletcher32Codec::new_with_configuration(&configuration));
         Ok(Codec::BytesToBytes(codec))
@@ -68,7 +67,7 @@ impl CodecTraitsV3 for Fletcher32Codec {
 }
 
 impl CodecTraitsV2 for Fletcher32Codec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: Fletcher32CodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(Fletcher32Codec::new_with_configuration(&configuration));
         Ok(Codec::BytesToBytes(codec))

--- a/zarrs/src/array/codec/bytes_to_bytes/fletcher32/fletcher32_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/fletcher32/fletcher32_codec.rs
@@ -37,10 +37,6 @@ impl Fletcher32Codec {
 }
 
 impl CodecTraits for Fletcher32Codec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
@@ -54,7 +54,6 @@ pub use zarrs_metadata_ext::codec::gdeflate::{
     GDeflateCodecConfiguration, GDeflateCodecConfigurationV0, GDeflateCompressionLevel,
     GDeflateCompressionLevelError,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(GDeflateCodec, v3: "zarrs.gdeflate");
 
@@ -64,7 +63,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for GDeflateCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         crate::warn_experimental_extension(metadata.name(), "codec");
         let configuration: GDeflateCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(GDeflateCodec::new_with_configuration(&configuration)?);

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate/gdeflate_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate/gdeflate_codec.rs
@@ -51,10 +51,6 @@ impl GDeflateCodec {
 }
 
 impl CodecTraits for GDeflateCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
@@ -38,7 +38,6 @@ pub use zarrs_metadata_ext::codec::gzip::{
     GzipCodecConfiguration, GzipCodecConfigurationV1, GzipCompressionLevel,
     GzipCompressionLevelError,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(GzipCodec, v3: "gzip", v2: "gzip");
 
@@ -53,7 +52,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for GzipCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: GzipCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(GzipCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))
@@ -61,7 +60,7 @@ impl CodecTraitsV3 for GzipCodec {
 }
 
 impl CodecTraitsV2 for GzipCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: GzipCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(GzipCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
@@ -51,10 +51,6 @@ impl GzipCodec {
 }
 
 impl CodecTraits for GzipCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
@@ -46,7 +46,6 @@ pub use zarrs_metadata_ext::codec::shuffle::{
 use zarrs_codec::Codec;
 use zarrs_metadata::v2::MetadataV2;
 use zarrs_metadata::v3::MetadataV3;
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(ShuffleCodec,
     v3: "numcodecs.shuffle", [],
@@ -61,7 +60,7 @@ inventory::submit! {
 }
 
 impl zarrs_codec::CodecTraitsV3 for ShuffleCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration = metadata.to_typed_configuration()?;
         let codec = Arc::new(ShuffleCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))
@@ -69,7 +68,7 @@ impl zarrs_codec::CodecTraitsV3 for ShuffleCodec {
 }
 
 impl zarrs_codec::CodecTraitsV2 for ShuffleCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration = metadata.to_typed_configuration()?;
         let codec = Arc::new(ShuffleCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))

--- a/zarrs/src/array/codec/bytes_to_bytes/shuffle/shuffle_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/shuffle/shuffle_codec.rs
@@ -43,10 +43,6 @@ impl ShuffleCodec {
 }
 
 impl CodecTraits for ShuffleCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_codec.rs
@@ -37,10 +37,6 @@ impl Default for TestUnboundedCodec {
 }
 
 impl CodecTraits for TestUnboundedCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
@@ -42,7 +42,6 @@ use zarrs_codec::{Codec, CodecPluginV2, CodecPluginV3, CodecTraitsV2, CodecTrait
 pub use zarrs_metadata_ext::codec::zlib::{
     ZlibCodecConfiguration, ZlibCodecConfigurationV1, ZlibCompressionLevel,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(ZlibCodec,
     v3: "numcodecs.zlib", [],
@@ -60,7 +59,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for ZlibCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: ZlibCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(ZlibCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))
@@ -68,7 +67,7 @@ impl CodecTraitsV3 for ZlibCodec {
 }
 
 impl CodecTraitsV2 for ZlibCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: ZlibCodecConfiguration = metadata.to_typed_configuration()?;
         let codec = Arc::new(ZlibCodec::new_with_configuration(&configuration)?);
         Ok(Codec::BytesToBytes(codec))

--- a/zarrs/src/array/codec/bytes_to_bytes/zlib/zlib_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zlib/zlib_codec.rs
@@ -43,10 +43,6 @@ impl ZlibCodec {
 }
 
 impl CodecTraits for ZlibCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
@@ -43,7 +43,6 @@ pub use zarrs_metadata_ext::codec::zstd::{
     ZstdCodecConfiguration, ZstdCodecConfigurationNumcodecs, ZstdCodecConfigurationV1,
     ZstdCompressionLevel,
 };
-use zarrs_plugin::PluginCreateError;
 
 zarrs_plugin::impl_extension_aliases!(ZstdCodec, v3: "zstd", v2: "zstd");
 
@@ -58,7 +57,7 @@ inventory::submit! {
 }
 
 impl CodecTraitsV3 for ZstdCodec {
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV3) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: ZstdCodecConfigurationV1 = metadata.to_typed_configuration()?;
         let codec = ZstdCodec::new(configuration.level.into(), configuration.checksum);
         Ok(Codec::BytesToBytes(Arc::new(codec)))
@@ -66,7 +65,7 @@ impl CodecTraitsV3 for ZstdCodec {
 }
 
 impl CodecTraitsV2 for ZstdCodec {
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError> {
+    fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
         let configuration: ZstdCodecConfigurationNumcodecs = metadata.to_typed_configuration()?;
         let codec = ZstdCodec::new(configuration.level.into(), false);
         Ok(Codec::BytesToBytes(Arc::new(codec)))

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd/zstd_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd/zstd_codec.rs
@@ -53,10 +53,6 @@ impl ZstdCodec {
 }
 
 impl CodecTraits for ZstdCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/tests/array_async_partial_encode.rs
+++ b/zarrs/tests/array_async_partial_encode.rs
@@ -12,7 +12,7 @@ use zarrs::storage::storage_adapter::sync_to_async::{
     SyncToAsyncSpawnBlocking, SyncToAsyncStorageAdapter,
 };
 use zarrs::storage::store::MemoryStore;
-use zarrs_codec::{ArrayToArrayCodecTraits, BytesToBytesCodecTraits, CodecOptions};
+use zarrs_codec::{BytesToBytesCodecTraits, CodecOptions, UnboundArrayToArrayCodecTraits};
 struct TokioSpawnBlocking;
 
 impl SyncToAsyncSpawnBlocking for TokioSpawnBlocking {
@@ -27,7 +27,7 @@ impl SyncToAsyncSpawnBlocking for TokioSpawnBlocking {
 
 /// Test async partial encoding for array-to-array codecs in isolation
 async fn test_array_to_array_codec_async_partial_encoding<
-    T: ArrayToArrayCodecTraits + Send + Sync + 'static,
+    T: UnboundArrayToArrayCodecTraits + Send + Sync + 'static,
 >(
     codec: Arc<T>,
     codec_name: &str,

--- a/zarrs/tests/array_sync.rs
+++ b/zarrs/tests/array_sync.rs
@@ -7,8 +7,7 @@ use std::sync::Arc;
 use zarrs::array::{Array, ArrayBuilder, ArrayBytes, ArraySubset, FillValue, data_type};
 use zarrs::storage::store::MemoryStore;
 use zarrs_codec::{
-    ArrayBytesDecodeIntoTarget, ArrayBytesFixedDisjointView, CodecOptions,
-    UnboundArrayToBytesCodecTraits,
+    ArrayBytesDecodeIntoTarget, ArrayBytesFixedDisjointView, ArrayToBytesCodecTraits, CodecOptions,
 };
 
 #[allow(clippy::single_range_in_vec_init)]
@@ -122,7 +121,7 @@ fn array_sync_read_uncompressed() -> Result<(), Box<dyn std::error::Error>> {
     let chunk_shape = array.chunk_shape(&vec![0; array.dimensionality()])?;
     assert_eq!(
         array
-            .codecs()
+            .codecs_bound()
             .partial_decode_granularity(&chunk_shape)
             .unwrap(),
         [NonZeroU64::new(2).unwrap(); 2]
@@ -160,7 +159,7 @@ fn array_sync_read_shard_compress() -> Result<(), Box<dyn std::error::Error>> {
     let chunk_shape = array.chunk_shape(&vec![0; array.dimensionality()])?;
     assert_eq!(
         array
-            .codecs()
+            .codecs_bound()
             .partial_decode_granularity(&chunk_shape)
             .unwrap(),
         [NonZeroU64::new(1).unwrap(); 2]

--- a/zarrs/tests/array_sync.rs
+++ b/zarrs/tests/array_sync.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use zarrs::array::{Array, ArrayBuilder, ArrayBytes, ArraySubset, FillValue, data_type};
 use zarrs::storage::store::MemoryStore;
 use zarrs_codec::{
-    ArrayBytesDecodeIntoTarget, ArrayBytesFixedDisjointView, ArrayToBytesCodecTraits, CodecOptions,
+    ArrayBytesDecodeIntoTarget, ArrayBytesFixedDisjointView, CodecOptions,
+    UnboundArrayToBytesCodecTraits,
 };
 
 #[allow(clippy::single_range_in_vec_init)]

--- a/zarrs/tests/array_sync_partial_encode.rs
+++ b/zarrs/tests/array_sync_partial_encode.rs
@@ -8,11 +8,11 @@ use zarrs::array::{ArrayBuilder, ArraySubset, ChunkShapeTraits, data_type};
 use zarrs::storage::ReadableStorageTraits;
 use zarrs::storage::storage_adapter::performance_metrics::PerformanceMetricsStorageAdapter;
 use zarrs::storage::store::MemoryStore;
-use zarrs_codec::{ArrayToArrayCodecTraits, BytesToBytesCodecTraits, CodecOptions};
+use zarrs_codec::{BytesToBytesCodecTraits, CodecOptions, UnboundArrayToArrayCodecTraits};
 
 /// Test sync partial encoding for array-to-array codecs in isolation
 fn test_array_to_array_codec_sync_partial_encoding<
-    T: ArrayToArrayCodecTraits + Send + Sync + 'static,
+    T: UnboundArrayToArrayCodecTraits + Send + Sync + 'static,
 >(
     codec: Arc<T>,
     codec_name: &str,

--- a/zarrs/tests/cities.rs
+++ b/zarrs/tests/cities.rs
@@ -12,7 +12,7 @@ use zarrs::array::codec::{VlenCodecConfiguration, ZstdCodec};
 use zarrs::array::{ArrayBuilder, ArrayBytes, ArrayMetadataOptions, data_type};
 use zarrs::storage::ReadableWritableListableStorage;
 use zarrs::storage::store::MemoryStore;
-use zarrs_codec::ArrayToBytesCodecTraits;
+use zarrs_codec::UnboundArrayToBytesCodecTraits;
 use zarrs_filesystem::FilesystemStore;
 
 fn read_cities() -> std::io::Result<Vec<String>> {
@@ -29,7 +29,7 @@ fn cities_impl(
     compression_level: Option<i32>,
     chunk_size: u64,
     shard_size: Option<u64>,
-    vlen_codec: Arc<dyn ArrayToBytesCodecTraits>,
+    vlen_codec: Arc<dyn UnboundArrayToBytesCodecTraits>,
     write_to_file: bool,
 ) -> Result<u64, Box<dyn Error>> {
     let store: ReadableWritableListableStorage = if write_to_file {

--- a/zarrs/tests/codec_bound.rs
+++ b/zarrs/tests/codec_bound.rs
@@ -1,0 +1,50 @@
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use zarrs::array::codec::{TransposeCodec, TransposeOrder};
+use zarrs::array::{
+    ArrayBuilder, ArrayBytes, ArrayCodecTraits, ArrayCreateError, ArrayToBytesCodecTraits,
+    CodecOptions, FillValue, data_type,
+};
+use zarrs::storage::store::MemoryStore;
+
+#[test]
+fn codec_chain_bound_context_and_runtime() -> Result<(), Box<dyn std::error::Error>> {
+    let array = ArrayBuilder::new(vec![4], vec![4], data_type::uint8(), 7u8)
+        .build(Arc::new(MemoryStore::new()), "/array")?;
+    let codecs = array.codecs_bound();
+
+    assert_eq!(codecs.data_type(), array.data_type());
+    assert_eq!(codecs.fill_value(), array.fill_value());
+
+    let shape = array.chunk_shape(&[0])?;
+    let decoded = ArrayBytes::from(vec![1, 2, 3, 4]);
+    let encoded = codecs.encode(decoded.clone(), &shape, &CodecOptions::default())?;
+    assert_eq!(
+        codecs.decode(encoded, &shape, &CodecOptions::default())?,
+        decoded
+    );
+    codecs.encoded_representation(&shape)?;
+    codecs.recommended_concurrency(&shape)?;
+
+    Ok(())
+}
+
+#[test]
+fn codec_binding_error_propagates_from_array_builder() {
+    let mut builder = ArrayBuilder::new(
+        vec![4, 4],
+        vec![4, 4],
+        data_type::uint8().to_optional(),
+        FillValue::from(None::<u8>),
+    );
+    builder.array_to_array_codecs(vec![Arc::new(TransposeCodec::new(
+        TransposeOrder::new(&[1, 0]).unwrap(),
+    ))]);
+
+    assert!(matches!(
+        builder.build(Arc::new(MemoryStore::new()), "/array"),
+        Err(ArrayCreateError::CodecError(_))
+    ));
+}

--- a/zarrs/tests/codec_bound.rs
+++ b/zarrs/tests/codec_bound.rs
@@ -45,6 +45,6 @@ fn codec_binding_error_propagates_from_array_builder() {
 
     assert!(matches!(
         builder.build(Arc::new(MemoryStore::new()), "/array"),
-        Err(ArrayCreateError::CodecError(_))
+        Err(ArrayCreateError::CodecsCreateError(_))
     ));
 }

--- a/zarrs/tests/codec_runtime_registration.rs
+++ b/zarrs/tests/codec_runtime_registration.rs
@@ -22,10 +22,6 @@ struct TestPassthroughCodec;
 zarrs_plugin::impl_extension_aliases!(TestPassthroughCodec, v3: "test.passthrough", v2: "test.passthrough");
 
 impl CodecTraits for TestPassthroughCodec {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn configuration(
         &self,
         _version: ZarrVersion,

--- a/zarrs/tests/codec_snapshot_tests.rs
+++ b/zarrs/tests/codec_snapshot_tests.rs
@@ -901,8 +901,8 @@ pub fn run_codec_test(config: &TestConfig, output_dir: &Path) -> CodecTestResult
     let array = match builder.build(store.clone(), "/") {
         Ok(a) => a,
         Err(e) => {
-            let reason = if let zarrs::array::ArrayCreateError::CodecError(e) = e {
-                format!("Data storage failed: {e}")
+            let reason = if let zarrs::array::ArrayCreateError::CodecsCreateError(e) = e {
+                format!("Codec creation failed: {e}")
             } else {
                 format!("Array creation failed: {e}")
             };
@@ -1247,7 +1247,7 @@ pub fn run_and_verify_snapshot_v2(config: &TestConfig, snapshot_path: &SnapshotP
                     }
                     None => {
                         assert!(
-                            reason.starts_with("Data storage failed:")
+                            reason.starts_with("Codec creation failed:")
                                 && snapshot_path.has_unsupported(&snapshots),
                             "Test {display_path} is unsupported ({reason}). Run with UPDATE_SNAPSHOTS=1 to record this."
                         );

--- a/zarrs/tests/codec_snapshot_tests.rs
+++ b/zarrs/tests/codec_snapshot_tests.rs
@@ -41,7 +41,9 @@ use zarrs::array::{
     data_type,
 };
 use zarrs::metadata_ext::data_type::NumpyTimeUnit;
-use zarrs_codec::{ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, BytesToBytesCodecTraits};
+use zarrs_codec::{
+    BytesToBytesCodecTraits, UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits,
+};
 use zarrs_filesystem::FilesystemStore;
 use zarrs_plugin::ExtensionAliasesV3;
 
@@ -182,9 +184,9 @@ pub struct TestConfig {
     /// Chunk shape (outer chunks for sharding)
     pub chunk_shape: Vec<u64>,
     /// Optional array-to-array codecs
-    pub array_to_array_codecs: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
+    pub array_to_array_codecs: Vec<Arc<dyn UnboundArrayToArrayCodecTraits>>,
     /// Optional array-to-bytes codec (None = use default for data type)
-    pub array_to_bytes_codec: Option<Arc<dyn ArrayToBytesCodecTraits>>,
+    pub array_to_bytes_codec: Option<Arc<dyn UnboundArrayToBytesCodecTraits>>,
     /// Optional bytes-to-bytes codecs
     pub bytes_to_bytes_codecs: Vec<Arc<dyn BytesToBytesCodecTraits>>,
     /// Chunk grid name for snapshot naming (e.g., "regular", "rectangular")
@@ -803,6 +805,16 @@ impl SnapshotPath {
         }
         None
     }
+
+    /// Return whether this test path has any unsupported marker.
+    #[must_use]
+    pub fn has_unsupported(&self, base_dir: &Path) -> bool {
+        base_dir
+            .join("unsupported")
+            .join(self.relative_path())
+            .read_dir()
+            .is_ok_and(|mut entries| entries.next().is_some())
+    }
 }
 
 /// Status of an existing snapshot
@@ -889,9 +901,12 @@ pub fn run_codec_test(config: &TestConfig, output_dir: &Path) -> CodecTestResult
     let array = match builder.build(store.clone(), "/") {
         Ok(a) => a,
         Err(e) => {
-            return CodecTestResult::Unsupported {
-                reason: format!("Array creation failed: {e}"),
+            let reason = if let zarrs::array::ArrayCreateError::CodecError(e) = e {
+                format!("Data storage failed: {e}")
+            } else {
+                format!("Array creation failed: {e}")
             };
+            return CodecTestResult::Unsupported { reason };
         }
     };
 
@@ -1231,7 +1246,9 @@ pub fn run_and_verify_snapshot_v2(config: &TestConfig, snapshot_path: &SnapshotP
                         );
                     }
                     None => {
-                        panic!(
+                        assert!(
+                            reason.starts_with("Data storage failed:")
+                                && snapshot_path.has_unsupported(&snapshots),
                             "Test {display_path} is unsupported ({reason}). Run with UPDATE_SNAPSHOTS=1 to record this."
                         );
                     }
@@ -1303,8 +1320,8 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
 
 /// A codec instance that can be any of the three codec categories
 pub enum CodecInstance {
-    ArrayToArray(Arc<dyn ArrayToArrayCodecTraits>),
-    ArrayToBytes(Arc<dyn ArrayToBytesCodecTraits>),
+    ArrayToArray(Arc<dyn UnboundArrayToArrayCodecTraits>),
+    ArrayToBytes(Arc<dyn UnboundArrayToBytesCodecTraits>),
     BytesToBytes(Arc<dyn BytesToBytesCodecTraits>),
 }
 

--- a/zarrs/tests/indexer.rs
+++ b/zarrs/tests/indexer.rs
@@ -251,13 +251,14 @@ fn indexer_partial_decode_impl<T: ElementOwned>(
     bytes: &[T],
 ) -> Vec<T> {
     let fill_value = FillValue::from(0u32);
+    let bound_codec = codec
+        .with_context(data_type.clone(), fill_value.clone())
+        .unwrap();
     let encoded_chunk = Arc::new(
-        codec
+        bound_codec
             .encode(
                 T::to_array_bytes(&data_type, bytes).unwrap(),
                 shape,
-                &data_type,
-                &fill_value,
                 &CodecOptions::default(),
             )
             .unwrap()
@@ -265,25 +266,21 @@ fn indexer_partial_decode_impl<T: ElementOwned>(
     );
 
     let partial_decoder = if _async {
-        codec
+        bound_codec
             .clone()
             .async_partial_decoder(
                 encoded_chunk.clone(),
                 shape,
-                &data_type,
-                &fill_value,
                 &CodecOptions::default(),
             )
             .await
             .unwrap()
     } else {
-        codec
+        bound_codec
             .clone()
             .partial_decoder(
                 encoded_chunk.clone(),
                 shape,
-                &data_type,
-                &fill_value,
                 &CodecOptions::default(),
             )
             .unwrap()
@@ -313,13 +310,14 @@ fn indexer_partial_encode_impl<T: ElementOwned>(
     bytes: &[T],
 ) -> Vec<T> {
     let fill_value = FillValue::from(0u32);
+    let bound_codec = codec
+        .with_context(data_type.clone(), fill_value.clone())
+        .unwrap();
     let encoded_chunk = Arc::new(
-        codec
+        bound_codec
             .encode(
                 T::to_array_bytes(&data_type, bytes).unwrap(),
                 shape,
-                &data_type,
-                &fill_value,
                 &CodecOptions::default(),
             )
             .unwrap()
@@ -328,13 +326,11 @@ fn indexer_partial_encode_impl<T: ElementOwned>(
 
     // TODO: Async partial encoder
     let output = Arc::new(Mutex::new(Some(encoded_chunk.to_vec())));
-    let partial_encoder = codec
+    let partial_encoder = bound_codec
         .clone()
         .partial_encoder(
             output.clone(),
             shape,
-            &data_type,
-            &fill_value,
             &CodecOptions::default(),
         )
         .unwrap();
@@ -358,14 +354,8 @@ fn indexer_partial_encode_impl<T: ElementOwned>(
     let output = output.lock().unwrap().clone().unwrap();
     T::from_array_bytes(
         &data_type,
-        codec
-            .decode(
-                output.into(),
-                shape,
-                &data_type,
-                &fill_value,
-                &CodecOptions::default(),
-            )
+        bound_codec
+            .decode(output.into(), shape, &CodecOptions::default())
             .unwrap(),
     )
     .unwrap()

--- a/zarrs/tests/indexer.rs
+++ b/zarrs/tests/indexer.rs
@@ -13,7 +13,8 @@ use zarrs::array::{
     DataType, ElementOwned, Indexer, IndexerError, data_type,
 };
 use zarrs_codec::{
-    ArrayToBytesCodecTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecOptions,
+    BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecOptions,
+    UnboundArrayToBytesCodecTraits,
 };
 use zarrs_data_type::FillValue;
 
@@ -243,7 +244,7 @@ fn indexer_array_subsets_vec() {
 
 #[async_generic::async_generic]
 fn indexer_partial_decode_impl<T: ElementOwned>(
-    codec: Arc<dyn ArrayToBytesCodecTraits>,
+    codec: Arc<dyn UnboundArrayToBytesCodecTraits>,
     shape: &[NonZeroU64],
     indexer: &dyn Indexer,
     data_type: DataType,
@@ -304,7 +305,7 @@ fn indexer_partial_decode_impl<T: ElementOwned>(
 
 // #[async_generic::async_generic]
 fn indexer_partial_encode_impl<T: ElementOwned>(
-    codec: Arc<dyn ArrayToBytesCodecTraits>,
+    codec: Arc<dyn UnboundArrayToBytesCodecTraits>,
     shape: &[NonZeroU64],
     indexer: &dyn Indexer,
     elements_partial_encode: &[T],
@@ -396,7 +397,7 @@ async fn async_indexer_array_subsets_fixed() {
         12.0, 13.0, 140.0, 150.0, //
     ];
 
-    let codecs: Vec<(Arc<dyn ArrayToBytesCodecTraits>, bool)> = vec![
+    let codecs: Vec<(Arc<dyn UnboundArrayToBytesCodecTraits>, bool)> = vec![
         (Arc::new(BytesCodec::little()), true),
         (
             Arc::new(CodecChain::new(
@@ -524,7 +525,7 @@ async fn async_indexer_array_subsets_variable() {
         "140.0",
         "150.0", //
     ];
-    let codecs: Vec<(Arc<dyn ArrayToBytesCodecTraits>, bool)> = vec![
+    let codecs: Vec<(Arc<dyn UnboundArrayToBytesCodecTraits>, bool)> = vec![
         (Arc::new(VlenCodec::default()), true),
         (
             Arc::new(CodecChain::new(

--- a/zarrs/tests/indexer.rs
+++ b/zarrs/tests/indexer.rs
@@ -268,21 +268,13 @@ fn indexer_partial_decode_impl<T: ElementOwned>(
     let partial_decoder = if _async {
         bound_codec
             .clone()
-            .async_partial_decoder(
-                encoded_chunk.clone(),
-                shape,
-                &CodecOptions::default(),
-            )
+            .async_partial_decoder(encoded_chunk.clone(), shape, &CodecOptions::default())
             .await
             .unwrap()
     } else {
         bound_codec
             .clone()
-            .partial_decoder(
-                encoded_chunk.clone(),
-                shape,
-                &CodecOptions::default(),
-            )
+            .partial_decoder(encoded_chunk.clone(), shape, &CodecOptions::default())
             .unwrap()
     };
 
@@ -328,11 +320,7 @@ fn indexer_partial_encode_impl<T: ElementOwned>(
     let output = Arc::new(Mutex::new(Some(encoded_chunk.to_vec())));
     let partial_encoder = bound_codec
         .clone()
-        .partial_encoder(
-            output.clone(),
-            shape,
-            &CodecOptions::default(),
-        )
+        .partial_encoder(output.clone(), shape, &CodecOptions::default())
         .unwrap();
     assert_eq!(
         partial_encoder.supports_partial_encode(),

--- a/zarrs_codec/CHANGELOG.md
+++ b/zarrs_codec/CHANGELOG.md
@@ -8,17 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add context-bound `ArrayToArrayCodecTraitsBound` and `ArrayToBytesCodecTraitsBound` runtime APIs
-- Repurpose `ArrayCodecTraits` as the shared bound API with data type, fill value, and context-free concurrency queries
 - Add `CodecCreateError` for codec creation, reconfiguration, and binding failures
+- Add `UnboundArrayTo{Array,Bytes}CodecTraits`
 
 ### Changed
-- **Breaking**: Make array codec-specific reconfiguration fallible
-- **Breaking**: Add eager `DataType` and `FillValue` binding to array codecs and remove those context parameters from bound runtime operations
-- Modify `ArrayToArrayCodecTraits`:
-  - Add `ArrayTo{Array,Bytes}CodecTraits::partial_decode_granularity` with a default implementation
-  - **Breaking**: Remove `ArrayToArrayCodecTraits::decoded_shape`
-
+- **Breaking**: Refactor `ArrayTo{Array,Bytes}CodecTraits`
+  - These traits are now associated with codecs that are _bound_ to a data type and fill value and validated at array creation time
+    - **Breaking**: Add `data_type()` and `fill_value()` methods
+    - **Breaking**: Remove `data_type` and `fill_value` parameters from various methods
+  - Add `partial_decode_granularity()` with a default implementation (moved from `ArrayCodecTraits`)
+  - **Breaking**: Remove `ArrayToArrayCodecTraits::decoded_shape()`
 
 ### Removed
 - **Breaking**: Remove `ArrayCodecTraits::partial_decode_granularity`

--- a/zarrs_codec/CHANGELOG.md
+++ b/zarrs_codec/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add context-bound `ArrayToArrayCodecTraitsBound` and `ArrayToBytesCodecTraitsBound` runtime APIs
+- Repurpose `ArrayCodecTraits` as the shared bound API with data type, fill value, and context-free concurrency queries
 
 ### Changed
+- **Breaking**: Make array codec-specific reconfiguration fallible
+- **Breaking**: Add eager `DataType` and `FillValue` binding to array codecs and remove those context parameters from bound runtime operations
 - Modify `ArrayToArrayCodecTraits`:
   - Add `ArrayTo{Array,Bytes}CodecTraits::partial_decode_granularity` with a default implementation
   - **Breaking**: Remove `ArrayToArrayCodecTraits::decoded_shape`

--- a/zarrs_codec/CHANGELOG.md
+++ b/zarrs_codec/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add context-bound `ArrayToArrayCodecTraitsBound` and `ArrayToBytesCodecTraitsBound` runtime APIs
 - Repurpose `ArrayCodecTraits` as the shared bound API with data type, fill value, and context-free concurrency queries
+- Add `CodecCreateError` for codec creation, reconfiguration, and binding failures
 
 ### Changed
 - **Breaking**: Make array codec-specific reconfiguration fallible

--- a/zarrs_codec/Cargo.toml
+++ b/zarrs_codec/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.29"
 inventory.workspace = true
 itertools = "0.14.0"
 rayon = "1.10.0"
+serde_json = "1.0.71"
 thiserror.workspace = true
 unsafe_cell_slice = "0.2.0"
 zarrs_chunk_grid.workspace = true

--- a/zarrs_codec/src/codec_partial_default.rs
+++ b/zarrs_codec/src/codec_partial_default.rs
@@ -510,13 +510,7 @@ where
         if let Ok(shape) = output_shape {
             let shape = ChunkShape::from(shape);
             self.codec
-                .decode(
-                    chunk_bytes,
-                    &shape,
-                    self.decoded_representation.data_type(),
-                    self.decoded_representation.fill_value(),
-                    options,
-                )
+                .decode(chunk_bytes, &shape, options)
                 .map(ArrayBytes::into_owned)
         } else {
             Ok(match self.decoded_representation.data_type().size() {
@@ -562,13 +556,9 @@ where
             .input_output_handle
             .partial_decode(&array_subset_all, options)
             .await?;
-        let mut decoded_value = self.codec.decode(
-            encoded_value,
-            self.decoded_representation.shape(),
-            self.decoded_representation.data_type(),
-            self.decoded_representation.fill_value(),
-            options,
-        )?;
+        let mut decoded_value =
+            self.codec
+                .decode(encoded_value, self.decoded_representation.shape(), options)?;
 
         // Validate the bytes
         decoded_value.validate(
@@ -595,13 +585,9 @@ where
             Ok(())
         } else {
             // Store the updated chunk
-            let encoded_value = self.codec.encode(
-                decoded_value,
-                self.decoded_representation.shape(),
-                self.decoded_representation.data_type(),
-                self.decoded_representation.fill_value(),
-                options,
-            )?;
+            let encoded_value =
+                self.codec
+                    .encode(decoded_value, self.decoded_representation.shape(), options)?;
             self.input_output_handle
                 .partial_encode(&array_subset_all, &encoded_value, options)
                 .await
@@ -643,13 +629,9 @@ where
 
         if let Some(bytes_enc) = bytes_enc {
             // Decode the entire chunk
-            let bytes_dec = self.codec.decode(
-                bytes_enc,
-                self.decoded_representation.shape(),
-                self.decoded_representation.data_type(),
-                self.decoded_representation.fill_value(),
-                options,
-            )?;
+            let bytes_dec =
+                self.codec
+                    .decode(bytes_enc, self.decoded_representation.shape(), options)?;
 
             // Extract the subsets
             let chunk_shape = self.decoded_representation.shape_u64();
@@ -703,13 +685,8 @@ where
 
         // Handle a missing chunk
         let mut chunk_bytes = if let Some(chunk_bytes) = chunk_bytes {
-            self.codec.decode(
-                chunk_bytes,
-                self.decoded_representation.shape(),
-                self.decoded_representation.data_type(),
-                self.decoded_representation.fill_value(),
-                options,
-            )?
+            self.codec
+                .decode(chunk_bytes, self.decoded_representation.shape(), options)?
         } else {
             ArrayBytes::new_fill_value(
                 self.decoded_representation.data_type(),
@@ -744,13 +721,9 @@ where
             Ok(())
         } else {
             // Store the updated chunk
-            let chunk_bytes = self.codec.encode(
-                chunk_bytes,
-                self.decoded_representation.shape(),
-                self.decoded_representation.data_type(),
-                self.decoded_representation.fill_value(),
-                options,
-            )?;
+            let chunk_bytes =
+                self.codec
+                    .encode(chunk_bytes, self.decoded_representation.shape(), options)?;
             self.input_output_handle
                 .partial_encode(0, chunk_bytes, options)
                 .await

--- a/zarrs_codec/src/codec_partial_default.rs
+++ b/zarrs_codec/src/codec_partial_default.rs
@@ -156,13 +156,7 @@ where
         if let Ok(shape) = output_shape {
             let shape = ChunkShape::from(shape);
             self.codec
-                .decode(
-                    chunk_bytes,
-                    &shape,
-                    self.decoded_representation.data_type(),
-                    self.decoded_representation.fill_value(),
-                    options,
-                )
+                .decode(chunk_bytes, &shape, options)
                 .map(ArrayBytes::into_owned)
         } else {
             Ok(match self.decoded_representation.data_type().size() {
@@ -204,13 +198,9 @@ where
         let encoded_value = self
             .input_output_handle
             .partial_decode(&array_subset_all, options)?;
-        let mut decoded_value = self.codec.decode(
-            encoded_value,
-            self.decoded_representation.shape(),
-            self.decoded_representation.data_type(),
-            self.decoded_representation.fill_value(),
-            options,
-        )?;
+        let mut decoded_value =
+            self.codec
+                .decode(encoded_value, self.decoded_representation.shape(), options)?;
 
         // Validate the bytes
         decoded_value.validate(
@@ -237,13 +227,9 @@ where
             Ok(())
         } else {
             // Store the updated chunk
-            let encoded_value = self.codec.encode(
-                decoded_value,
-                self.decoded_representation.shape(),
-                self.decoded_representation.data_type(),
-                self.decoded_representation.fill_value(),
-                options,
-            )?;
+            let encoded_value =
+                self.codec
+                    .encode(decoded_value, self.decoded_representation.shape(), options)?;
             self.input_output_handle
                 .partial_encode(&array_subset_all, &encoded_value, options)
         }
@@ -281,13 +267,9 @@ where
 
         if let Some(bytes_enc) = bytes_enc {
             // Decode the entire chunk
-            let bytes_dec = self.codec.decode(
-                bytes_enc,
-                self.decoded_representation.shape(),
-                self.decoded_representation.data_type(),
-                self.decoded_representation.fill_value(),
-                options,
-            )?;
+            let bytes_dec =
+                self.codec
+                    .decode(bytes_enc, self.decoded_representation.shape(), options)?;
 
             // Extract the subsets
             let chunk_shape = self.decoded_representation.shape_u64();
@@ -338,13 +320,8 @@ where
 
         // Handle a missing chunk
         let mut chunk_bytes = if let Some(chunk_bytes) = chunk_bytes {
-            self.codec.decode(
-                chunk_bytes,
-                self.decoded_representation.shape(),
-                self.decoded_representation.data_type(),
-                self.decoded_representation.fill_value(),
-                options,
-            )?
+            self.codec
+                .decode(chunk_bytes, self.decoded_representation.shape(), options)?
         } else {
             ArrayBytes::new_fill_value(
                 self.decoded_representation.data_type(),
@@ -379,13 +356,9 @@ where
             Ok(())
         } else {
             // Store the updated chunk
-            let chunk_bytes = self.codec.encode(
-                chunk_bytes,
-                self.decoded_representation.shape(),
-                self.decoded_representation.data_type(),
-                self.decoded_representation.fill_value(),
-                options,
-            )?;
+            let chunk_bytes =
+                self.codec
+                    .encode(chunk_bytes, self.decoded_representation.shape(), options)?;
             self.input_output_handle
                 .partial_encode(0, chunk_bytes, options)
         }

--- a/zarrs_codec/src/lib.rs
+++ b/zarrs_codec/src/lib.rs
@@ -421,6 +421,9 @@ pub trait CodecTraits: ExtensionName + MaybeSend + MaybeSync {
 
 /// Traits shared by context-bound array codecs.
 pub trait ArrayCodecTraits: MaybeSend + MaybeSync {
+    /// Returns this codec as [`Any`].
+    fn as_any(&self) -> &dyn Any;
+
     /// Return the decoded data type bound to this codec.
     fn data_type(&self) -> &DataType;
 
@@ -1176,7 +1179,7 @@ pub trait UnboundArrayToArrayCodecTraits: CodecTraits + core::fmt::Debug {
     /// # Errors
     /// Returns a [`CodecError`] if the `data_type` or `fill_value` is not supported by this codec.
     fn with_context(
-        self: Arc<Self>,
+        &self,
         data_type: DataType,
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError>;
@@ -1202,7 +1205,9 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     ///
     /// # Errors
     /// Returns a [`CodecError`] if the `decoded_shape` is not supported by this codec.
-    fn encoded_shape(&self, decoded_shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError>;
+    fn encoded_shape(&self, decoded_shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError> {
+        Ok(decoded_shape.to_vec())
+    }
 
     /// Map a partial decode granularity from the encoded representation to the decoded representation.
     ///
@@ -1212,7 +1217,14 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         &self,
         decoded_shape: &[NonZeroU64],
         encoded_granularity: &[NonZeroU64],
-    ) -> Result<ChunkShape, CodecError>;
+    ) -> Result<ChunkShape, CodecError> {
+        let encoded_shape = self.encoded_shape(decoded_shape)?;
+        if encoded_shape == decoded_shape {
+            Ok(encoded_granularity.to_vec())
+        } else {
+            Ok(decoded_shape.to_vec())
+        }
+    }
 
     /// Encode a chunk.
     ///
@@ -1245,7 +1257,16 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError>;
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
+        _ = options;
+        Ok(Arc::new(ArrayToArrayCodecPartialDefault::new(
+            input_handle,
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+            self.into_dyn(),
+        )))
+    }
 
     /// Initialise a partial encoder.
     ///
@@ -1256,7 +1277,16 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError>;
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        _ = options;
+        Ok(Arc::new(ArrayToArrayCodecPartialDefault::new(
+            input_output_handle,
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+            self.into_dyn(),
+        )))
+    }
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial decoder.
@@ -1268,7 +1298,16 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError>;
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
+        _ = options;
+        Ok(Arc::new(ArrayToArrayCodecPartialDefault::new(
+            input_handle,
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+            self.into_dyn(),
+        )))
+    }
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial encoder.
@@ -1280,7 +1319,16 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         input_output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError>;
+    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
+        _ = options;
+        Ok(Arc::new(ArrayToArrayCodecPartialDefault::new(
+            input_output_handle,
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+            self.into_dyn(),
+        )))
+    }
 }
 
 /// Traits for array to bytes codecs.
@@ -1313,7 +1361,7 @@ pub trait UnboundArrayToBytesCodecTraits: CodecTraits + core::fmt::Debug {
     /// # Errors
     /// Returns a [`CodecError`] if the `data_type` or `fill_value` is not supported by this codec.
     fn with_context(
-        self: Arc<Self>,
+        &self,
         data_type: DataType,
         fill_value: FillValue,
     ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError>;
@@ -1349,7 +1397,9 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     fn partial_decode_granularity(
         &self,
         decoded_shape: &[NonZeroU64],
-    ) -> Result<ChunkShape, CodecError>;
+    ) -> Result<ChunkShape, CodecError> {
+        Ok(decoded_shape.to_vec())
+    }
 
     /// Encode a chunk.
     ///
@@ -1410,7 +1460,10 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         shape: &[NonZeroU64],
         output_target: ArrayBytesDecodeIntoTarget<'_>,
         options: &CodecOptions,
-    ) -> Result<(), CodecError>;
+    ) -> Result<(), CodecError> {
+        let bytes = self.decode(bytes, shape, options)?;
+        decode_into_array_bytes_target(&bytes, output_target)
+    }
 
     /// Initialise a partial decoder.
     /// # Errors
@@ -1420,7 +1473,16 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError>;
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
+        _ = options;
+        Ok(Arc::new(ArrayToBytesCodecPartialDefault::new(
+            input_handle,
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+            self.into_dyn(),
+        )))
+    }
 
     /// Initialise a partial encoder.
     ///
@@ -1431,7 +1493,16 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError>;
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
+        _ = options;
+        Ok(Arc::new(ArrayToBytesCodecPartialDefault::new(
+            input_output_handle,
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+            self.into_dyn(),
+        )))
+    }
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial decoder.
@@ -1443,7 +1514,16 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError>;
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
+        _ = options;
+        Ok(Arc::new(ArrayToBytesCodecPartialDefault::new(
+            input_handle,
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+            self.into_dyn(),
+        )))
+    }
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial encoder.
@@ -1455,7 +1535,16 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError>;
+    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
+        _ = options;
+        Ok(Arc::new(ArrayToBytesCodecPartialDefault::new(
+            input_output_handle,
+            shape.to_vec(),
+            self.data_type().clone(),
+            self.fill_value().clone(),
+            self.into_dyn(),
+        )))
+    }
 }
 
 /// Traits for bytes to bytes codecs.

--- a/zarrs_codec/src/lib.rs
+++ b/zarrs_codec/src/lib.rs
@@ -390,9 +390,6 @@ pub trait CodecTraitsV3 {
 
 /// Codec traits.
 pub trait CodecTraits: ExtensionName + MaybeSend + MaybeSync {
-    /// Returns this codec as [`Any`].
-    fn as_any(&self) -> &dyn Any;
-
     /// Create the codec configuration.
     ///
     /// A hidden codec (e.g. a cache) will return [`None`], since it will not have any associated metadata.

--- a/zarrs_codec/src/lib.rs
+++ b/zarrs_codec/src/lib.rs
@@ -138,7 +138,7 @@ pub struct PartialEncoderCapability {
 
 /// A Zarr V3 codec plugin.
 #[derive(derive_more::Deref)]
-pub struct CodecPluginV3(Plugin<Codec, MetadataV3>);
+pub struct CodecPluginV3(Plugin<Codec, MetadataV3, CodecCreateError>);
 inventory::collect!(CodecPluginV3);
 
 impl CodecPluginV3 {
@@ -150,7 +150,7 @@ impl CodecPluginV3 {
 
 /// A Zarr V2 codec plugin.
 #[derive(derive_more::Deref)]
-pub struct CodecPluginV2(Plugin<Codec, MetadataV2>);
+pub struct CodecPluginV2(Plugin<Codec, MetadataV2, CodecCreateError>);
 inventory::collect!(CodecPluginV2);
 
 impl CodecPluginV2 {
@@ -161,10 +161,10 @@ impl CodecPluginV2 {
 }
 
 /// A runtime V3 codec plugin for dynamic registration.
-pub type CodecRuntimePluginV3 = RuntimePlugin<Codec, MetadataV3>;
+pub type CodecRuntimePluginV3 = RuntimePlugin<Codec, MetadataV3, CodecCreateError>;
 
 /// A runtime V2 codec plugin for dynamic registration.
-pub type CodecRuntimePluginV2 = RuntimePlugin<Codec, MetadataV2>;
+pub type CodecRuntimePluginV2 = RuntimePlugin<Codec, MetadataV2, CodecCreateError>;
 
 /// Global runtime registry for V3 codec plugins.
 pub static CODEC_RUNTIME_REGISTRY_V3: LazyLock<RuntimeRegistry<CodecRuntimePluginV3>> =
@@ -256,7 +256,7 @@ impl Codec {
     /// Returns [`PluginCreateError`] if the metadata is invalid or not associated with a registered codec plugin.
     pub fn from_metadata<'a>(
         metadata: impl Into<CodecMetadata<'a>>,
-    ) -> Result<Self, PluginCreateError> {
+    ) -> Result<Self, CodecCreateError> {
         match metadata.into() {
             CodecMetadata::V2(metadata) => Self::from_metadata_v2(metadata),
             CodecMetadata::V3(metadata) => Self::from_metadata_v3(metadata),
@@ -266,8 +266,8 @@ impl Codec {
     /// Create a codec from V3 metadata.
     ///
     /// # Errors
-    /// Returns [`PluginCreateError`] if the metadata is invalid or not associated with a registered codec plugin.
-    fn from_metadata_v3(metadata: &MetadataV3) -> Result<Self, PluginCreateError> {
+    /// Returns [`CodecCreateError`] if the metadata is invalid or not associated with a registered codec plugin.
+    fn from_metadata_v3(metadata: &MetadataV3) -> Result<Self, CodecCreateError> {
         let name = metadata.name();
 
         // Check runtime registry first (higher priority)
@@ -291,14 +291,18 @@ impl Codec {
                 return plugin.create(metadata);
             }
         }
-        Err(PluginUnsupportedError::new(metadata.name().to_string(), "codec".to_string()).into())
+        Err(PluginCreateError::Unsupported(PluginUnsupportedError::new(
+            metadata.name().to_string(),
+            "codec".to_string(),
+        ))
+        .into())
     }
 
     /// Create a codec from V2 metadata.
     ///
     /// # Errors
-    /// Returns [`PluginCreateError`] if the metadata is invalid or not associated with a registered codec plugin.
-    fn from_metadata_v2(metadata: &MetadataV2) -> Result<Self, PluginCreateError> {
+    /// Returns [`CodecCreateError`] if the metadata is invalid or not associated with a registered codec plugin.
+    fn from_metadata_v2(metadata: &MetadataV2) -> Result<Self, CodecCreateError> {
         let name = metadata.id();
 
         // Check runtime registry first (higher priority)
@@ -322,7 +326,11 @@ impl Codec {
                 return plugin.create(metadata);
             }
         }
-        Err(PluginUnsupportedError::new(metadata.id().to_string(), "codec".to_string()).into())
+        Err(PluginCreateError::Unsupported(PluginUnsupportedError::new(
+            metadata.id().to_string(),
+            "codec".to_string(),
+        ))
+        .into())
     }
 
     /// Create the codec configuration.
@@ -369,8 +377,8 @@ pub trait CodecTraitsV2 {
     /// Create a codec from Zarr V2 metadata.
     ///
     /// # Errors
-    /// Returns [`PluginCreateError`] if the plugin cannot be created.
-    fn create(metadata: &MetadataV2) -> Result<Codec, PluginCreateError>
+    /// Returns [`CodecCreateError`] if the codec cannot be created.
+    fn create(metadata: &MetadataV2) -> Result<Codec, CodecCreateError>
     where
         Self: Sized;
 }
@@ -382,8 +390,8 @@ pub trait CodecTraitsV3 {
     /// Create a codec from Zarr V3 metadata.
     ///
     /// # Errors
-    /// Returns [`PluginCreateError`] if the plugin cannot be created.
-    fn create(metadata: &MetadataV3) -> Result<Codec, PluginCreateError>
+    /// Returns [`CodecCreateError`] if the codec cannot be created.
+    fn create(metadata: &MetadataV3) -> Result<Codec, CodecCreateError>
     where
         Self: Sized;
 }
@@ -1909,6 +1917,12 @@ impl From<&str> for CodecCreateError {
 impl From<String> for CodecCreateError {
     fn from(error: String) -> Self {
         Self::Other(error)
+    }
+}
+
+impl From<Arc<serde_json::Error>> for CodecCreateError {
+    fn from(error: Arc<serde_json::Error>) -> Self {
+        Self::PluginCreateError(PluginCreateError::from(error))
     }
 }
 

--- a/zarrs_codec/src/lib.rs
+++ b/zarrs_codec/src/lib.rs
@@ -233,9 +233,9 @@ pub fn unregister_codec_v2(handle: &CodecRuntimeRegistryHandleV2) -> bool {
 #[derive(Debug)]
 pub enum Codec {
     /// An array to array codec.
-    ArrayToArray(Arc<dyn ArrayToArrayCodecTraits>),
+    ArrayToArray(Arc<dyn UnboundArrayToArrayCodecTraits>),
     /// An array to bytes codec.
-    ArrayToBytes(Arc<dyn ArrayToBytesCodecTraits>),
+    ArrayToBytes(Arc<dyn UnboundArrayToBytesCodecTraits>),
     /// A bytes to bytes codec.
     BytesToBytes(Arc<dyn BytesToBytesCodecTraits>),
 }
@@ -419,16 +419,21 @@ pub trait CodecTraits: ExtensionName + MaybeSend + MaybeSync {
     fn partial_encoder_capability(&self) -> PartialEncoderCapability;
 }
 
-/// Traits for both array to array and array to bytes codecs.
-pub trait ArrayCodecTraits: CodecTraits {
-    /// Return the recommended concurrency for the requested decoded representation.
+/// Traits shared by context-bound array codecs.
+pub trait ArrayCodecTraits: MaybeSend + MaybeSync {
+    /// Return the decoded data type bound to this codec.
+    fn data_type(&self) -> &DataType;
+
+    /// Return the decoded fill value bound to this codec.
+    fn fill_value(&self) -> &FillValue;
+
+    /// Return the recommended concurrency for the requested decoded shape.
     ///
     /// # Errors
-    /// Returns [`CodecError`] if the decoded representation is not valid for the codec.
+    /// Returns [`CodecError`] if the decoded `shape` is not valid for the codec.
     fn recommended_concurrency(
         &self,
         shape: &[NonZeroU64],
-        data_type: &DataType,
     ) -> Result<RecommendedConcurrency, CodecError>;
 }
 
@@ -1145,103 +1150,69 @@ impl AsyncBytesPartialEncoderTraits for StoragePartialEncoder<AsyncReadableWrita
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
+pub trait UnboundArrayToArrayCodecTraits: CodecTraits + core::fmt::Debug {
     /// Return a dynamic version of the codec.
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits>;
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToArrayCodecTraits>;
 
     /// Return a version of this codec reconfigured with the provided codec-specific options.
     ///
     /// The default implementation returns the codec unchanged.
     /// Override this to read your codec's options type from [`CodecSpecificOptions`].
+    ///
+    /// # Errors
+    /// Returns a [`CodecError`] if the codec cannot be reconfigured.
     #[expect(unused_variables)]
     fn with_codec_specific_options(
         self: Arc<Self>,
         opts: &CodecSpecificOptions,
-    ) -> Arc<dyn ArrayToArrayCodecTraits> {
-        self.into_dyn()
+    ) -> Result<Arc<dyn UnboundArrayToArrayCodecTraits>, CodecError> {
+        Ok(self.into_dyn())
     }
 
-    /// Returns the encoded data type for a given decoded data type.
+    /// Bind this codec to a decoded data type and fill value.
+    ///
+    /// Binding eagerly validates and derives the encoded context.
     ///
     /// # Errors
-    /// Returns a [`CodecError`] if the data type is not supported by this codec.
-    fn encoded_data_type(&self, decoded_data_type: &DataType) -> Result<DataType, CodecError>;
+    /// Returns a [`CodecError`] if the `data_type` or `fill_value` is not supported by this codec.
+    fn with_context(
+        self: Arc<Self>,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError>;
+}
 
-    /// Returns the encoded fill value for a given decoded fill value
-    ///
-    /// The encoded fill value is computed by applying [`ArrayToArrayCodecTraits::encode`] to the `decoded_fill_value`.
-    /// This may need to be implemented manually if a codec does not support encoding a single element or the encoding is otherwise dependent on the chunk shape.
-    ///
-    /// # Errors
-    /// Returns a [`CodecError`] if the data type is not supported by this codec.
-    fn encoded_fill_value(
-        &self,
-        decoded_data_type: &DataType,
-        decoded_fill_value: &FillValue,
-    ) -> Result<FillValue, CodecError> {
-        let element_shape = ChunkShape::from(vec![unsafe { NonZeroU64::new_unchecked(1) }]);
+/// Runtime traits for an array-to-array codec bound to a data type and fill value.
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
+    /// Return a dynamic version of the bound codec.
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits>;
 
-        // Calculate the changed fill value
-        let fill_value = self
-            .encode(
-                ArrayBytes::new_fill_value(decoded_data_type, 1, decoded_fill_value)?,
-                &element_shape,
-                decoded_data_type,
-                decoded_fill_value,
-                &CodecOptions::default(),
-            )?
-            .into_fixed()?
-            .into_owned();
-        Ok(FillValue::new(fill_value))
-    }
+    /// Return the encoded data type.
+    fn encoded_data_type(&self) -> &DataType;
+
+    /// Return the encoded fill value.
+    fn encoded_fill_value(&self) -> &FillValue;
 
     /// Returns the shape of the encoded chunk for a given decoded chunk shape.
     ///
-    /// The default implementation returns the shape unchanged.
-    ///
     /// # Errors
-    /// Returns a [`CodecError`] if the shape is not supported by this codec.
-    fn encoded_shape(&self, decoded_shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError> {
-        Ok(decoded_shape.to_vec())
-    }
+    /// Returns a [`CodecError`] if the `decoded_shape` is not supported by this codec.
+    fn encoded_shape(&self, decoded_shape: &[NonZeroU64]) -> Result<ChunkShape, CodecError>;
 
     /// Map a partial decode granularity from the encoded representation to the decoded representation.
     ///
-    /// The default implementation is for shape and order-preserving codecs, where the granularity is unchanged.
-    /// Codecs may return `decoded_shape` if they do not support granular access or otherwise calculate a different granularity for partial decoding.
-    ///
     /// # Errors
     /// Returns a [`CodecError`] if the decoded shape or encoded granularity is not supported by this codec.
-    #[expect(unused_variables)]
     fn partial_decode_granularity(
         &self,
         decoded_shape: &[NonZeroU64],
         encoded_granularity: &[NonZeroU64],
-    ) -> Result<ChunkShape, CodecError> {
-        Ok(encoded_granularity.to_vec())
-    }
-
-    /// Returns the encoded chunk representation given the decoded chunk representation.
-    ///
-    /// The default implementation returns the chunk representation from the outputs of
-    /// - [`encoded_data_type`](ArrayToArrayCodecTraits::encoded_data_type),
-    /// - [`encoded_fill_value`](ArrayToArrayCodecTraits::encoded_fill_value), and
-    /// - [`encoded_shape`](ArrayToArrayCodecTraits::encoded_shape).
-    ///
-    /// # Errors
-    /// Returns a [`CodecError`] if the decoded chunk representation is not supported by this codec.
-    fn encoded_representation(
-        &self,
-        shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
-    ) -> Result<(ChunkShape, DataType, FillValue), CodecError> {
-        Ok((
-            self.encoded_shape(shape)?,
-            self.encoded_data_type(data_type)?,
-            self.encoded_fill_value(data_type, fill_value)?,
-        ))
-    }
+    ) -> Result<ChunkShape, CodecError>;
 
     /// Encode a chunk.
     ///
@@ -1251,8 +1222,6 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError>;
 
@@ -1264,108 +1233,54 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError>;
 
     /// Initialise a partial decoder.
     ///
-    /// The default implementation decodes the entire chunk.
-    ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    #[allow(unused_variables)]
     fn partial_decoder(
         self: Arc<Self>,
         input_handle: Arc<dyn ArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-        Ok(Arc::new(ArrayToArrayCodecPartialDefault::new(
-            input_handle,
-            shape.to_vec(),
-            data_type.clone(),
-            fill_value.clone(),
-            self.into_dyn(),
-        )))
-    }
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError>;
 
     /// Initialise a partial encoder.
     ///
-    /// The default implementation reencodes the entire chunk.
-    ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    #[allow(unused_variables)]
     fn partial_encoder(
         self: Arc<Self>,
         input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
-        Ok(Arc::new(ArrayToArrayCodecPartialDefault::new(
-            input_output_handle,
-            shape.to_vec(),
-            data_type.clone(),
-            fill_value.clone(),
-            self.into_dyn(),
-        )))
-    }
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError>;
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial decoder.
     ///
-    /// The default implementation decodes the entire chunk.
-    ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    #[allow(unused_variables)]
     async fn async_partial_decoder(
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
-        Ok(Arc::new(ArrayToArrayCodecPartialDefault::new(
-            input_handle,
-            shape.to_vec(),
-            data_type.clone(),
-            fill_value.clone(),
-            self.into_dyn(),
-        )))
-    }
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError>;
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial encoder.
     ///
-    /// The default implementation reencodes the entire chunk.
-    ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    #[allow(unused_variables)]
     async fn async_partial_encoder(
         self: Arc<Self>,
         input_output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
-        Ok(Arc::new(ArrayToArrayCodecPartialDefault::new(
-            input_output_handle,
-            shape.to_vec(),
-            data_type.clone(),
-            fill_value.clone(),
-            self.into_dyn(),
-        )))
-    }
+    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError>;
 }
 
 /// Traits for array to bytes codecs.
@@ -1374,21 +1289,45 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     async_trait::async_trait
 )]
 #[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
-pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
+pub trait UnboundArrayToBytesCodecTraits: CodecTraits + core::fmt::Debug {
     /// Return a dynamic version of the codec.
-    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits>;
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToBytesCodecTraits>;
 
     /// Return a version of this codec reconfigured with the provided codec-specific options.
     ///
     /// The default implementation returns the codec unchanged.
     /// Override this to read your codec's options type from [`CodecSpecificOptions`].
+    ///
+    /// # Errors
+    /// Returns a [`CodecError`] if the codec cannot be reconfigured.
     #[expect(unused_variables)]
     fn with_codec_specific_options(
         self: Arc<Self>,
         opts: &CodecSpecificOptions,
-    ) -> Arc<dyn ArrayToBytesCodecTraits> {
-        self.into_dyn()
+    ) -> Result<Arc<dyn UnboundArrayToBytesCodecTraits>, CodecError> {
+        Ok(self.into_dyn())
     }
+
+    /// Bind this codec to a decoded data type and fill value.
+    ///
+    /// # Errors
+    /// Returns a [`CodecError`] if the `data_type` or `fill_value` is not supported by this codec.
+    fn with_context(
+        self: Arc<Self>,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError>;
+}
+
+/// Runtime traits for an array-to-bytes codec bound to a data type and fill value.
+#[cfg_attr(
+    all(feature = "async", not(target_arch = "wasm32")),
+    async_trait::async_trait
+)]
+#[cfg_attr(all(feature = "async", target_arch = "wasm32"), async_trait::async_trait(?Send))]
+pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
+    /// Return a dynamic version of the bound codec.
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToBytesCodecTraits>;
 
     /// Returns the size of the encoded representation given a size of the decoded representation.
     ///
@@ -1397,8 +1336,6 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     fn encoded_representation(
         &self,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
     ) -> Result<BytesRepresentation, CodecError>;
 
     /// Return the partial decode granularity.
@@ -1412,9 +1349,7 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     fn partial_decode_granularity(
         &self,
         decoded_shape: &[NonZeroU64],
-    ) -> Result<ChunkShape, CodecError> {
-        Ok(decoded_shape.to_vec())
-    }
+    ) -> Result<ChunkShape, CodecError>;
 
     /// Encode a chunk.
     ///
@@ -1424,8 +1359,6 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         &self,
         bytes: ArrayBytes<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytesRaw<'a>, CodecError>;
 
@@ -1437,27 +1370,22 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         &self,
         bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError>;
 
-    /// Compact a chunk.
+    /// Compact a chunk to remove any extraneous data.
     ///
-    /// Takes an encoded representation and compacts it to remove any extraneous data.
     /// The default implementation returns the input `bytes` unchanged.
     ///
     /// Returns `Ok(None)` if no compaction was performed.
     ///
     /// # Errors
     /// Returns [`CodecError`] if a codec fails or `bytes` is incompatible with the decoded representation.
-    #[expect(unused_variables)]
+    #[allow(unused_variables)]
     fn compact<'a>(
         &self,
         bytes: ArrayBytesRaw<'a>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
     ) -> Result<Option<ArrayBytesRaw<'a>>, CodecError> {
         Ok(None)
@@ -1480,118 +1408,54 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
         &self,
         bytes: ArrayBytesRaw<'_>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
         options: &CodecOptions,
-    ) -> Result<(), CodecError> {
-        let num_elements = output_target.num_elements();
-        let shape_num_elements: u64 = shape.iter().map(|d| d.get()).product();
-        if shape_num_elements != num_elements {
-            return Err(InvalidNumberOfElementsError::new(num_elements, shape_num_elements).into());
-        }
-
-        let decoded_value = self.decode(bytes, shape, data_type, fill_value, options)?;
-        decode_into_array_bytes_target(&decoded_value, output_target)
-    }
+    ) -> Result<(), CodecError>;
 
     /// Initialise a partial decoder.
-    ///
-    /// The default implementation decodes the entire chunk.
-    ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    #[allow(unused_variables)]
     fn partial_decoder(
         self: Arc<Self>,
         input_handle: Arc<dyn BytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError> {
-        Ok(Arc::new(ArrayToBytesCodecPartialDefault::new(
-            input_handle,
-            shape.to_vec(),
-            data_type.clone(),
-            fill_value.clone(),
-            self.into_dyn(),
-        )))
-    }
+    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, CodecError>;
 
     /// Initialise a partial encoder.
     ///
-    /// The default implementation reencodes the entire chunk.
-    ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    #[allow(unused_variables)]
     fn partial_encoder(
         self: Arc<Self>,
         input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
-        Ok(Arc::new(ArrayToBytesCodecPartialDefault::new(
-            input_output_handle,
-            shape.to_vec(),
-            data_type.clone(),
-            fill_value.clone(),
-            self.into_dyn(),
-        )))
-    }
+    ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError>;
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial decoder.
     ///
-    /// The default implementation decodes the entire chunk.
-    ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    #[allow(unused_variables)]
     async fn async_partial_decoder(
         self: Arc<Self>,
         input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError> {
-        Ok(Arc::new(ArrayToBytesCodecPartialDefault::new(
-            input_handle,
-            shape.to_vec(),
-            data_type.clone(),
-            fill_value.clone(),
-            self.into_dyn(),
-        )))
-    }
+    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, CodecError>;
 
     #[cfg(feature = "async")]
     /// Initialise an asynchronous partial encoder.
     ///
-    /// The default implementation reencodes the entire chunk.
-    ///
     /// # Errors
     /// Returns a [`CodecError`] if initialisation fails.
-    #[allow(unused_variables)]
     async fn async_partial_encoder(
         self: Arc<Self>,
         input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
         shape: &[NonZeroU64],
-        data_type: &DataType,
-        fill_value: &FillValue,
         options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
-        Ok(Arc::new(ArrayToBytesCodecPartialDefault::new(
-            input_output_handle,
-            shape.to_vec(),
-            data_type.clone(),
-            fill_value.clone(),
-            self.into_dyn(),
-        )))
-    }
+    ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError>;
 }
 
 /// Traits for bytes to bytes codecs.

--- a/zarrs_codec/src/lib.rs
+++ b/zarrs_codec/src/lib.rs
@@ -1889,15 +1889,22 @@ pub enum CodecCreateError {
     /// Unsupported data type.
     #[error("{}", format_unsupported_data_type(.0, .1))]
     UnsupportedDataType(DataType, String),
-    /// Data type does not support a codec.
-    #[error(transparent)]
-    UnsupportedDataTypeCodec(#[from] zarrs_data_type::DataTypeCodecError),
     /// An incompatible fill value error.
     #[error(transparent)]
     DataTypeFillValueError(#[from] DataTypeFillValueError),
     /// Other.
     #[error("{_0}")]
     Other(String),
+}
+
+impl From<zarrs_data_type::DataTypeCodecError> for CodecCreateError {
+    fn from(error: zarrs_data_type::DataTypeCodecError) -> Self {
+        let zarrs_data_type::DataTypeCodecError::UnsupportedDataType {
+            data_type,
+            codec_name,
+        } = error;
+        Self::UnsupportedDataType(data_type, codec_name.to_string())
+    }
 }
 
 impl CodecCreateError {
@@ -1954,9 +1961,6 @@ pub enum CodecError {
     /// Unsupported data type.
     #[error("{}", format_unsupported_data_type(.0, .1))]
     UnsupportedDataType(DataType, String),
-    /// Data type does not support a codec.
-    #[error(transparent)]
-    UnsupportedDataTypeCodec(#[from] zarrs_data_type::DataTypeCodecError),
     /// Offsets are not [`None`] with a fixed length data type.
     #[error(
         "Offsets are invalid or are not compatible with the data type (e.g. fixed-sized data types)"
@@ -1998,6 +2002,19 @@ pub enum CodecError {
     /// An array region error.
     #[error(transparent)]
     ArraySubsetError(#[from] ArraySubsetError),
+    /// Codec create error.
+    #[error(transparent)]
+    CodecCreateError(#[from] CodecCreateError),
+}
+
+impl From<zarrs_data_type::DataTypeCodecError> for CodecError {
+    fn from(error: zarrs_data_type::DataTypeCodecError) -> Self {
+        let zarrs_data_type::DataTypeCodecError::UnsupportedDataType {
+            data_type,
+            codec_name,
+        } = error;
+        Self::UnsupportedDataType(data_type, codec_name.to_string())
+    }
 }
 
 fn format_unsupported_data_type(data_type: &DataType, codec_name: &String) -> String {

--- a/zarrs_codec/src/lib.rs
+++ b/zarrs_codec/src/lib.rs
@@ -1160,12 +1160,12 @@ pub trait UnboundArrayToArrayCodecTraits: CodecTraits + core::fmt::Debug {
     /// Override this to read your codec's options type from [`CodecSpecificOptions`].
     ///
     /// # Errors
-    /// Returns a [`CodecError`] if the codec cannot be reconfigured.
+    /// Returns a [`CodecCreateError`] if the codec cannot be reconfigured.
     #[expect(unused_variables)]
     fn with_codec_specific_options(
         self: Arc<Self>,
         opts: &CodecSpecificOptions,
-    ) -> Result<Arc<dyn UnboundArrayToArrayCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn UnboundArrayToArrayCodecTraits>, CodecCreateError> {
         Ok(self.into_dyn())
     }
 
@@ -1174,12 +1174,12 @@ pub trait UnboundArrayToArrayCodecTraits: CodecTraits + core::fmt::Debug {
     /// Binding eagerly validates and derives the encoded context.
     ///
     /// # Errors
-    /// Returns a [`CodecError`] if the `data_type` or `fill_value` is not supported by this codec.
+    /// Returns a [`CodecCreateError`] if the `data_type` or `fill_value` is not supported by this codec.
     fn with_context(
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecError>;
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecCreateError>;
 }
 
 /// Runtime traits for an array-to-array codec bound to a data type and fill value.
@@ -1344,24 +1344,24 @@ pub trait UnboundArrayToBytesCodecTraits: CodecTraits + core::fmt::Debug {
     /// Override this to read your codec's options type from [`CodecSpecificOptions`].
     ///
     /// # Errors
-    /// Returns a [`CodecError`] if the codec cannot be reconfigured.
+    /// Returns a [`CodecCreateError`] if the codec cannot be reconfigured.
     #[expect(unused_variables)]
     fn with_codec_specific_options(
         self: Arc<Self>,
         opts: &CodecSpecificOptions,
-    ) -> Result<Arc<dyn UnboundArrayToBytesCodecTraits>, CodecError> {
+    ) -> Result<Arc<dyn UnboundArrayToBytesCodecTraits>, CodecCreateError> {
         Ok(self.into_dyn())
     }
 
     /// Bind this codec to a decoded data type and fill value.
     ///
     /// # Errors
-    /// Returns a [`CodecError`] if the `data_type` or `fill_value` is not supported by this codec.
+    /// Returns a [`CodecCreateError`] if the `data_type` or `fill_value` is not supported by this codec.
     fn with_context(
         &self,
         data_type: DataType,
         fill_value: FillValue,
-    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecError>;
+    ) -> Result<Arc<dyn ArrayToBytesCodecTraits>, CodecCreateError>;
 }
 
 /// Runtime traits for an array-to-bytes codec bound to a data type and fill value.
@@ -1562,8 +1562,8 @@ pub trait BytesToBytesCodecTraits: CodecTraits + core::fmt::Debug {
     fn with_codec_specific_options(
         self: Arc<Self>,
         opts: &CodecSpecificOptions,
-    ) -> Arc<dyn BytesToBytesCodecTraits> {
-        self.into_dyn()
+    ) -> Result<Arc<dyn BytesToBytesCodecTraits>, CodecCreateError> {
+        Ok(self.into_dyn())
     }
 
     /// Return the maximum internal concurrency supported for the requested decoded representation.
@@ -1869,7 +1869,50 @@ impl SubsetOutOfBoundsError {
     }
 }
 
-/// A codec error.
+/// A codec creation error.
+///
+/// This is used for failures while creating codecs from metadata, reconfiguring codecs, or binding
+/// unbound array codecs to a decoded data type and fill value.
+#[derive(Clone, Debug, Error)]
+pub enum CodecCreateError {
+    /// A plugin creation error.
+    #[error(transparent)]
+    PluginCreateError(#[from] PluginCreateError),
+    /// Unsupported data type.
+    #[error("{}", format_unsupported_data_type(.0, .1))]
+    UnsupportedDataType(DataType, String),
+    /// Data type does not support a codec.
+    #[error(transparent)]
+    UnsupportedDataTypeCodec(#[from] zarrs_data_type::DataTypeCodecError),
+    /// An incompatible fill value error.
+    #[error(transparent)]
+    DataTypeFillValueError(#[from] DataTypeFillValueError),
+    /// Other.
+    #[error("{_0}")]
+    Other(String),
+}
+
+impl CodecCreateError {
+    /// Create a new [`CodecCreateError::Other`] from a displayable error or message.
+    #[must_use]
+    pub fn other(error: impl ToString) -> Self {
+        Self::Other(error.to_string())
+    }
+}
+
+impl From<&str> for CodecCreateError {
+    fn from(error: &str) -> Self {
+        Self::Other(error.to_string())
+    }
+}
+
+impl From<String> for CodecCreateError {
+    fn from(error: String) -> Self {
+        Self::Other(error)
+    }
+}
+
+/// A codec runtime error.
 #[non_exhaustive]
 #[derive(Clone, Debug, Error)]
 pub enum CodecError {
@@ -1894,7 +1937,7 @@ pub enum CodecError {
     /// A store error.
     #[error(transparent)]
     StorageError(#[from] StorageError),
-    /// Unsupported data type
+    /// Unsupported data type.
     #[error("{}", format_unsupported_data_type(.0, .1))]
     UnsupportedDataType(DataType, String),
     /// Data type does not support a codec.

--- a/zarrs_plugin/CHANGELOG.md
+++ b/zarrs_plugin/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Add `TError` generic to `[Runtime]Plugin`
+- Add `TError` generic to `[Runtime]Plugin[2]`
 
 ## [0.4.1] - 2026-02-02
 

--- a/zarrs_plugin/src/plugin.rs
+++ b/zarrs_plugin/src/plugin.rs
@@ -1,26 +1,26 @@
 use crate::PluginCreateError;
 
 /// A plugin.
-pub struct Plugin<TPlugin, TInput> {
+pub struct Plugin<TPlugin, TInput, TError = PluginCreateError> {
     /// Tests if the name is a match for this plugin.
     match_name_fn: fn(name: &str) -> bool,
     /// Create an implementation of this plugin from metadata.
-    create_fn: fn(input: &TInput) -> Result<TPlugin, PluginCreateError>,
+    create_fn: fn(input: &TInput) -> Result<TPlugin, TError>,
 }
 
 /// A plugin (two parameters).
-pub struct Plugin2<TPlugin, TInput1, TInput2> {
+pub struct Plugin2<TPlugin, TInput1, TInput2, TError = PluginCreateError> {
     /// Tests if the name is a match for this plugin.
     match_name_fn: fn(name: &str) -> bool,
     /// Create an implementation of this plugin from metadata.
-    create_fn: fn(input1: &TInput1, input2: &TInput2) -> Result<TPlugin, PluginCreateError>,
+    create_fn: fn(input1: &TInput1, input2: &TInput2) -> Result<TPlugin, TError>,
 }
 
-impl<TPlugin, TInput> Plugin<TPlugin, TInput> {
+impl<TPlugin, TInput, TError> Plugin<TPlugin, TInput, TError> {
     /// Create a new plugin for registration.
     pub const fn new(
         match_name_fn: fn(name: &str) -> bool,
-        create_fn: fn(inputs: &TInput) -> Result<TPlugin, PluginCreateError>,
+        create_fn: fn(inputs: &TInput) -> Result<TPlugin, TError>,
     ) -> Self {
         Self {
             match_name_fn,
@@ -32,11 +32,8 @@ impl<TPlugin, TInput> Plugin<TPlugin, TInput> {
     ///
     /// # Errors
     ///
-    /// Returns a [`PluginCreateError`] if plugin creation fails due to either:
-    ///  - metadata name being unregistered,
-    ///  - or the configuration is invalid, or
-    ///  - some other reason specific to the plugin.
-    pub fn create(&self, input: &TInput) -> Result<TPlugin, PluginCreateError> {
+    /// Returns a [`TError`] if plugin creation fails.
+    pub fn create(&self, input: &TInput) -> Result<TPlugin, TError> {
         (self.create_fn)(input)
     }
 

--- a/zarrs_plugin/src/plugin.rs
+++ b/zarrs_plugin/src/plugin.rs
@@ -44,11 +44,11 @@ impl<TPlugin, TInput, TError> Plugin<TPlugin, TInput, TError> {
     }
 }
 
-impl<TPlugin, TInput1, TInput2> Plugin2<TPlugin, TInput1, TInput2> {
+impl<TPlugin, TInput1, TInput2, TError> Plugin2<TPlugin, TInput1, TInput2, TError> {
     /// Create a new plugin for registration.
     pub const fn new(
         match_name_fn: fn(name: &str) -> bool,
-        create_fn: fn(input1: &TInput1, input2: &TInput2) -> Result<TPlugin, PluginCreateError>,
+        create_fn: fn(input1: &TInput1, input2: &TInput2) -> Result<TPlugin, TError>,
     ) -> Self {
         Self {
             match_name_fn,
@@ -60,11 +60,11 @@ impl<TPlugin, TInput1, TInput2> Plugin2<TPlugin, TInput1, TInput2> {
     ///
     /// # Errors
     ///
-    /// Returns a [`PluginCreateError`] if plugin creation fails due to either:
+    /// Returns a `TError` if plugin creation fails due to either:
     ///  - metadata name being unregistered,
     ///  - or the configuration is invalid, or
     ///  - some other reason specific to the plugin.
-    pub fn create(&self, input1: &TInput1, input2: &TInput2) -> Result<TPlugin, PluginCreateError> {
+    pub fn create(&self, input1: &TInput1, input2: &TInput2) -> Result<TPlugin, TError> {
         (self.create_fn)(input1, input2)
     }
 

--- a/zarrs_plugin/src/runtime_plugin.rs
+++ b/zarrs_plugin/src/runtime_plugin.rs
@@ -22,7 +22,7 @@ use crate::{MaybeSend, MaybeSync, PluginCreateError};
 /// );
 /// ```
 #[allow(clippy::type_complexity)]
-pub struct RuntimePlugin<TPlugin, TInput>
+pub struct RuntimePlugin<TPlugin, TInput, TError = PluginCreateError>
 where
     TPlugin: MaybeSend + MaybeSync + 'static,
     TInput: ?Sized + 'static,
@@ -30,10 +30,10 @@ where
     /// Tests if the name is a match for this plugin.
     match_name_fn: Box<dyn Fn(&str) -> bool + Send + Sync + 'static>,
     /// Create an implementation of this plugin from input.
-    create_fn: Box<dyn Fn(&TInput) -> Result<TPlugin, PluginCreateError> + Send + Sync + 'static>,
+    create_fn: Box<dyn Fn(&TInput) -> Result<TPlugin, TError> + Send + Sync + 'static>,
 }
 
-impl<TPlugin, TInput> RuntimePlugin<TPlugin, TInput>
+impl<TPlugin, TInput, TError> RuntimePlugin<TPlugin, TInput, TError>
 where
     TPlugin: MaybeSend + MaybeSync + 'static,
     TInput: ?Sized + 'static,
@@ -42,7 +42,7 @@ where
     pub fn new<M, C>(match_name_fn: M, create_fn: C) -> Self
     where
         M: Fn(&str) -> bool + Send + Sync + 'static,
-        C: Fn(&TInput) -> Result<TPlugin, PluginCreateError> + Send + Sync + 'static,
+        C: Fn(&TInput) -> Result<TPlugin, TError> + Send + Sync + 'static,
     {
         Self {
             match_name_fn: Box::new(match_name_fn),
@@ -53,8 +53,8 @@ where
     /// Create a `TPlugin` plugin from `input`.
     ///
     /// # Errors
-    /// Returns a [`PluginCreateError`] if plugin creation fails.
-    pub fn create(&self, input: &TInput) -> Result<TPlugin, PluginCreateError> {
+    /// Returns a [`TError`] if plugin creation fails.
+    pub fn create(&self, input: &TInput) -> Result<TPlugin, TError> {
         (self.create_fn)(input)
     }
 

--- a/zarrs_plugin/src/runtime_plugin.rs
+++ b/zarrs_plugin/src/runtime_plugin.rs
@@ -69,7 +69,7 @@ where
 ///
 /// This is the runtime equivalent of [`Plugin2`](crate::Plugin2).
 #[allow(clippy::type_complexity)]
-pub struct RuntimePlugin2<TPlugin, TInput1, TInput2>
+pub struct RuntimePlugin2<TPlugin, TInput1, TInput2, TError = PluginCreateError>
 where
     TPlugin: MaybeSend + MaybeSync + 'static,
     TInput1: ?Sized + 'static,
@@ -78,12 +78,10 @@ where
     /// Tests if the name is a match for this plugin.
     match_name_fn: Box<dyn Fn(&str) -> bool + Send + Sync + 'static>,
     /// Create an implementation of this plugin from input.
-    create_fn: Box<
-        dyn Fn(&TInput1, &TInput2) -> Result<TPlugin, PluginCreateError> + Send + Sync + 'static,
-    >,
+    create_fn: Box<dyn Fn(&TInput1, &TInput2) -> Result<TPlugin, TError> + Send + Sync + 'static>,
 }
 
-impl<TPlugin, TInput1, TInput2> RuntimePlugin2<TPlugin, TInput1, TInput2>
+impl<TPlugin, TInput1, TInput2, TError> RuntimePlugin2<TPlugin, TInput1, TInput2, TError>
 where
     TPlugin: MaybeSend + MaybeSync + 'static,
     TInput1: ?Sized + 'static,
@@ -93,7 +91,7 @@ where
     pub fn new<M, C>(match_name_fn: M, create_fn: C) -> Self
     where
         M: Fn(&str) -> bool + Send + Sync + 'static,
-        C: Fn(&TInput1, &TInput2) -> Result<TPlugin, PluginCreateError> + Send + Sync + 'static,
+        C: Fn(&TInput1, &TInput2) -> Result<TPlugin, TError> + Send + Sync + 'static,
     {
         Self {
             match_name_fn: Box::new(match_name_fn),
@@ -104,8 +102,8 @@ where
     /// Create a `TPlugin` plugin from `input1` and `input2`.
     ///
     /// # Errors
-    /// Returns a [`PluginCreateError`] if plugin creation fails.
-    pub fn create(&self, input1: &TInput1, input2: &TInput2) -> Result<TPlugin, PluginCreateError> {
+    /// Returns a `TError` if plugin creation fails.
+    pub fn create(&self, input1: &TInput1, input2: &TInput2) -> Result<TPlugin, TError> {
         (self.create_fn)(input1, input2)
     }
 
@@ -123,15 +121,29 @@ where
 mod wasm_impls {
     use super::{RuntimePlugin, RuntimePlugin2};
 
-    unsafe impl<TPlugin: 'static, TInput: ?Sized + 'static> Send for RuntimePlugin<TPlugin, TInput> {}
-    unsafe impl<TPlugin: 'static, TInput: ?Sized + 'static> Sync for RuntimePlugin<TPlugin, TInput> {}
-
-    unsafe impl<TPlugin: 'static, TInput1: ?Sized + 'static, TInput2: ?Sized + 'static> Send
-        for RuntimePlugin2<TPlugin, TInput1, TInput2>
+    unsafe impl<TPlugin: 'static, TInput: ?Sized + 'static, TError: 'static> Send
+        for RuntimePlugin<TPlugin, TInput, TError>
     {
     }
-    unsafe impl<TPlugin: 'static, TInput1: ?Sized + 'static, TInput2: ?Sized + 'static> Sync
-        for RuntimePlugin2<TPlugin, TInput1, TInput2>
+    unsafe impl<TPlugin: 'static, TInput: ?Sized + 'static, TError: 'static> Sync
+        for RuntimePlugin<TPlugin, TInput, TError>
+    {
+    }
+
+    unsafe impl<
+        TPlugin: 'static,
+        TInput1: ?Sized + 'static,
+        TInput2: ?Sized + 'static,
+        TError: 'static,
+    > Send for RuntimePlugin2<TPlugin, TInput1, TInput2, TError>
+    {
+    }
+    unsafe impl<
+        TPlugin: 'static,
+        TInput1: ?Sized + 'static,
+        TInput2: ?Sized + 'static,
+        TError: 'static,
+    > Sync for RuntimePlugin2<TPlugin, TInput1, TInput2, TError>
     {
     }
 }


### PR DESCRIPTION
This binds a data type and fill value to codecs on Array construction time. This allows some precomputation (useful for #374) and upfront validation of data type and fill value compatibility.

#### TODO
- [ ] Review Sharding
- [ ] Review CodecChain
- [ ] Merge into #374