### PR TITLE
feat(filesystem): add opt-in file handle caching for partial reads

### DIFF
--- a/zarrs_filesystem/CHANGELOG.md
+++ b/zarrs_filesystem/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/zarrs/zarrs/compare/zarrs_filesystem-v0.3.10...HEAD)
 
+### Added
+- Add `FilesystemStoreOptions::file_handle_cache_size`: an opt-in least-recently-used cache of open file handles that are reused across partial reads, greatly reducing `open`/`stat`/`close` metadata operations (e.g. on Lustre/NFS) when reading many byte ranges from the same files
+
 ## [0.3.10](https://github.com/zarrs/zarrs/releases/tag/zarrs_filesystem-v0.3.10) - 2026-07-05
 
 ### Changed

--- a/zarrs_filesystem/Cargo.toml
+++ b/zarrs_filesystem/Cargo.toml
@@ -20,6 +20,7 @@ bytes = "1.7.0"
 derive_more = { version = "2.0.0", features = ["from"] }
 itertools = "0.14.0"
 libc = "0.2.158"
+lru = "0.16.0"
 page_size = "0.6.0"
 pathdiff = "0.2.0"
 positioned-io = "0.3.5"

--- a/zarrs_filesystem/src/lib.rs
+++ b/zarrs_filesystem/src/lib.rs
@@ -20,10 +20,12 @@ use zarrs_storage::{
 
 #[cfg(target_os = "linux")]
 mod direct_io;
+use lru::LruCache;
 use positioned_io::{RandomAccessFile, ReadAt, WriteAt};
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -65,6 +67,7 @@ fn bytes_aligned(size: usize) -> BytesMut {
 #[derive(Debug, Clone, Default)]
 pub struct FilesystemStoreOptions {
     direct_io: bool,
+    file_handle_cache_size: usize,
 }
 
 impl FilesystemStoreOptions {
@@ -74,6 +77,34 @@ impl FilesystemStoreOptions {
         self.direct_io = direct_io;
         self
     }
+
+    /// Set the capacity of the file handle cache (default: 0, disabled).
+    ///
+    /// If nonzero, up to `file_handle_cache_size` files are kept open in a least-recently-used
+    /// cache and reused across [partial read](ReadableStorageTraits::get_partial_many) calls,
+    /// rather than each call opening and closing the file it reads from.
+    /// This substantially reduces filesystem metadata operations (`open`/`stat`/`close`) when many
+    /// byte ranges are read from the same files, such as partial reads of sharded arrays.
+    /// It is particularly beneficial on network filesystems (e.g. Lustre, NFS), where each
+    /// metadata operation is a server round trip.
+    ///
+    /// Cached file handles count towards the process open-file limit (e.g. `ulimit -n` on POSIX
+    /// systems); choose a capacity comfortably below that limit.
+    ///
+    /// Cached handles are invalidated on writes and erases through this store, but not on external
+    /// modification of the underlying files.
+    /// This option has no effect on reads with [`direct_io`](Self::direct_io) enabled.
+    pub fn file_handle_cache_size(&mut self, file_handle_cache_size: usize) -> &mut Self {
+        self.file_handle_cache_size = file_handle_cache_size;
+        self
+    }
+}
+
+/// A cached open file handle and its size at open time.
+#[derive(Debug)]
+struct CachedFile {
+    file: RandomAccessFile,
+    size: u64,
 }
 
 /// A synchronous file system store.
@@ -85,6 +116,7 @@ pub struct FilesystemStore {
     sort: bool,
     options: FilesystemStoreOptions,
     files: Mutex<HashMap<StoreKey, Arc<RwLock<()>>>>,
+    handle_cache: Option<Mutex<LruCache<StoreKey, Arc<CachedFile>>>>,
 }
 
 impl FilesystemStore {
@@ -109,11 +141,15 @@ impl FilesystemStore {
             return Err(FilesystemStoreCreateError::InvalidBasePath(base_path));
         }
 
+        let handle_cache = NonZeroUsize::new(options.file_handle_cache_size)
+            .map(|capacity| Mutex::new(LruCache::new(capacity)));
+
         Ok(Self {
             base_path,
             sort: false,
             options,
             files: Mutex::default(),
+            handle_cache,
         })
     }
 
@@ -157,6 +193,53 @@ impl FilesystemStore {
         path
     }
 
+    /// Open the file for `key`, or retrieve/populate the cached handle if the file handle cache is
+    /// enabled.
+    ///
+    /// Returns [`None`] if the file does not exist.
+    /// Must be called with the file mutex of `key` held (read or write).
+    fn open_or_cached(&self, key: &StoreKey) -> Result<Option<Arc<CachedFile>>, StorageError> {
+        if let Some(cache) = &self.handle_cache {
+            if let Some(handle) = cache.lock().unwrap().get(key) {
+                return Ok(Some(handle.clone()));
+            }
+        }
+
+        let file = match RandomAccessFile::open(self.key_to_fspath(key)) {
+            Ok(file) => file,
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    return Ok(None);
+                }
+                return Err(err.into());
+            }
+        };
+        let size = positioned_io::Size::size(&file)?
+            .ok_or_else(|| StorageError::Other("Could not determine file size".to_string()))?;
+        let handle = Arc::new(CachedFile { file, size });
+
+        if let Some(cache) = &self.handle_cache {
+            cache.lock().unwrap().put(key.clone(), handle.clone());
+        }
+        Ok(Some(handle))
+    }
+
+    /// Invalidate the cached file handle for `key`, if any.
+    ///
+    /// Must be called with the file mutex of `key` held for writing.
+    fn invalidate_handle(&self, key: &StoreKey) {
+        if let Some(cache) = &self.handle_cache {
+            cache.lock().unwrap().pop(key);
+        }
+    }
+
+    /// Invalidate all cached file handles.
+    fn invalidate_all_handles(&self) {
+        if let Some(cache) = &self.handle_cache {
+            cache.lock().unwrap().clear();
+        }
+    }
+
     fn get_file_mutex(&self, key: &StoreKey) -> Arc<RwLock<()>> {
         let mut files = self.files.lock().unwrap();
         let file = files
@@ -176,6 +259,7 @@ impl FilesystemStore {
     ) -> Result<(), StorageError> {
         let file = self.get_file_mutex(key);
         let _lock = file.write();
+        self.invalidate_handle(key);
 
         // Create directories
         let key_path = self.key_to_fspath(key);
@@ -343,20 +427,14 @@ impl ReadableStorageTraits for FilesystemStore {
             return self.get_partial_many_direct_io(key, byte_ranges);
         }
 
-        // Lock and open the file
+        // Lock and open the file (or reuse a cached handle)
         let file_mutex = self.get_file_mutex(key);
         let _lock = file_mutex.read();
-        let file = match RandomAccessFile::open(self.key_to_fspath(key)) {
-            Ok(file) => file,
-            Err(err) => {
-                if err.kind() == std::io::ErrorKind::NotFound {
-                    return Ok(None);
-                }
-                return Err(err.into());
-            }
+        let Some(handle) = self.open_or_cached(key)? else {
+            return Ok(None);
         };
-        let file_size = positioned_io::Size::size(&file)?
-            .ok_or_else(|| StorageError::Other("Could not determine file size".to_string()))?;
+        let file = &handle.file;
+        let file_size = handle.size;
 
         let out = byte_ranges
             .map(|byte_range| {
@@ -423,6 +501,7 @@ impl WritableStorageTraits for FilesystemStore {
     fn erase(&self, key: &StoreKey) -> Result<(), StorageError> {
         let file = self.get_file_mutex(key);
         let _lock = file.write();
+        self.invalidate_handle(key);
 
         let key_path = self.key_to_fspath(key);
         let result = std::fs::remove_file(key_path);
@@ -438,6 +517,7 @@ impl WritableStorageTraits for FilesystemStore {
 
     fn erase_prefix(&self, prefix: &StorePrefix) -> Result<(), StorageError> {
         let _lock = self.files.lock(); // lock all operations
+        self.invalidate_all_handles();
 
         let prefix_path = self.prefix_to_fs_path(prefix);
         let result = std::fs::remove_dir_all(prefix_path);

--- a/zarrs_filesystem/tests/filesystem.rs
+++ b/zarrs_filesystem/tests/filesystem.rs
@@ -63,6 +63,83 @@ fn direct_io_store_test() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[test]
+#[cfg_attr(miri, ignore)]
+fn filesystem_handle_cache() -> Result<(), Box<dyn Error>> {
+    use zarrs_filesystem::FilesystemStoreOptions;
+
+    let path = tempfile::TempDir::new()?;
+    let mut opts = FilesystemStoreOptions::default();
+    opts.file_handle_cache_size(16);
+    let store = FilesystemStore::new_with_options(path.path(), opts)?.sorted();
+    zarrs_storage::store_test::store_write(&store)?;
+    zarrs_storage::store_test::store_read(&store)?;
+    zarrs_storage::store_test::store_list(&store)?;
+    zarrs_storage::store_test::store_list_size(&store)?;
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn filesystem_handle_cache_invalidation() -> Result<(), Box<dyn Error>> {
+    use zarrs_filesystem::FilesystemStoreOptions;
+    use zarrs_storage::{ReadableStorageTraits, StoreKey, WritableStorageTraits};
+
+    let path = tempfile::TempDir::new()?;
+    let mut opts = FilesystemStoreOptions::default();
+    opts.file_handle_cache_size(16);
+    let store = FilesystemStore::new_with_options(path.path(), opts)?;
+
+    let key: StoreKey = "a/b".try_into()?;
+    store.set(&key, vec![0u8; 4].into())?;
+    assert_eq!(store.get(&key)?.unwrap(), vec![0u8; 4]);
+
+    // Overwrite with a different size; the cached handle must not serve stale bytes or size
+    store.set(&key, vec![1u8; 8].into())?;
+    assert_eq!(store.get(&key)?.unwrap(), vec![1u8; 8]);
+
+    // Erase; the cached handle must not resurrect the key
+    store.erase(&key)?;
+    assert!(store.get(&key)?.is_none());
+
+    // Erase prefix invalidates too
+    store.set(&key, vec![2u8; 4].into())?;
+    assert_eq!(store.get(&key)?.unwrap(), vec![2u8; 4]);
+    store.erase_prefix(&"a/".try_into()?)?;
+    assert!(store.get(&key)?.is_none());
+
+    Ok(())
+}
+
+/// Prove the cached handle is actually reused: delete the file behind the store's back and check
+/// that reads still succeed from the retained file handle (POSIX unlink semantics).
+#[cfg(unix)]
+#[test]
+#[cfg_attr(miri, ignore)]
+fn filesystem_handle_cache_reuse() -> Result<(), Box<dyn Error>> {
+    use zarrs_filesystem::FilesystemStoreOptions;
+    use zarrs_storage::{ReadableStorageTraits, StoreKey, WritableStorageTraits};
+
+    let path = tempfile::TempDir::new()?;
+    let mut opts = FilesystemStoreOptions::default();
+    opts.file_handle_cache_size(16);
+    let store = FilesystemStore::new_with_options(path.path(), opts)?;
+
+    let key: StoreKey = "a/b".try_into()?;
+    store.set(&key, vec![1u8; 4].into())?;
+    assert_eq!(store.get(&key)?.unwrap(), vec![1u8; 4]);
+
+    // Delete the file behind the store's back; a cached-handle read still succeeds
+    std::fs::remove_file(store.key_to_fspath(&key))?;
+    assert_eq!(store.get(&key)?.unwrap(), vec![1u8; 4]);
+
+    // Erasing through the store drops the handle; the key is then gone
+    store.erase(&key)?;
+    assert!(store.get(&key)?.is_none());
+
+    Ok(())
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn direct_io_coalescing_test() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
Hi, I am training a 1TB dataset with random access on a lustre cluster using zarrs. So I keep doing profiling and the cluster became unaccessible and I started a benchmark by trying to simulate the very slow lustre :). Then I noticed the number of open syscalls for partial reads. So I created this PR. 

AI Disclaimer! I made AI write the report and reproducibility code. I will try on the cluster myself once it is availible but the code seems good to me honestly and it seems like a free win.


### Problem

`FilesystemStore::get_partial_many` opens, `fstat`s, and closes the file on **every call**, and the sharding partial decoder issues one call per inner chunk. Reading *k* inner chunks from a shard therefore costs *k*× `open`/`stat`/`close` instead of 1×. On local SSDs this is cheap, but on network filesystems (Lustre, NFS) every open/stat is a metadata-server round trip, and it dominates partial reads of sharded arrays.

Profiling that motivated this (zarrs-python/#152-shaped workload on Lustre): a scattered read touching 128 shard files issued ~1300 `openat`+`statx`+`close` — one full cycle per inner-chunk byte range — while the `pread64` count was already optimal.

### Change

Adds `FilesystemStoreOptions::file_handle_cache_size` (**default 0 = disabled**; behaviour is unchanged unless opted in). When nonzero, up to that many open file handles (plus their size at open time) are kept in an LRU keyed by `StoreKey` and reused across `get_partial_many` calls.

- Slots under the store's existing per-key `RwLock`: readers share the cached handle under the read guard; `set`/`erase` invalidate under the write guard; `erase_prefix` clears the cache. All reads complete inside the guard, so a stale handle can never serve rewritten or erased data.
- Concurrent reads on a shared handle are safe: `positioned-io`'s `ReadAt::read_at` takes `&self` (`pread` on unix, explicit-offset `seek_read` on Windows), and the crate provides `ReadAt for Arc<RandomAccessFile>`.
- The direct I/O read path is unaffected (documented).
- Cached handles count toward the process open-file limit; documented so users size the capacity below `ulimit -n`.
- New dependency: `lru = "0.16.0"` (same requirement the `zarrs` crate already declares).

### Results

Linux, sharded 1-D int64 array, 10 shard files, reading 99 of 100 inner chunks per shard (`strace` tallies on the store files):

|  | cache off (current) | cache on (16) |
|---|---|---|
| `openat` | 1000 | **10** |
| `statx` | 1000 | **10** |
| `close` | 1000 | **10** |
| `pread64` | 1000 | 1000 (unchanged) |

Wall-clock with injected per-open latency (LD_PRELOAD shim adding a fixed delay to `open` of store files, emulating a network-FS metadata round trip), single build, cache toggled by the option:

| per-open latency | cache off | cache on |
|---|---|---|
| 0 ms | 27 ms | 16 ms |
| 1 ms | 260 ms | 34 ms |
| 3 ms | 750 ms | 58 ms |
| 6 ms | 1480 ms | **95 ms (15.6×)** |

The saving scales with inner-chunks-touched-per-shard: with the cache, opens equal the number of files touched; without it, files × inner chunks. Measured 10×–500× fewer opens as inner-chunks-per-shard grows from 10 to 500 (fixed 4 shard files).

### Tests

- Existing `zarrs_storage` store test suite run with the cache enabled.
- Invalidation: overwrite with a different size, erase, and `erase_prefix` are all visible through a populated cache.
- Handle reuse proven directly (unix): unlink the file behind the store's back; a cached-handle read still succeeds, and `erase` through the store then drops it.

<details>
<summary><b>Reproducing the results</b> (any Linux with <code>strace</code> and a C compiler)</summary>

Set up a probe crate against this branch:

```bash
git clone --branch perf/fd-caching https://github.com/zarrs/zarrs /tmp/zarrs-pr
cargo new /tmp/fdprobe && cd /tmp/fdprobe
cat >> Cargo.toml <<'TOML'
zarrs = { path = "/tmp/zarrs-pr/zarrs" }
ndarray = "0.17"
TOML
```

`src/main.rs` — builds a sharded 1-D int64 array, then reads `READ_N` of each shard's inner chunks (geometry and cache size are env-driven):

```rust
use std::sync::Arc;
use ndarray::ArrayD;
use zarrs::array::{data_type, Array, ArrayBuilder, ArraySubset};
use zarrs::filesystem::{FilesystemStore, FilesystemStoreOptions};
use zarrs::storage::ReadableWritableListableStorage;

fn envu(k: &str, d: u64) -> u64 {
    std::env::var(k).ok().and_then(|s| s.parse().ok()).unwrap_or(d)
}

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let n = envu("N", 4_000_000);
    let shard = envu("SHARD", 400_000);
    let inner = envu("INNER", 4_000);
    let read_n = envu("READ_N", 99);
    let fdc = envu("FDCACHE", 0) as usize;
    let mode = std::env::var("MODE").unwrap_or_else(|_| "read".into());
    let path = std::env::var("STORE").unwrap_or_else(|_| "/tmp/zs_store".into());

    let mut opts = FilesystemStoreOptions::default();
    opts.file_handle_cache_size(fdc);
    let store: ReadableWritableListableStorage =
        Arc::new(FilesystemStore::new_with_options(&path, opts)?);
    let nsh = n / shard;

    if mode == "build" {
        let array = ArrayBuilder::new(vec![n], vec![shard], data_type::int64(), 0i64)
            .subchunk_shape(vec![inner])
            .build(store.clone(), "/arr")?;
        array.store_metadata()?;
        for s in 0..nsh {
            let chunk = ArrayD::<i64>::from_shape_fn(vec![shard as usize], |i| {
                (s * shard + i[0] as u64) as i64
            });
            array.store_chunk(&[s], chunk)?;
        }
        return Ok(());
    }

    let array = Array::open(store.clone(), "/arr")?;
    let t0 = std::time::Instant::now();
    let mut total = 0usize;
    for s in 0..nsh {
        let lo = s * shard;
        let subset = ArraySubset::new_with_ranges(&[lo..lo + read_n * inner]);
        let data: ArrayD<i64> = array.retrieve_array_subset(&subset)?;
        total += data.len();
    }
    println!(
        "fd_cache={fdc} read_elapsed_ms={:.1} total={total}",
        t0.elapsed().as_secs_f64() * 1e3
    );
    Ok(())
}
```

**1. Metadata collapse** (first table). 10 shards × 99 inner chunks; tally syscalls on the chunk files:

```bash
cargo build --release
MODE=build ./target/release/fdprobe

for FDC in 0 16; do
  rm -f /tmp/tr.*
  strace -ff -y -e trace=openat,statx,pread64,close -o /tmp/tr \
    env FDCACHE=$FDC ./target/release/fdprobe
  echo "FDCACHE=$FDC:"; cat /tmp/tr.* | grep zs_store | grep '/c/' | \
    awk '/openat\(/{o++} /statx\(/{s++} /pread64\(/{r++} /close\(/{c++}
         END{printf "  openat=%d statx=%d pread64=%d close=%d\n",o,s,r,c}'
done
```

**2. Injected open latency** (second table). Compile the shim, which delays `open`/`open64`/`openat` of store files by `LAT_US` microseconds (Rust's `File::open` goes through glibc's `open64` symbol, so the shim must hook the symbols even though strace shows the `openat` syscall):

```c
// latency.c: cc -shared -fPIC -O2 latency.c -o latency.so -ldl
#define _GNU_SOURCE
#include <dlfcn.h>
#include <fcntl.h>
#include <stdarg.h>
#include <stdlib.h>
#include <string.h>
#include <time.h>
static long lat_ns = -1;
static const char *marker = NULL;
static void maybe_sleep(const char *p) {
    if (lat_ns < 0) {
        char *us = getenv("LAT_US");
        lat_ns = (us ? atol(us) : 0) * 1000L;
        marker = getenv("LAT_MARKER");
        if (!marker) marker = "zs_store";
    }
    if (lat_ns && p && strstr(p, marker)) {
        struct timespec t = {lat_ns / 1000000000L, lat_ns % 1000000000L};
        nanosleep(&t, NULL);
    }
}
#define WRAP(NAME)                                                        \
    int NAME(const char *path, int flags, ...) {                          \
        static int (*real)(const char *, int, ...) = NULL;                \
        if (!real) real = dlsym(RTLD_NEXT, #NAME);                        \
        mode_t m = 0;                                                     \
        if (flags & O_CREAT) { va_list a; va_start(a, flags); m = va_arg(a, int); va_end(a); } \
        maybe_sleep(path);                                                \
        return real(path, flags, m);                                      \
    }
WRAP(open)
WRAP(open64)
int openat(int d, const char *path, int flags, ...) {
    static int (*real)(int, const char *, int, ...) = NULL;
    if (!real) real = dlsym(RTLD_NEXT, "openat");
    mode_t m = 0;
    if (flags & O_CREAT) { va_list a; va_start(a, flags); m = va_arg(a, int); va_end(a); }
    maybe_sleep(path);
    return real(d, path, flags, m);
}
```

```bash
for us in 0 1000 3000 6000; do
  for FDC in 0 16; do
    LD_PRELOAD=./latency.so LAT_US=$us FDCACHE=$FDC ./target/release/fdprobe
  done
done
```

**3. Scaling with inner-chunks-per-shard** (fixed 4 shard files, read all but one inner chunk per shard):

```bash
for IN in 100000 20000 4000 2000; do
  IPS=$((1000000 / IN)); ST=/tmp/zq_$IN
  N=4000000 SHARD=1000000 INNER=$IN STORE=$ST MODE=build ./target/release/fdprobe
  for FDC in 0 16; do
    strace -f -e trace=openat -o /tmp/tr1 env N=4000000 SHARD=1000000 INNER=$IN \
      READ_N=$((IPS - 1)) STORE=$ST FDCACHE=$FDC ./target/release/fdprobe >/dev/null 2>&1
    echo "INNER=$IN inner/shard=$IPS FDCACHE=$FDC opens=$(grep -c '/c/' /tmp/tr1)"
  done
done
```

</details>