### PR TITLE
feat(plugin): support non-`str` matching

### DIFF
--- a/zarrs_plugin/CHANGELOG.md
+++ b/zarrs_plugin/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Add `TError` generic to `[Runtime]Plugin[2]`
+- Add `TError` and `TMatch` generics to `[Runtime]Plugin[2]`
 
 ## [0.4.1] - 2026-02-02
 

--- a/zarrs_plugin/src/plugin.rs
+++ b/zarrs_plugin/src/plugin.rs
@@ -1,25 +1,34 @@
 use crate::PluginCreateError;
 
 /// A plugin.
-pub struct Plugin<TPlugin, TInput, TError = PluginCreateError> {
+pub struct Plugin<TPlugin, TInput, TError = PluginCreateError, TMatch = str>
+where
+    TMatch: ?Sized,
+{
     /// Tests if the name is a match for this plugin.
-    match_name_fn: fn(name: &str) -> bool,
+    match_name_fn: fn(name: &TMatch) -> bool,
     /// Create an implementation of this plugin from metadata.
     create_fn: fn(input: &TInput) -> Result<TPlugin, TError>,
 }
 
 /// A plugin (two parameters).
-pub struct Plugin2<TPlugin, TInput1, TInput2, TError = PluginCreateError> {
+pub struct Plugin2<TPlugin, TInput1, TInput2, TError = PluginCreateError, TMatch = str>
+where
+    TMatch: ?Sized,
+{
     /// Tests if the name is a match for this plugin.
-    match_name_fn: fn(name: &str) -> bool,
+    match_name_fn: fn(name: &TMatch) -> bool,
     /// Create an implementation of this plugin from metadata.
     create_fn: fn(input1: &TInput1, input2: &TInput2) -> Result<TPlugin, TError>,
 }
 
-impl<TPlugin, TInput, TError> Plugin<TPlugin, TInput, TError> {
+impl<TPlugin, TInput, TError, TMatch> Plugin<TPlugin, TInput, TError, TMatch>
+where
+    TMatch: ?Sized,
+{
     /// Create a new plugin for registration.
     pub const fn new(
-        match_name_fn: fn(name: &str) -> bool,
+        match_name_fn: fn(name: &TMatch) -> bool,
         create_fn: fn(inputs: &TInput) -> Result<TPlugin, TError>,
     ) -> Self {
         Self {
@@ -39,15 +48,18 @@ impl<TPlugin, TInput, TError> Plugin<TPlugin, TInput, TError> {
 
     /// Returns true if this plugin is associated with `name`.
     #[must_use]
-    pub fn match_name(&self, name: &str) -> bool {
+    pub fn match_name(&self, name: &TMatch) -> bool {
         (self.match_name_fn)(name)
     }
 }
 
-impl<TPlugin, TInput1, TInput2, TError> Plugin2<TPlugin, TInput1, TInput2, TError> {
+impl<TPlugin, TInput1, TInput2, TError, TMatch> Plugin2<TPlugin, TInput1, TInput2, TError, TMatch>
+where
+    TMatch: ?Sized,
+{
     /// Create a new plugin for registration.
     pub const fn new(
-        match_name_fn: fn(name: &str) -> bool,
+        match_name_fn: fn(name: &TMatch) -> bool,
         create_fn: fn(input1: &TInput1, input2: &TInput2) -> Result<TPlugin, TError>,
     ) -> Self {
         Self {
@@ -70,7 +82,7 @@ impl<TPlugin, TInput1, TInput2, TError> Plugin2<TPlugin, TInput1, TInput2, TErro
 
     /// Returns true if this plugin is associated with `name`.
     #[must_use]
-    pub fn match_name(&self, name: &str) -> bool {
+    pub fn match_name(&self, name: &TMatch) -> bool {
         (self.match_name_fn)(name)
     }
 }

--- a/zarrs_plugin/src/plugin.rs
+++ b/zarrs_plugin/src/plugin.rs
@@ -6,7 +6,7 @@ where
     TMatch: ?Sized,
 {
     /// Tests if the name is a match for this plugin.
-    match_name_fn: fn(name: &TMatch) -> bool,
+    match_fn: fn(r#match: &TMatch) -> bool,
     /// Create an implementation of this plugin from metadata.
     create_fn: fn(input: &TInput) -> Result<TPlugin, TError>,
 }
@@ -17,7 +17,7 @@ where
     TMatch: ?Sized,
 {
     /// Tests if the name is a match for this plugin.
-    match_name_fn: fn(name: &TMatch) -> bool,
+    match_fn: fn(r#match: &TMatch) -> bool,
     /// Create an implementation of this plugin from metadata.
     create_fn: fn(input1: &TInput1, input2: &TInput2) -> Result<TPlugin, TError>,
 }
@@ -28,11 +28,11 @@ where
 {
     /// Create a new plugin for registration.
     pub const fn new(
-        match_name_fn: fn(name: &TMatch) -> bool,
+        match_fn: fn(r#match: &TMatch) -> bool,
         create_fn: fn(inputs: &TInput) -> Result<TPlugin, TError>,
     ) -> Self {
         Self {
-            match_name_fn,
+            match_fn,
             create_fn,
         }
     }
@@ -46,10 +46,11 @@ where
         (self.create_fn)(input)
     }
 
-    /// Returns true if this plugin is associated with `name`.
+    /// Returns true if this plugin is associated with `match`.with `match`.
+    // TODO: Rename to `match` on breaking release
     #[must_use]
-    pub fn match_name(&self, name: &TMatch) -> bool {
-        (self.match_name_fn)(name)
+    pub fn match_name(&self, r#match: &TMatch) -> bool {
+        (self.match_fn)(r#match)
     }
 }
 
@@ -59,11 +60,11 @@ where
 {
     /// Create a new plugin for registration.
     pub const fn new(
-        match_name_fn: fn(name: &TMatch) -> bool,
+        match_fn: fn(r#match: &TMatch) -> bool,
         create_fn: fn(input1: &TInput1, input2: &TInput2) -> Result<TPlugin, TError>,
     ) -> Self {
         Self {
-            match_name_fn,
+            match_fn,
             create_fn,
         }
     }
@@ -80,9 +81,10 @@ where
         (self.create_fn)(input1, input2)
     }
 
-    /// Returns true if this plugin is associated with `name`.
+    /// Returns true if this plugin is associated with `match`.with `match`.
+    // TODO: Rename to `match` on breaking release
     #[must_use]
-    pub fn match_name(&self, name: &TMatch) -> bool {
-        (self.match_name_fn)(name)
+    pub fn match_name(&self, r#match: &TMatch) -> bool {
+        (self.match_fn)(r#match)
     }
 }

--- a/zarrs_plugin/src/runtime_plugin.rs
+++ b/zarrs_plugin/src/runtime_plugin.rs
@@ -22,26 +22,28 @@ use crate::{MaybeSend, MaybeSync, PluginCreateError};
 /// );
 /// ```
 #[allow(clippy::type_complexity)]
-pub struct RuntimePlugin<TPlugin, TInput, TError = PluginCreateError>
+pub struct RuntimePlugin<TPlugin, TInput, TError = PluginCreateError, TMatch = str>
 where
     TPlugin: MaybeSend + MaybeSync + 'static,
     TInput: ?Sized + 'static,
+    TMatch: ?Sized,
 {
     /// Tests if the name is a match for this plugin.
-    match_name_fn: Box<dyn Fn(&str) -> bool + Send + Sync + 'static>,
+    match_name_fn: Box<dyn Fn(&TMatch) -> bool + Send + Sync + 'static>,
     /// Create an implementation of this plugin from input.
     create_fn: Box<dyn Fn(&TInput) -> Result<TPlugin, TError> + Send + Sync + 'static>,
 }
 
-impl<TPlugin, TInput, TError> RuntimePlugin<TPlugin, TInput, TError>
+impl<TPlugin, TInput, TError, TMatch> RuntimePlugin<TPlugin, TInput, TError, TMatch>
 where
     TPlugin: MaybeSend + MaybeSync + 'static,
     TInput: ?Sized + 'static,
+    TMatch: ?Sized,
 {
     /// Create a new runtime plugin for registration.
     pub fn new<M, C>(match_name_fn: M, create_fn: C) -> Self
     where
-        M: Fn(&str) -> bool + Send + Sync + 'static,
+        M: Fn(&TMatch) -> bool + Send + Sync + 'static,
         C: Fn(&TInput) -> Result<TPlugin, TError> + Send + Sync + 'static,
     {
         Self {
@@ -60,7 +62,7 @@ where
 
     /// Returns true if this plugin is associated with `name`.
     #[must_use]
-    pub fn match_name(&self, name: &str) -> bool {
+    pub fn match_name(&self, name: &TMatch) -> bool {
         (self.match_name_fn)(name)
     }
 }
@@ -69,28 +71,31 @@ where
 ///
 /// This is the runtime equivalent of [`Plugin2`](crate::Plugin2).
 #[allow(clippy::type_complexity)]
-pub struct RuntimePlugin2<TPlugin, TInput1, TInput2, TError = PluginCreateError>
+pub struct RuntimePlugin2<TPlugin, TInput1, TInput2, TError = PluginCreateError, TMatch = str>
 where
     TPlugin: MaybeSend + MaybeSync + 'static,
     TInput1: ?Sized + 'static,
     TInput2: ?Sized + 'static,
+    TMatch: ?Sized,
 {
     /// Tests if the name is a match for this plugin.
-    match_name_fn: Box<dyn Fn(&str) -> bool + Send + Sync + 'static>,
+    match_name_fn: Box<dyn Fn(&TMatch) -> bool + Send + Sync + 'static>,
     /// Create an implementation of this plugin from input.
     create_fn: Box<dyn Fn(&TInput1, &TInput2) -> Result<TPlugin, TError> + Send + Sync + 'static>,
 }
 
-impl<TPlugin, TInput1, TInput2, TError> RuntimePlugin2<TPlugin, TInput1, TInput2, TError>
+impl<TPlugin, TInput1, TInput2, TError, TMatch>
+    RuntimePlugin2<TPlugin, TInput1, TInput2, TError, TMatch>
 where
     TPlugin: MaybeSend + MaybeSync + 'static,
     TInput1: ?Sized + 'static,
     TInput2: ?Sized + 'static,
+    TMatch: ?Sized,
 {
     /// Create a new runtime plugin for registration.
     pub fn new<M, C>(match_name_fn: M, create_fn: C) -> Self
     where
-        M: Fn(&str) -> bool + Send + Sync + 'static,
+        M: Fn(&TMatch) -> bool + Send + Sync + 'static,
         C: Fn(&TInput1, &TInput2) -> Result<TPlugin, TError> + Send + Sync + 'static,
     {
         Self {
@@ -109,7 +114,7 @@ where
 
     /// Returns true if this plugin is associated with `name`.
     #[must_use]
-    pub fn match_name(&self, name: &str) -> bool {
+    pub fn match_name(&self, name: &TMatch) -> bool {
         (self.match_name_fn)(name)
     }
 }
@@ -121,12 +126,12 @@ where
 mod wasm_impls {
     use super::{RuntimePlugin, RuntimePlugin2};
 
-    unsafe impl<TPlugin: 'static, TInput: ?Sized + 'static, TError: 'static> Send
-        for RuntimePlugin<TPlugin, TInput, TError>
+    unsafe impl<TPlugin: 'static, TInput: ?Sized + 'static, TError: 'static, TMatch: ?Sized> Send
+        for RuntimePlugin<TPlugin, TInput, TError, TMatch>
     {
     }
-    unsafe impl<TPlugin: 'static, TInput: ?Sized + 'static, TError: 'static> Sync
-        for RuntimePlugin<TPlugin, TInput, TError>
+    unsafe impl<TPlugin: 'static, TInput: ?Sized + 'static, TError: 'static, TMatch: ?Sized> Sync
+        for RuntimePlugin<TPlugin, TInput, TError, TMatch>
     {
     }
 
@@ -135,7 +140,8 @@ mod wasm_impls {
         TInput1: ?Sized + 'static,
         TInput2: ?Sized + 'static,
         TError: 'static,
-    > Send for RuntimePlugin2<TPlugin, TInput1, TInput2, TError>
+        TMatch: ?Sized,
+    > Send for RuntimePlugin2<TPlugin, TInput1, TInput2, TError, TMatch>
     {
     }
     unsafe impl<
@@ -143,7 +149,8 @@ mod wasm_impls {
         TInput1: ?Sized + 'static,
         TInput2: ?Sized + 'static,
         TError: 'static,
-    > Sync for RuntimePlugin2<TPlugin, TInput1, TInput2, TError>
+        TMatch: ?Sized,
+    > Sync for RuntimePlugin2<TPlugin, TInput1, TInput2, TError, TMatch>
     {
     }
 }

--- a/zarrs_plugin/src/runtime_plugin.rs
+++ b/zarrs_plugin/src/runtime_plugin.rs
@@ -29,7 +29,7 @@ where
     TMatch: ?Sized,
 {
     /// Tests if the name is a match for this plugin.
-    match_name_fn: Box<dyn Fn(&TMatch) -> bool + Send + Sync + 'static>,
+    match_fn: Box<dyn Fn(&TMatch) -> bool + Send + Sync + 'static>,
     /// Create an implementation of this plugin from input.
     create_fn: Box<dyn Fn(&TInput) -> Result<TPlugin, TError> + Send + Sync + 'static>,
 }
@@ -41,13 +41,13 @@ where
     TMatch: ?Sized,
 {
     /// Create a new runtime plugin for registration.
-    pub fn new<M, C>(match_name_fn: M, create_fn: C) -> Self
+    pub fn new<M, C>(match_fn: M, create_fn: C) -> Self
     where
         M: Fn(&TMatch) -> bool + Send + Sync + 'static,
         C: Fn(&TInput) -> Result<TPlugin, TError> + Send + Sync + 'static,
     {
         Self {
-            match_name_fn: Box::new(match_name_fn),
+            match_fn: Box::new(match_fn),
             create_fn: Box::new(create_fn),
         }
     }
@@ -60,10 +60,11 @@ where
         (self.create_fn)(input)
     }
 
-    /// Returns true if this plugin is associated with `name`.
+    /// Returns true if this plugin is associated with `match`.
+    // TODO: Rename to `match` on breaking release
     #[must_use]
-    pub fn match_name(&self, name: &TMatch) -> bool {
-        (self.match_name_fn)(name)
+    pub fn match_name(&self, r#match: &TMatch) -> bool {
+        (self.match_fn)(r#match)
     }
 }
 
@@ -79,7 +80,7 @@ where
     TMatch: ?Sized,
 {
     /// Tests if the name is a match for this plugin.
-    match_name_fn: Box<dyn Fn(&TMatch) -> bool + Send + Sync + 'static>,
+    match_fn: Box<dyn Fn(&TMatch) -> bool + Send + Sync + 'static>,
     /// Create an implementation of this plugin from input.
     create_fn: Box<dyn Fn(&TInput1, &TInput2) -> Result<TPlugin, TError> + Send + Sync + 'static>,
 }
@@ -93,13 +94,13 @@ where
     TMatch: ?Sized,
 {
     /// Create a new runtime plugin for registration.
-    pub fn new<M, C>(match_name_fn: M, create_fn: C) -> Self
+    pub fn new<M, C>(match_fn: M, create_fn: C) -> Self
     where
         M: Fn(&TMatch) -> bool + Send + Sync + 'static,
         C: Fn(&TInput1, &TInput2) -> Result<TPlugin, TError> + Send + Sync + 'static,
     {
         Self {
-            match_name_fn: Box::new(match_name_fn),
+            match_fn: Box::new(match_fn),
             create_fn: Box::new(create_fn),
         }
     }
@@ -112,10 +113,11 @@ where
         (self.create_fn)(input1, input2)
     }
 
-    /// Returns true if this plugin is associated with `name`.
+    /// Returns true if this plugin is associated with `match`.with `match`.
+    // TODO: Rename to `match` on breaking release
     #[must_use]
-    pub fn match_name(&self, name: &TMatch) -> bool {
-        (self.match_name_fn)(name)
+    pub fn match_name(&self, r#match: &TMatch) -> bool {
+        (self.match_fn)(r#match)
     }
 }
 


### PR DESCRIPTION
Adds `TMatch` generic to `[Runtime]Plugin[2]` defaulting to `str. `name` is now a misnomer.