### PR TITLE
fix!(array): enforce fixed dimensionality and persist dimension names in V2->V3 if set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improves the API for computing partial decoding granularity
   - Subchunk-producing codecs and partial decoders now expose ordered subchunk-grid hierarchies
     so nested sharding levels can be selected independently
+- **Breaking**: Make array dimensionality immutable; dimensionality-changing shape updates now return `ArrayCreateError::ChangedDimensionality`
 - **Behavioural change**: Chunk grids no longer support out-of-bounds operations or unlimited dimensions - resize before extending arrays
   - Reading/writing completely out-of-bounds chunks is now an error
   - Querying completely out-of-bounds chunks always returns `None`
@@ -81,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `vlen` index endianness handling to use actual index data type rather than `uint64`
 - Fixed a panic when retrieving an array subset spanning multiple chunks through a chunk cache with a nested optional data type (e.g. `Option<Option<u8>>`)
   - Only the outermost mask was allocated, so inner masks were also dropped
+- **Breaking**: Make `ArrayMutOps::set_dimension_names()` fallible, validate and persist names, and retain them when converting Zarr V2 arrays to V3
 
 ## [0.23.13](https://github.com/zarrs/zarrs/releases/tag/zarrs-v0.23.13) - 2026-05-24
 

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -144,12 +144,20 @@ pub fn chunk_shape_to_array_shape(chunk_shape: &[std::num::NonZeroU64]) -> Array
 ///  - [`codecs`](Array::codecs)
 ///  - [`storage_transformers`](Array::storage_transformers)
 ///  - [`path`](Array::path)
+///  - [`dimensionality`](Array::dimensionality), see [Array Dimensionality](#array-dimensionality) below
 ///
 /// ### Mutable Array Metadata
 /// Do not forget to store metadata after mutation.
 ///  - [`shape`](Array::shape) / [`set_shape`](Array::set_shape) / [`set_shape_and_chunk_grid`](Array::set_shape_and_chunk_grid)
 ///  - [`attributes`](Array::attributes) / [`attributes_mut`](Array::attributes_mut)
 ///  - [`dimension_names`](Array::dimension_names) / [`set_dimension_names`](Array::set_dimension_names)
+///
+/// ### Array Dimensionality
+/// The dimensionality of an array is **fixed** for the lifetime of an [`Array`].
+/// It is established when the array is created or opened, and the data type, codec chain, chunk grid, chunk keys and dimension names are all bound to it.
+///
+/// An array can be resized within its dimensionality, but it cannot gain or lose dimensions:
+/// [`set_shape`](Array::set_shape) and [`set_shape_and_chunk_grid`](Array::set_shape_and_chunk_grid) return [`ArrayCreateError::ChangedDimensionality`] if the new shape has a different number of dimensions.
 ///
 /// ### `zarrs` Metadata
 /// By default, the `zarrs` version and a link to its source code is written to the `_zarrs` attribute in array metadata when calling [`store_metadata`](Array::store_metadata).
