### PR TITLE
refactor: `Arc` metadata in `Array`/`Group`

### DIFF
--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -430,8 +430,8 @@ pub struct Array<TStorage: ?Sized> {
     storage_transformers: StorageTransformerChain,
     /// An optional list of dimension names.
     dimension_names: Option<Vec<DimensionName>>,
-    /// Metadata used to create the array
-    metadata: ArrayMetadata,
+    /// Metadata used to create the array.
+    metadata: Arc<ArrayMetadata>,
     /// Options
     codec_options: CodecOptions,
     metadata_options: ArrayMetadataOptions,
@@ -593,7 +593,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
             codecs_bound,
             storage_transformers,
             dimension_names: v3.dimension_names.clone(),
-            metadata: ArrayMetadata::V3(v3),
+            metadata: Arc::new(ArrayMetadata::V3(v3)),
             codec_options,
             metadata_options,
             metadata_erase_version,
@@ -686,7 +686,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
             storage_transformers,
             dimension_names: None,
             codec_options,
-            metadata: ArrayMetadata::V2(v2),
+            metadata: Arc::new(ArrayMetadata::V2(v2)),
             metadata_options,
             metadata_erase_version,
         })
@@ -788,7 +788,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
             .decoded_subchunk_grids((&self.chunk_grid).into())?;
 
         // Update metadata based on version
