### PR TITLE
Remove warnings from reshape codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Remove warnings from now-stable `reshape` codec
+
 ## [0.23.5] - 2026-03-03
 
 ### Changed

--- a/zarrs/doc/status/codecs.md
+++ b/zarrs/doc/status/codecs.md
@@ -1,7 +1,7 @@
 | Codec Type     | V3 `name`                          | V2 `id`                             | Feature Flag* |
 | -------------- | ---------------------------------- | ----------------------------------- | ------------- |
 | Array to Array | [`transpose`]                      | (implicit with `"order": "F"`)      | **transpose** |
-|                | 🚧[`reshape`]                      | -                                   |               |
+|                | [`reshape`]                        | -                                   |               |
 |                | 🚧[`numcodecs.fixedscaleoffset`]   | `fixedscaleoffset`                  |               |
 |                | [`bitround`]                       | `bitround`                          | bitround      |
 |                | 🚧[`zarrs.squeeze`]                | -                                   |               |

--- a/zarrs/src/array/codec/array_to_array/reshape.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape.rs
@@ -2,15 +2,11 @@
 //!
 //! Performs a reshaping operation.
 //!
-//! <div class="warning">
-//! This codec is experimental and may be incompatible with other Zarr V3 implementations.
-//! </div>
-//!
 //! ### Compatible Implementations
 //! None
 //!
 //! ### Specification
-//! - <https://github.com/zarr-developers/zarr-extensions/blob/7295bf1ec15c978f1a63b90d55891712b950c797/codecs/reshape/README.md>
+//! - <https://github.com/zarr-developers/zarr-extensions/tree/main/codecs/reshape>
 //!
 //! ### Codec `name` Aliases (Zarr V3)
 //! - `reshape`


### PR DESCRIPTION
The reshape extension was merged without further change.