@@ -738,8 +746,12 @@ impl<TStorage: ?Sized> Array<TStorage> {
     /// This method allows setting both the array shape and chunk grid simultaneously.
     /// Some chunk grids depend on the array shape (e.g. `rectilinear`), so this method ensures that the chunk grid is correctly configured for the new array shape.
     ///
+    /// The dimensionality of an array is fixed once it has been created or opened, so
+    /// `array_shape` must have the same length as the current [`shape`](ArrayOps::shape).
+    ///
     /// # Errors
     /// Returns an [`ArrayCreateError`] if:
+    ///  - `array_shape` changes the array dimensionality,
     ///  - the chunk grid is not compatible with `array_shape`, or
     ///  - the chunk grid metadata is invalid.
     ///
@@ -758,6 +770,15 @@ impl<TStorage: ?Sized> Array<TStorage> {
         let chunk_grid_metadata: builder::ArrayBuilderChunkGridMetadata =
             chunk_grid_metadata.into();
         let chunk_grid_metadata = chunk_grid_metadata.to_metadata()?;
+
+        // The dimensionality of an array is fixed once it exists: the codec chain, chunk keys and
+        // dimension names are all bound to it. Checked before any mutation.
+        if array_shape.len() != self.dimensionality() {
+            return Err(ArrayCreateError::ChangedDimensionality(
+                array_shape.len(),
+                self.dimensionality(),
+            ));
+        }
 
         // Create the new chunk grid
         self.chunk_grid = ChunkGrid::from_metadata(&chunk_grid_metadata, &array_shape)
@@ -818,7 +839,9 @@ impl<TStorage: ?Sized> Array<TStorage> {
     pub fn to_v3(self) -> Result<Self, ArrayMetadataV2ToV3Error> {
         match self.metadata {
             ArrayMetadata::V2(metadata) => {
-                let metadata: ArrayMetadata = array_metadata_v2_to_v3(&metadata)?.into();
+                let mut metadata = array_metadata_v2_to_v3(&metadata)?;
+                // Zarr V2 metadata has no dimension names to convert, so take the array's.
+                metadata.dimension_names.clone_from(&self.dimension_names);
                 Ok(Self {
                     storage: self.storage,
                     path: self.path,
@@ -831,7 +854,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
                     codecs_bound: self.codecs_bound,
                     storage_transformers: self.storage_transformers,
                     dimension_names: self.dimension_names,
-                    metadata,
+                    metadata: metadata.into(),
                     codec_options: self.codec_options,
                     metadata_options: self.metadata_options,
                     metadata_erase_version: self.metadata_erase_version,
@@ -1246,6 +1269,146 @@ mod tests {
                 &serde_json::Value::String("apple".to_string())
             ))
         );
+    }
+
+    /// Setting dimension names must reach the metadata document, otherwise `store_metadata`
+    /// would silently drop them.
+    #[test]
+    fn array_set_dimension_names_reaches_metadata() {
+        use zarrs_metadata::IntoDimensionName;
+
+        let mut array = ArrayBuilder::new(vec![8, 8], vec![4, 4], data_type::uint8(), 0u8)
+            .build(Arc::new(MemoryStore::new()), "/array")
+            .unwrap();
+
+        array
+            .set_dimension_names(Some(vec![
+                "y".into_dimension_name(),
+                "x".into_dimension_name(),
+            ]))
+            .unwrap();
+        assert_eq!(
+            array.dimension_names(),
+            &Some(vec!["y".into_dimension_name(), "x".into_dimension_name()])
+        );
+        match array.metadata() {
+            ArrayMetadata::V3(metadata) => {
+                assert_eq!(
+                    metadata.dimension_names,
+                    Some(vec!["y".into_dimension_name(), "x".into_dimension_name()])
+                );
+            }
+            ArrayMetadata::V2(_) => panic!("expected V3 metadata"),
+        }
+
+        // Clearing them writes through too
+        array.set_dimension_names(None).unwrap();
+        match array.metadata() {
+            ArrayMetadata::V3(metadata) => assert_eq!(metadata.dimension_names, None),
+            ArrayMetadata::V2(_) => panic!("expected V3 metadata"),
+        }
+    }
+
+    /// Dimension names that do not match the array dimensionality are rejected on creation, so
+    /// they must not be reachable through the mutators either.
+    #[test]
+    fn array_set_dimension_names_rejects_invalid() {
+        use zarrs_metadata::IntoDimensionName;
+
+        let mut array = ArrayBuilder::new(vec![8, 8], vec![4, 4], data_type::uint8(), 0u8)
+            .dimension_names(["y", "x"].into())
+            .build(Arc::new(MemoryStore::new()), "/array")
+            .unwrap();
+
+        // Wrong number of names
+        assert_eq!(
+            array
+                .set_dimension_names(Some(vec![
+                    "z".into_dimension_name(),
+                    "y".into_dimension_name(),
+                    "x".into_dimension_name(),
+                ]))
+                .unwrap_err()
+                .to_string(),
+            "the number of dimension names 3 does not match array dimensionality 2"
+        );
+    }
+
+    /// The dimensionality of an array is fixed once it has been created or opened.
+    #[test]
+    fn array_dimensionality_is_fixed() {
+        let mut array = ArrayBuilder::new(vec![8, 8], vec![4, 4], data_type::uint8(), 0u8)
+            .dimension_names(["y", "x"].into())
+            .build(Arc::new(MemoryStore::new()), "/array")
+            .unwrap();
+
+        assert_eq!(
+            array.set_shape(vec![4, 4, 4]).unwrap_err().to_string(),
+            "cannot change the array dimensionality from 2 to 3"
+        );
+        assert_eq!(
+            unsafe { array.set_shape_and_chunk_grid(vec![4, 4, 4], vec![2, 2, 2]) }
+                .unwrap_err()
+                .to_string(),
+            "cannot change the array dimensionality from 2 to 3"
+        );
+
+        // Rejected before the array is modified
+        assert_eq!(array.shape(), &[8, 8]);
+        assert_eq!(array.dimensionality(), 2);
+        assert_eq!(array.chunk_grid_shape(), &[2, 2]);
+
+        // Resizing within the same dimensionality is still permitted
+        array.set_shape(vec![16, 16]).unwrap();
+        assert_eq!(array.shape(), &[16, 16]);
+        unsafe { array.set_shape_and_chunk_grid(vec![4, 4], vec![2, 2]) }.unwrap();
+        assert_eq!(array.shape(), &[4, 4]);
+    }
+
+    /// Zarr V2 metadata has no dimension names field, but a Zarr V2 array may still be written as
+    /// Zarr V3, so setting them must be permitted and must survive the conversion.
+    #[test]
+    fn array_v2_set_dimension_names_survives_v3_conversion() {
+        use zarrs_metadata::IntoDimensionName;
+        use zarrs_metadata::v2::{ArrayMetadataV2, DataTypeMetadataV2};
+
+        let metadata = ArrayMetadataV2::new(
+            vec![10, 10],
+            vec![std::num::NonZeroU64::new(5).unwrap(); 2],
+            DataTypeMetadataV2::Simple("<i4".to_string()),
+            FillValueMetadata::from(0),
+            None, // compressor
+            None, // filters
+        );
+        let mut array = Array::new_with_metadata(
+            Arc::new(MemoryStore::new()),
+            "/",
+            ArrayMetadata::V2(metadata),
+        )
+        .unwrap();
+
+        let names = vec!["y".into_dimension_name(), "x".into_dimension_name()];
+        array.set_dimension_names(Some(names.clone())).unwrap();
+        assert_eq!(array.dimension_names(), &Some(names.clone()));
+
+        // Written as Zarr V3, the names are carried into the converted metadata
+        let converted = array.metadata_opt(
+            &ArrayMetadataOptions::default()
+                .with_metadata_convert_version(MetadataConvertVersion::V3),
+        );
+        match converted {
+            ArrayMetadata::V3(metadata) => {
+                assert_eq!(metadata.dimension_names, Some(names.clone()));
+            }
+            ArrayMetadata::V2(_) => panic!("expected V3 metadata"),
+        }
+
+        // As does `to_v3`
+        let array_v3 = array.to_v3().unwrap();
+        match array_v3.metadata() {
+            ArrayMetadata::V3(metadata) => assert_eq!(metadata.dimension_names, Some(names)),
+            ArrayMetadata::V2(_) => panic!("expected V3 metadata"),
+        }
     }
 
     #[test]

--- a/zarrs/src/array/array_errors.rs
+++ b/zarrs/src/array/array_errors.rs
@@ -66,6 +66,9 @@ pub enum ArrayCreateError {
     /// The number of dimension names does not match the array dimensionality.
     #[error("the number of dimension names {0} does not match array dimensionality {1}")]
     InvalidDimensionNames(usize, usize),
+    /// The dimensionality of an array cannot be changed after it is created or opened.
+    #[error("cannot change the array dimensionality from {1} to {0}")]
+    ChangedDimensionality(usize, usize),
     /// Storage error.
     #[error(transparent)]
     StorageError(#[from] StorageError),

--- a/zarrs/src/array/array_ops/array_mut_ops.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops.rs
@@ -35,13 +35,28 @@ pub trait ArrayMutOps: ArrayOps {
 
     /// Set the array shape.
     ///
+    /// The dimensionality of an array is fixed once it has been created or opened, so
+    /// `array_shape` must have the same length as the current [`shape`](super::ArrayOps::shape).
+    ///
     /// # Errors
-    /// Returns an [`ArrayCreateError`] if the chunk grid is not compatible with `array_shape`.
+    /// Returns an [`ArrayCreateError`] if `array_shape` changes the array dimensionality, or the
+    /// chunk grid is not compatible with `array_shape`.
     #[allow(clippy::missing_errors_doc)]
     fn set_shape(&mut self, array_shape: ArrayShape) -> Result<&mut Self, super::ArrayCreateError>;
 
     /// Set the dimension names.
-    fn set_dimension_names(&mut self, dimension_names: Option<Vec<DimensionName>>) -> &mut Self;
+    ///
+    /// Zarr V2 metadata has no dimension names field, so for a Zarr V2 array these are only
+    /// written on store if the metadata options convert the metadata to Zarr V3.
+    ///
+    /// # Errors
+    /// Returns an [`ArrayCreateError`](super::ArrayCreateError) if `dimension_names` is `Some` and
+    /// its length does not match the array dimensionality.
+    #[allow(clippy::missing_errors_doc)]
+    fn set_dimension_names(
+        &mut self,
+        dimension_names: Option<Vec<DimensionName>>,
+    ) -> Result<&mut Self, super::ArrayCreateError>;
 
     /// Mutably borrow the array attributes.
     fn attributes_mut(&mut self) -> &mut serde_json::Map<String, serde_json::Value>;

--- a/zarrs/src/array/array_ops/array_mut_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops_array.rs
@@ -37,6 +37,15 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
     }
 
     pub fn set_shape(&mut self, array_shape: ArrayShape) -> Result<&mut Self, ArrayCreateError> {
+        // The dimensionality of an array is fixed once it exists. Most chunk grids would reject
+        // this anyway, but not with a consistent error. Checked before any mutation.
+        if array_shape.len() != self.dimensionality() {
+            return Err(ArrayCreateError::ChangedDimensionality(
+                array_shape.len(),
+                self.dimensionality(),
+            ));
+        }
+
         self.chunk_grid = ChunkGrid::from_metadata(&self.chunk_grid.metadata(), &array_shape)
             .map_err(ArrayCreateError::ChunkGridCreateError)?;
         self.subchunk_grids = self
@@ -53,12 +62,33 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
         Ok(self)
     }
 
+    /// Set the dimension names.
+    ///
+    /// # Errors
+    /// Returns an [`ArrayCreateError`] if `dimension_names` is `Some` and its length does not
+    /// match the array dimensionality.
     pub fn set_dimension_names(
         &mut self,
         dimension_names: Option<Vec<DimensionName>>,
-    ) -> &mut Self {
+    ) -> Result<&mut Self, ArrayCreateError> {
+        // Matches the validation performed when an array is created
+        if let Some(dimension_names) = &dimension_names
+            && dimension_names.len() != self.dimensionality()
+        {
+            return Err(ArrayCreateError::InvalidDimensionNames(
+                dimension_names.len(),
+                self.dimensionality(),
+            ));
+        }
+
+        // Write through to the metadata document, otherwise `store_metadata` would not see the
+        // change. Zarr V2 metadata has no dimension names field; they are carried into the
+        // converted metadata by `metadata_opt` when it converts to Zarr V3.
+        if let ArrayMetadata::V3(metadata) = &mut self.metadata {
+            metadata.dimension_names.clone_from(&dimension_names);
+        }
         self.dimension_names = dimension_names;
-        self
+        Ok(self)
     }
 
     pub fn attributes_mut(&mut self) -> &mut serde_json::Map<String, serde_json::Value> {

--- a/zarrs/src/array/array_ops/array_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_ops_array.rs
@@ -122,8 +122,11 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
             (AM::V3(metadata), V::Default | V::V3) => ArrayMetadata::V3(metadata),
             (AM::V2(metadata), V::Default) => ArrayMetadata::V2(metadata),
             (AM::V2(metadata), V::V3) => {
-                let metadata = array_metadata_v2_to_v3(&metadata)
+                let mut metadata = array_metadata_v2_to_v3(&metadata)
                     .expect("conversion succeeded on array creation");
+                // Zarr V2 metadata has no dimension names to convert, so take the array's. They
+                // are only representable once converted to Zarr V3.
+                metadata.dimension_names.clone_from(&self.dimension_names);
                 AM::V3(metadata)
             }
         };


### PR DESCRIPTION
- `set_dimension_names` is now fallible
- Reject dimensionality changes with a dedicated error
- Validate and persist dimension names, including V2-to-V3 conversion