-        match &mut self.metadata {
+        match Arc::make_mut(&mut self.metadata) {
             ArrayMetadata::V3(metadata) => {
                 metadata.shape = array_shape;
                 metadata.chunk_grid = chunk_grid_metadata;
@@ -837,31 +837,16 @@ impl<TStorage: ?Sized> Array<TStorage> {
     /// # Errors
     /// Returns a [`ArrayMetadataV2ToV3Error`] if the metadata is not compatible with Zarr V3 metadata.
     pub fn to_v3(self) -> Result<Self, ArrayMetadataV2ToV3Error> {
-        match self.metadata {
-            ArrayMetadata::V2(metadata) => {
-                let mut metadata = array_metadata_v2_to_v3(&metadata)?;
-                // Zarr V2 metadata has no dimension names to convert, so take the array's.
-                metadata.dimension_names.clone_from(&self.dimension_names);
-                Ok(Self {
-                    storage: self.storage,
-                    path: self.path,
-                    data_type: self.data_type,
-                    chunk_grid: self.chunk_grid,
-                    subchunk_grids: self.subchunk_grids,
-                    chunk_key_encoding: self.chunk_key_encoding,
-                    fill_value: self.fill_value,
-                    codecs: self.codecs,
-                    codecs_bound: self.codecs_bound,
-                    storage_transformers: self.storage_transformers,
-                    dimension_names: self.dimension_names,
-                    metadata: metadata.into(),
-                    codec_options: self.codec_options,
-                    metadata_options: self.metadata_options,
-                    metadata_erase_version: self.metadata_erase_version,
-                })
-            }
-            ArrayMetadata::V3(_) => Ok(self),
-        }
+        let ArrayMetadata::V2(metadata) = &*self.metadata else {
+            return Ok(self);
+        };
+        let mut metadata = array_metadata_v2_to_v3(metadata)?;
+        // Zarr V2 metadata has no dimension names to convert, so take the array's.
+        metadata.dimension_names.clone_from(&self.dimension_names);
+        Ok(Self {
+            metadata: Arc::new(ArrayMetadata::V3(metadata)),
+            ..self
+        })
     }
 
     /// Reject the array if it contains unsupported extensions or additional fields with `"must_understand": true`.
@@ -1237,6 +1222,27 @@ mod tests {
 
         let array_other = Array::open(store, array_path).unwrap();
         assert_eq!(array_other.metadata(), &stored_metadata);
+    }
+
+    #[test]
+    fn array_clone_shares_metadata_copy_on_write() {
+        let array = ArrayBuilder::new(vec![8, 8], vec![4, 4], data_type::uint8(), 0u8)
+            .build(Arc::new(MemoryStore::new()), "/array")
+            .unwrap();
+        let mut clone = array.clone();
+
+        assert!(Arc::ptr_eq(&array.metadata, &clone.metadata));
+
+        clone.set_shape(vec![16, 16]).unwrap();
+        clone
+            .attributes_mut()
+            .insert("test".to_string(), "apple".into());
+
+        assert!(!Arc::ptr_eq(&array.metadata, &clone.metadata));
+        assert_eq!(array.shape(), &[8, 8]);
+        assert!(array.attributes().is_empty());
+        assert_eq!(clone.shape(), &[16, 16]);
+        assert_eq!(clone.attributes().get("test"), Some(&"apple".into()));
     }
 
     #[test]

--- a/zarrs/src/array/array_ops/array_mut_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops_array.rs
@@ -51,7 +51,7 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
         self.subchunk_grids = self
             .codecs_bound
             .decoded_subchunk_grids((&self.chunk_grid).into())?;
-        match &mut self.metadata {
+        match Arc::make_mut(&mut self.metadata) {
             ArrayMetadata::V3(metadata) => {
                 metadata.shape = array_shape;
             }
@@ -84,7 +84,7 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
         // Write through to the metadata document, otherwise `store_metadata` would not see the
         // change. Zarr V2 metadata has no dimension names field; they are carried into the
         // converted metadata by `metadata_opt` when it converts to Zarr V3.
-        if let ArrayMetadata::V3(metadata) = &mut self.metadata {
+        if let ArrayMetadata::V3(metadata) = Arc::make_mut(&mut self.metadata) {
             metadata.dimension_names.clone_from(&dimension_names);
         }
         self.dimension_names = dimension_names;
@@ -92,7 +92,7 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
     }
 
     pub fn attributes_mut(&mut self) -> &mut serde_json::Map<String, serde_json::Value> {
-        match &mut self.metadata {
+        match Arc::make_mut(&mut self.metadata) {
             ArrayMetadata::V3(metadata) => &mut metadata.attributes,
             ArrayMetadata::V2(metadata) => &mut metadata.attributes,
         }

--- a/zarrs/src/array/array_ops/array_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_ops_array.rs
@@ -79,7 +79,7 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
     }
 
     pub fn attributes(&self) -> &serde_json::Map<String, serde_json::Value> {
-        match &self.metadata {
+        match &*self.metadata {
             ArrayMetadata::V3(metadata) => &metadata.attributes,
             ArrayMetadata::V2(metadata) => &metadata.attributes,
         }
@@ -93,7 +93,9 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
     pub fn metadata_opt(&self, options: &ArrayMetadataOptions) -> ArrayMetadata {
         use ArrayMetadata as AM;
         use MetadataConvertVersion as V;
-        let mut metadata = self.metadata.clone();
+        // Deliberately clone the metadata document, not only the `Arc` handle: the returned
+        // metadata has the requested options applied without changing the array.
+        let mut metadata = (*self.metadata).clone();
 
         // Attribute manipulation
         if options.include_zarrs_metadata() {

--- a/zarrs/src/array/array_ops/array_write_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_write_ops_array.rs
@@ -62,7 +62,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
     pub fn erase_metadata_opt(&self, options: MetadataEraseVersion) -> Result<(), StorageError> {
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
-            MetadataEraseVersion::Default => match self.metadata {
+            MetadataEraseVersion::Default => match &*self.metadata {
                 ArrayMetadata::V3(_) => storage_handle.erase(&meta_key_v3(self.path())),
                 ArrayMetadata::V2(_) => {
                     storage_handle.erase(&meta_key_v2_array(self.path()))?;

--- a/zarrs/src/array/array_ops/async_array_write_ops_array.rs
+++ b/zarrs/src/array/array_ops/async_array_write_ops_array.rs
@@ -77,7 +77,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
     ) -> Result<(), StorageError> {
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
-            MetadataEraseVersion::Default => match self.metadata {
+            MetadataEraseVersion::Default => match &*self.metadata {
                 ArrayMetadata::V3(_) => storage_handle.erase(&meta_key_v3(self.path())).await,
                 ArrayMetadata::V2(_) => {
                     storage_handle

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -162,10 +162,10 @@ use zarrs_storage::{
 };
 
 /// A group.
-#[derive(Clone, Debug, Display)]
+#[derive(Debug, Display)]
 #[display(
     "group at {path} with metadata {}",
-    "serde_json::to_string(metadata).unwrap_or_default()"
+    "serde_json::to_string(&**metadata).unwrap_or_default()"
 )]
 pub struct Group<TStorage: ?Sized> {
     /// The storage.
@@ -175,10 +175,24 @@ pub struct Group<TStorage: ?Sized> {
     #[allow(dead_code)]
     path: NodePath,
     /// The metadata.
-    metadata: GroupMetadata,
+    metadata: Arc<GroupMetadata>,
     metadata_options: GroupMetadataOptions,
     metadata_erase_version: MetadataEraseVersion,
     use_consolidated_metadata: UseConsolidatedMetadata,
+}
+
+// A manual implementation avoids the spurious `TStorage: Clone` bound added by `derive(Clone)`.
+impl<TStorage: ?Sized> Clone for Group<TStorage> {
+    fn clone(&self) -> Self {
+        Self {
+            storage: self.storage.clone(),
+            path: self.path.clone(),
+            metadata: self.metadata.clone(),
+            metadata_options: self.metadata_options,
+            metadata_erase_version: self.metadata_erase_version,
+            use_consolidated_metadata: self.use_consolidated_metadata,
+        }
+    }
 }
 
 impl<TStorage: ?Sized> Group<TStorage> {
@@ -216,7 +230,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
         Ok(Self {
             storage,
             path,
-            metadata,
+            metadata: Arc::new(metadata),
             metadata_options: options.metadata_options(),
             metadata_erase_version: options.metadata_erase_version(),
             use_consolidated_metadata: options.use_consolidated_metadata(),
@@ -237,8 +251,8 @@ impl<TStorage: ?Sized> Group<TStorage> {
 
     /// Get attributes.
     #[must_use]
-    pub const fn attributes(&self) -> &serde_json::Map<String, serde_json::Value> {
-        match &self.metadata {
+    pub fn attributes(&self) -> &serde_json::Map<String, serde_json::Value> {
+        match &*self.metadata {
             GroupMetadata::V3(metadata) => &metadata.attributes,
             GroupMetadata::V2(metadata) => &metadata.attributes,
         }
@@ -247,7 +261,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
     /// Mutably borrow the group attributes.
     #[must_use]
     pub fn attributes_mut(&mut self) -> &mut serde_json::Map<String, serde_json::Value> {
-        match &mut self.metadata {
+        match Arc::make_mut(&mut self.metadata) {
             GroupMetadata::V3(metadata) => &mut metadata.attributes,
             GroupMetadata::V2(metadata) => &mut metadata.attributes,
         }
@@ -266,7 +280,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
     pub fn metadata_opt(&self, options: &GroupMetadataOptions) -> GroupMetadata {
         use GroupMetadata as GM;
         use MetadataConvertVersion as V;
-        let metadata = self.metadata.clone();
+        let metadata = (*self.metadata).clone();
 
         match (metadata, options.metadata_convert_version()) {
             (GM::V3(metadata), V::Default | V::V3) => GM::V3(metadata),
@@ -280,7 +294,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
     /// Consolidated metadata is not currently supported for Zarr V2 groups.
     #[must_use]
     pub fn consolidated_metadata(&self) -> Option<ConsolidatedMetadata> {
-        if let GroupMetadata::V3(group_metadata) = &self.metadata {
+        if let GroupMetadata::V3(group_metadata) = &*self.metadata {
             if let Some(consolidated_metadata) = group_metadata
                 .additional_fields
                 .get("consolidated_metadata")
@@ -303,7 +317,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
         &mut self,
         consolidated_metadata: Option<ConsolidatedMetadata>,
     ) -> &mut Self {
-        if let GroupMetadata::V3(group_metadata) = &mut self.metadata {
+        if let GroupMetadata::V3(group_metadata) = Arc::make_mut(&mut self.metadata) {
             if let Some(consolidated_metadata) = consolidated_metadata {
                 group_metadata.additional_fields.insert(
                     "consolidated_metadata".to_string(),
@@ -323,15 +337,11 @@ impl<TStorage: ?Sized> Group<TStorage> {
     /// If the group is already Zarr V3, this is a no-op.
     #[must_use]
     pub fn to_v3(self) -> Self {
-        if let GroupMetadata::V2(metadata) = self.metadata {
-            let metadata: GroupMetadata = group_metadata_v2_to_v3(&metadata).into();
+        if let GroupMetadata::V2(metadata) = &*self.metadata {
+            let metadata: GroupMetadata = group_metadata_v2_to_v3(metadata).into();
             Self {
-                storage: self.storage,
-                path: self.path,
-                metadata,
-                metadata_options: self.metadata_options,
-                metadata_erase_version: self.metadata_erase_version,
-                use_consolidated_metadata: self.use_consolidated_metadata,
+                metadata: Arc::new(metadata),
+                ..self
             }
         } else {
             self
@@ -882,7 +892,7 @@ impl<TStorage: ?Sized + WritableStorageTraits> Group<TStorage> {
     pub fn erase_metadata_opt(&self, options: MetadataEraseVersion) -> Result<(), StorageError> {
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
-            MetadataEraseVersion::Default => match self.metadata {
+            MetadataEraseVersion::Default => match &*self.metadata {
                 GroupMetadata::V3(_) => storage_handle.erase(&meta_key_v3(self.path())),
                 GroupMetadata::V2(_) => {
                     storage_handle.erase(&meta_key_v2_group(self.path()))?;
@@ -970,7 +980,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> Group<TStorage> {
     ) -> Result<(), StorageError> {
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
-            MetadataEraseVersion::Default => match self.metadata {
+            MetadataEraseVersion::Default => match &*self.metadata {
                 GroupMetadata::V3(_) => storage_handle.erase(&meta_key_v3(self.path())).await,
                 GroupMetadata::V2(_) => {
                     storage_handle
@@ -1132,6 +1142,26 @@ mod tests {
         //     group.to_string(),
         //     r#"group at /group with metadata {"node_type":"group","zarr_format":3}"#
         // );
+    }
+
+    #[test]
+    fn group_clone_shares_metadata_copy_on_write() {
+        let metadata = serde_json::from_str(JSON_VALID1).unwrap();
+        let group = Group::new_with_metadata(Arc::new(MemoryStore::new()), "/", metadata).unwrap();
+        let mut clone = group.clone();
+
+        assert!(Arc::ptr_eq(&group.metadata, &clone.metadata));
+
+        clone
+            .attributes_mut()
+            .insert("new".to_string(), serde_json::Value::Bool(true));
+
+        assert!(!Arc::ptr_eq(&group.metadata, &clone.metadata));
+        assert!(!group.attributes().contains_key("new"));
+        assert_eq!(
+            clone.attributes().get("new"),
+            Some(&serde_json::Value::Bool(true))
+        );
     }
 
     #[test]


### PR DESCRIPTION
- For cheaper `Clone`s
- Also remove `TStorage: Clone` bound on `Group`
- `Group::attributes` is no longer `const`