### PR TITLE
Add derive(Clone) to ArrayBuilder

### DIFF
--- a/zarrs/src/array/builder.rs
+++ b/zarrs/src/array/builder.rs
@@ -96,7 +96,7 @@ use array_builder_fill_value::ArrayBuilderFillValueImpl;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ArrayBuilder {
     /// Data type.
     data_type: ArrayBuilderDataType,
@@ -130,7 +130,7 @@ pub struct ArrayBuilder {
     metadata_options: ArrayMetadataOptions,
 }
 
-#[derive(Debug, From)]
+#[derive(Clone, Debug, From)]
 enum ArrayBuilderChunkGridMaybe {
     ChunkGrid(ChunkGrid),
     Metadata(ArrayShape, ArrayBuilderChunkGridMetadata),


### PR DESCRIPTION
When thinking about how to expose `ArrayBuilder` to Python in Zarrista, I came across a need to have `Clone` on `ArrayBuilder`.

Common Python APIs to create Zarr arrays have _huge surfaces_ in a single function. For example [`zarr.create`](https://zarr.readthedocs.io/en/latest/api/zarr/create/#zarr.create) has 26 parameters plus a basked of arbitrary `**kwargs`.

I really didn't want that, so I decided to pursue a chaining API (see https://github.com/developmentseed/zarrista/pull/39), like so:
```py
from zarrista import (
    ArrayBuilder,
    ChunkGrid,
    DataType,
    FillValue,
    MemoryStore,
)

array = (
    ArrayBuilder(
        ChunkGrid.regular([8, 8], [4, 4]),
        DataType.from_string("int8"),
        FillValue(b"\x00"),
    )
    .shape([16, 16])
    .dimension_names(["y", "x"])
    .create(MemoryStore(), "/a")
)
```

1. This prevents the need to have all parameters in a single function call 
2. And more importantly, it means that we can expose a single interface to create either metadata, a synchronous array, or an asynchronous array, depending on whether you finish with `create_metadata`, `create`, or `create_async`

This is somewhat similar to the `ArrayBuilder` API in Rust... **But** I wanted **immutable chaining** over in-place mutation.

This isn't currently possible with `ArrayBuilder` unless you implement `Clone`. Even if you added builder methods that consumed `self` and returned `Self`, that wouldn't work in Python because we can't consume `self` (unless we neuter the previous Python instance of the builder)

For context, [here's the specific code](https://github.com/developmentseed/zarrista/pull/39/changes#diff-fd119ea2cba0d0fdd66f8c0c7dbeab42b621970da47ac785d3b09720417a4258) in https://github.com/developmentseed/zarrista/pull/39 that uses clone:

```rs
#[pyclass(module = "zarrista.array", frozen, name = "ArrayBuilder")]
pub struct PyArrayBuilder(ArrayBuilder);

impl PyArrayBuilder {
    fn with(&self, f: impl FnOnce(&mut ArrayBuilder)) -> Self {
        let mut b = self.0.clone();
        f(&mut b);
        Self(b)
    }
}

#[pymethods]
impl PyArrayBuilder {
    #[new]
    fn py_new(chunk_grid: PyChunkGrid, dtype: PyDataType, fill_value: PyFillValue) -> Self {
        Self(ArrayBuilder::new_with_chunk_grid(
            chunk_grid.into_inner(),
            dtype.into_inner(),
            fill_value.into_inner(),
        ))
    }

    fn attrs(&self, attrs: PyAttributes) -> PyResult<Self> {
        Ok(self.with(|builder| {
            builder.attributes(attrs.into_inner());
        }))
    }

    fn chunk_grid(&self, chunk_grid: PyChunkGrid) -> Self {
        self.with(|builder| {
            builder.chunk_grid(chunk_grid.into_inner());
        })
    }

    fn chunk_key_encoding(&self, chunk_key_encoding: PyChunkKeyEncoding) -> Self {
        self.with(|builder| {
            builder.chunk_key_encoding(chunk_key_encoding.into_inner());
        })
    }

... etc
}
```