### PR TITLE
feat: implement cloning for arrays and codec chains

### DIFF
--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -425,6 +425,28 @@ pub struct Array<TStorage: ?Sized> {
     metadata_erase_version: MetadataEraseVersion,
 }
 
+impl<TStorage: ?Sized> Clone for Array<TStorage> {
+    fn clone(&self) -> Self {
+        Self {
+            storage: self.storage.clone(),
+            path: self.path.clone(),
+            data_type: self.data_type.clone(),
+            chunk_grid: self.chunk_grid.clone(),
+            subchunk_grids: self.subchunk_grids.clone(),
+            chunk_key_encoding: self.chunk_key_encoding.clone(),
+            fill_value: self.fill_value.clone(),
+            codecs: self.codecs.clone(),
+            codecs_bound: self.codecs_bound.clone(),
+            storage_transformers: self.storage_transformers.clone(),
+            dimension_names: self.dimension_names.clone(),
+            metadata: self.metadata.clone(),
+            codec_options: self.codec_options,
+            metadata_options: self.metadata_options,
+            metadata_erase_version: self.metadata_erase_version,
+        }
+    }
+}
+
 impl<TStorage: ?Sized> Array<TStorage> {
     /// Replace the storage backing an array.
     pub fn with_storage<TStorage2: ?Sized>(&self, storage: Arc<TStorage2>) -> Array<TStorage2> {

--- a/zarrs/src/array/array_cached.rs
+++ b/zarrs/src/array/array_cached.rs
@@ -50,6 +50,15 @@ pub struct ArrayCached<TStorage: ?Sized, C> {
     cache: Arc<C>,
 }
 
+impl<TStorage: ?Sized, C> Clone for ArrayCached<TStorage, C> {
+    fn clone(&self) -> Self {
+        Self {
+            array: self.array.clone(),
+            cache: self.cache.clone(),
+        }
+    }
+}
+
 impl<TStorage: ?Sized, C> ArrayCached<TStorage, C> {
     /// Create a new cached array wrapper.
     #[must_use]

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -89,7 +89,7 @@ pub struct CodecChain {
 }
 
 /// A codec chain bound to an array data type and fill value.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CodecChainBound {
     array_to_array: Vec<Arc<dyn ArrayToArrayCodecTraits>>,
     array_to_bytes: Arc<dyn ArrayToBytesCodecTraits>,


### PR DESCRIPTION
- Add `Clone` implementations for `Array` and `ArrayCached`
- Derive `Clone` for bound codec chains

Closes #434